### PR TITLE
perf: reduce unnecessary re-renders in Feed and SettingsProvider

### DIFF
--- a/src/helpers/provider/SettingsProvider.tsx
+++ b/src/helpers/provider/SettingsProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState } from "react";
+import { createContext, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
 import SettingsStore from "#/helpers/Stores/SettingsStore";
@@ -51,20 +51,27 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
     SettingsStore.setContentSettings(contentSettings);
   }, [contentSettings]);
 
+  const contextValue = useMemo(
+    () => ({
+      contentSettings,
+      setContentSettings,
+      advancedSettings,
+      setAdvancedSettings,
+    }),
+    [
+      contentSettings,
+      advancedSettings,
+      setContentSettings,
+      setAdvancedSettings,
+    ],
+  );
+
   if (!settingsLoaded) {
-    // Optionally, you could render a loading indicator here
     return;
   }
 
   return (
-    <SettingsContext.Provider
-      value={{
-        contentSettings,
-        setContentSettings,
-        advancedSettings,
-        setAdvancedSettings,
-      }}
-    >
+    <SettingsContext.Provider value={contextValue}>
       {children}
     </SettingsContext.Provider>
   );

--- a/src/screens/Home/components/Feed.tsx
+++ b/src/screens/Home/components/Feed.tsx
@@ -43,7 +43,7 @@ export interface FeedProperties {
  */
 const Feed = (properties: FeedProperties) => {
   const [posts, setPosts] = useState<Post<unknown>[]>([]);
-  const [inView, setInView] = useState(new Set<string>());
+  const inViewRef = useRef(new Set<string>());
   const [rerender, setRerender] = useState(0);
   const [initialLoad, setInitialLoad] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(true);
@@ -117,19 +117,16 @@ const Feed = (properties: FeedProperties) => {
     else setIsLoadingMore(false);
   }, [loadmore, page, getPosts, posts]);
 
-  // Update inView set immutably – do not mutate state directly.
   const onViewableItemsChanged = useCallback(
     ({ viewableItems }: { viewableItems: ViewToken[] }) => {
-      setInView((previous) => {
-        const newSet = new Set(previous);
-        for (const item of viewableItems) {
-          if (item.isViewable) {
-            newSet.add(item.item.id);
-          }
+      let changed = false;
+      for (const item of viewableItems) {
+        if (item.isViewable && !inViewRef.current.has(item.item.id)) {
+          inViewRef.current.add(item.item.id);
+          changed = true;
         }
-        setRerender(newSet.size);
-        return newSet;
-      });
+      }
+      if (changed) setRerender((n) => n + 1);
     },
     [],
   );
@@ -141,24 +138,20 @@ const Feed = (properties: FeedProperties) => {
     },
   ]);
 
-  const renderItem: ListRenderItem<Post<unknown>> = useCallback(
-    ({ item }) => {
-      // Skip rendering if item.data is not an object.
-      if (typeof item.data !== "object") return undefined;
-      return (
-        <GenericPost
-          key={item.id}
-          component={item.component}
-          data={item.data}
-          contentFavIdentifier={item.contentFavIdentifier}
-          contentType={item.contentType}
-          shareable={item.shareable}
-          inView={inView.has(item.id)}
-        />
-      );
-    },
-    [inView],
-  );
+  const renderItem: ListRenderItem<Post<unknown>> = useCallback(({ item }) => {
+    if (typeof item.data !== "object") return undefined;
+    return (
+      <GenericPost
+        key={item.id}
+        component={item.component}
+        data={item.data}
+        contentFavIdentifier={item.contentFavIdentifier}
+        contentType={item.contentType}
+        shareable={item.shareable}
+        inView={inViewRef.current.has(item.id)}
+      />
+    );
+  }, []);
 
   const contentContainerStyle = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

- **SettingsContext**: Das Context-Value-Objekt wird jetzt mit `useMemo` memoiziert. Bisher wurde bei jedem Render des Providers ein neues Objekt erstellt, was alle Consumer (Home, Feed, Settings-Screens) unnötig neu gerendert hat — auch wenn sich die Settings gar nicht geändert haben.
- **Feed**: `inView` (Set der sichtbaren Post-IDs) wurde von `useState` auf `useRef` umgestellt. Vorher: Jedes Scroll-Event triggerte einen State-Update → `renderItem` wurde neu erstellt → FlatList renderte alle sichtbaren Items neu. Außerdem wurde `setRerender` innerhalb eines State-Updaters aufgerufen (React-Anti-Pattern). Jetzt: Der Ref wird direkt mutiert, ein einzelner Counter-State (`rerender`) wird nur inkrementiert wenn wirklich neue Items sichtbar werden, und `renderItem` ist stabil (keine Dependency auf `inView`).

## Was ein Reviewer wissen sollte

- `extraData={rerender}` auf der FlatList bleibt erhalten — das ist der korrekte Mechanismus, um FlatList zum Re-render zu zwingen, wenn der Ref-Inhalt sich ändert. Ohne `extraData` würde `inView` nie für neu sichtbare Items feuern.
- `setContentSettings` / `setAdvancedSettings` sind `useState`-Setter und von React garantiert stabil — sie erscheinen trotzdem in den `useMemo`-Dependencies (ESLint-konform), haben aber in der Praxis keinen Einfluss auf die Memoization.
- TypeScript: Keine Fehler nach den Änderungen.

## Test plan

- [x] Feed lädt und scrollt normal
- [x] Neue Posts werden korrekt als "sichtbar" markiert (z.B. Autoplay-Videos oder Lazy-Loading wenn vorhanden)
- [ ] Settings-Änderungen propagieren sich korrekt durch die App
- [x] Pull-to-refresh und Load-more funktionieren

🤖 Generated with [Claude Code](https://claude.com/claude-code)