### PR TITLE
Add checks and fallbacks to shareintent handler

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -200,7 +200,7 @@ const ShareIntentRunner = () => {
 
           router.push(safePath as Href);
         } catch {
-          // Fallback to search for parse errors
+          // Fallback to search when URL parsing fails - treats malformed URL as search query
           router.push({
             pathname: "/search",
             params: { tag: shareIntent.webUrl },

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -24,6 +24,7 @@ import MissionPopup from "#/components/popups/MissionPopup";
 import ToastShareSheet from "#/components/popups/ToastShareSheet";
 import Colors from "#/constants/Colors";
 import Config from "#/constants/Config";
+import { shouldExcludeFromDeepLink } from "#/helpers/DeepLinkFilter";
 import NotificationManager from "#/helpers/Notifications";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
 import { BadgeProvider } from "#/helpers/provider/BadgeProvider";
@@ -187,6 +188,19 @@ const ShareIntentRunner = () => {
             router.push({
               pathname: "/search",
               params: { tag: shareIntent.webUrl },
+            });
+            return;
+          }
+
+          // Check if the path should be excluded from deep linking (e.g., /wp-content/uploads/)
+          if (shouldExcludeFromDeepLink(path)) {
+            // Open excluded URLs with OS default handler instead of in-app
+            Linking.openURL(shareIntent.webUrl).catch((error) => {
+              console.warn(
+                "Failed to open excluded URL:",
+                shareIntent.webUrl,
+                error,
+              );
             });
             return;
           }

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -200,8 +200,18 @@ const ShareIntentRunner = () => {
 
           router.push(safePath as Href);
         } catch {
-          // swallow malformed urls
+          // Fallback to search for parse errors
+          router.push({
+            pathname: "/search",
+            params: { tag: shareIntent.webUrl },
+          });
         }
+      } else if (shareIntent?.type === "text" && shareIntent.text) {
+        // Route text share intents to search page
+        router.push({
+          pathname: "/search",
+          params: { tag: shareIntent.text },
+        });
       }
     }, 0);
 

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -181,8 +181,9 @@ const ShareIntentRunner = () => {
     const t = setTimeout(() => {
       if (shareIntent?.type === "weburl") {
         try {
-          const { path } = Linking.parse(shareIntent.webUrl);
-          if (!shareIntent.webUrl.includes(Config.wpUrl)) {
+          const { hostname, path } = Linking.parse(shareIntent.webUrl);
+          const { hostname: baseHostname } = Linking.parse(Config.wpUrl);
+          if (hostname !== baseHostname) {
             router.push({
               pathname: "/search",
               params: { tag: shareIntent.webUrl },


### PR DESCRIPTION
This combines https://github.com/Volksverpetzer/vvp_app/pull/60 and https://github.com/Volksverpetzer/vvp_app/pull/60

- The ShareIntentRunner only handled weburl type share intents, ignoring text shares and silently swallowing URL parse errors. This broke the share-to-search functionality that existed in the original shareintent.tsx screen.
- 
- The share intent URL validation used includes() to check if a URL is internal, which allows bypass attacks like https://evil.com/?q=volksverpetzer.de.