### PR TITLE
perf/chore: context memoization, FlatList opt, store hardening, shared ImageModal, misc fixes

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -38,7 +38,7 @@ const Index = () => {
           const { hostname: baseHost } = Linking.parse(Config.wpUrl);
 
           if (hostname === baseHost && shouldExcludeFromDeepLink(path)) {
-            Linking.openURL(initialUrl);
+            await Linking.openURL(initialUrl);
             appOpenRoutine();
             const onboarded = await PersonalStore.isOnboardingDone();
             router.dismissTo(onboarded ? "/home" : "/onboarding");

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -31,45 +31,36 @@ const Index = () => {
     // If the app was launched via a deep/universal link, let Expo Router handle it.
     // Avoid overriding the initial URL by redirecting to onboarding/home here.
     (async () => {
-      const initialUrl = await Linking.getInitialURL();
-      if (initialUrl) {
-        const { hostname, path } = Linking.parse(initialUrl);
-        const { hostname: baseHost } = Linking.parse(Config.wpUrl);
+      try {
+        const initialUrl = await Linking.getInitialURL();
+        if (initialUrl) {
+          const { hostname, path } = Linking.parse(initialUrl);
+          const { hostname: baseHost } = Linking.parse(Config.wpUrl);
 
-        // Check if the URL should be excluded from deep linking (e.g., /wp-content/uploads/)
-        if (hostname === baseHost && shouldExcludeFromDeepLink(path)) {
-          // Open excluded URLs with OS default handler instead of in-app
-          Linking.openURL(initialUrl);
-          // Continue with normal app initialization
-          appOpenRoutine();
-          PersonalStore.isOnboardingDone().then((onboarded) => {
-            if (onboarded) {
-              router.dismissTo("/home");
-            } else {
-              router.replace("/onboarding");
-            }
-          });
-          return;
+          if (hostname === baseHost && shouldExcludeFromDeepLink(path)) {
+            Linking.openURL(initialUrl);
+            appOpenRoutine();
+            const onboarded = await PersonalStore.isOnboardingDone();
+            router.dismissTo(onboarded ? "/home" : "/onboarding");
+            return;
+          }
+
+          const hasPath =
+            typeof path === "string" && path.replace(/\//g, "").length > 0;
+          if (hostname === baseHost && hasPath) {
+            appOpenRoutine();
+            return;
+          }
         }
 
-        const hasPath =
-          typeof path === "string" && path.replace(/\//g, "").length > 0;
-        if (hostname === baseHost && hasPath) {
-          // Launched via a Volksverpetzer article URL. Let router handle it.
-          appOpenRoutine();
-          return;
-        }
+        appOpenRoutine();
+        const onboarded = await PersonalStore.isOnboardingDone();
+        router.dismissTo(onboarded ? "/home" : "/onboarding");
+      } catch (error) {
+        console.error("App open error:", error);
+        appOpenRoutine();
+        router.replace("/onboarding");
       }
-
-      // No initial URL: proceed with normal first-screen decision
-      appOpenRoutine();
-      PersonalStore.isOnboardingDone().then((onboarded) => {
-        if (onboarded) {
-          router.dismissTo("/home");
-        } else {
-          router.replace("/onboarding");
-        }
-      });
     })();
   }, [router]);
   return <UiSpinner size="large" />;

--- a/src/components/media/ImageModal.tsx
+++ b/src/components/media/ImageModal.tsx
@@ -1,0 +1,47 @@
+import { Zoomable } from "@likashefqet/react-native-image-zoom";
+import { Image } from "expo-image";
+import { Button, Modal, useWindowDimensions } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import View from "#/components/design/View";
+import Colors from "#/constants/Colors";
+import { styles } from "#/constants/Styles";
+import {
+  useAppColorScheme,
+  useCorporateColor,
+} from "#/hooks/useAppColorScheme";
+
+interface ImageModalProperties {
+  uri: string;
+  visible: boolean;
+  onClose: () => void;
+}
+
+const ImageModal = ({ uri, visible, onClose }: ImageModalProperties) => {
+  const { width } = useWindowDimensions();
+  const colorScheme = useAppColorScheme();
+  const corporate = useCorporateColor();
+  const backgroundColor = Colors[colorScheme].background;
+
+  return (
+    <Modal style={styles.centered} visible={visible} onRequestClose={onClose}>
+      <GestureHandlerRootView style={{ flex: 1, backgroundColor }}>
+        <Zoomable
+          style={{ width, height: "90%", ...styles.centered }}
+          isDoubleTapEnabled
+          doubleTapScale={3}
+          maxScale={5}
+          isPanEnabled
+          isPinchEnabled
+        >
+          <Image source={{ uri }} style={{ width, height: "100%" }} />
+        </Zoomable>
+      </GestureHandlerRootView>
+      <View style={{ padding: 50 }}>
+        <Button color={corporate} title="Schließen" onPress={onClose} />
+      </View>
+    </Modal>
+  );
+};
+
+export default ImageModal;

--- a/src/components/media/ImageModal.tsx
+++ b/src/components/media/ImageModal.tsx
@@ -34,7 +34,11 @@ const ImageModal = ({ uri, visible, onClose }: ImageModalProperties) => {
           isPanEnabled
           isPinchEnabled
         >
-          <Image source={{ uri }} style={{ width, height: "100%" }} />
+          <Image
+            source={{ uri }}
+            style={{ width, height: "100%" }}
+            contentFit="contain"
+          />
         </Zoomable>
       </GestureHandlerRootView>
       <View style={{ padding: 50 }}>

--- a/src/components/media/ImageModal.tsx
+++ b/src/components/media/ImageModal.tsx
@@ -24,7 +24,7 @@ const ImageModal = ({ uri, visible, onClose }: ImageModalProperties) => {
   const backgroundColor = Colors[colorScheme].background;
 
   return (
-    <Modal style={styles.centered} visible={visible} onRequestClose={onClose}>
+    <Modal visible={visible} onRequestClose={onClose}>
       <GestureHandlerRootView style={{ flex: 1, backgroundColor }}>
         <Zoomable
           style={{ width, height: "90%", ...styles.centered }}

--- a/src/components/posts/GenericPost.tsx
+++ b/src/components/posts/GenericPost.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import type { ViewStyle } from "react-native";
 
 import ShareBar from "#/components/bars/ShareBar";
@@ -29,15 +29,6 @@ const GenericPost = (properties: ComponentProperty<object>) => {
     shareable,
     style,
   } = properties;
-  // Flag to mark if the component has been in view at least once.
-  const [hasBeenInView, setHasBeenInView] = useState(false);
-
-  useEffect(() => {
-    if (inView && !hasBeenInView) {
-      setHasBeenInView(true);
-    }
-  }, [inView, hasBeenInView]);
-
   // Memoize the combined style to avoid re-creating the style object on every render.
   const combinedStyle: ViewStyle = useMemo(
     () => ({
@@ -51,7 +42,7 @@ const GenericPost = (properties: ComponentProperty<object>) => {
 
   return (
     <View style={combinedStyle}>
-      <Component inView={hasBeenInView} {...data} />
+      <Component inView={inView} {...data} />
       {shareable ? (
         <ShareBar
           shareable={shareable}

--- a/src/components/posts/RedditPost.tsx
+++ b/src/components/posts/RedditPost.tsx
@@ -1,12 +1,11 @@
-import { ImageZoom } from "@likashefqet/react-native-image-zoom";
+import { Image } from "expo-image";
 import { useState } from "react";
-import { Button, Modal, TouchableOpacity } from "react-native";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { TouchableOpacity } from "react-native";
 
 import View from "#/components/design/View";
+import ImageModal from "#/components/media/ImageModal";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
-import { styles } from "#/constants/Styles";
 import { onShare as _onShare } from "#/helpers/Sharing";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
@@ -41,7 +40,6 @@ const RedditPost = (properties: RedditProperties) => {
   const [dims, setDims] = useState({ width: 0, height: 0 });
   const [isModalOpen, setIsModalOpen] = useState(false);
   const colorScheme = useAppColorScheme();
-  const corporate = Colors[colorScheme].primary;
   const img_dim = properties.preview?.images[0].source ?? {
     width: 100,
     height: 100,
@@ -64,7 +62,6 @@ const RedditPost = (properties: RedditProperties) => {
   };
   const date = datebeautify();
 
-  const onModalClose = () => setIsModalOpen(false);
   const onLayout = (event) => {
     const { height, width } = event.nativeEvent.layout;
     setDims({ width: width, height: height });
@@ -80,6 +77,10 @@ const RedditPost = (properties: RedditProperties) => {
     }
   };
 
+  const imageUri = inView
+    ? properties.url_overridden_by_dest
+    : properties.thumbnail;
+
   return (
     <>
       <TouchableOpacity
@@ -90,15 +91,13 @@ const RedditPost = (properties: RedditProperties) => {
         activeOpacity={0.8}
       >
         <View>
-          <ImageZoom
+          <Image
             style={{
               left: 0,
               width: dims.width,
               height: Math.round(height_relation * dims.width),
             }}
-            uri={
-              inView ? properties.url_overridden_by_dest : properties.thumbnail
-            }
+            source={{ uri: imageUri }}
           />
           <UiText
             style={{
@@ -124,25 +123,11 @@ const RedditPost = (properties: RedditProperties) => {
           </UiText>
         </View>
       </TouchableOpacity>
-      <Modal style={styles.centered} visible={isModalOpen}>
-        <GestureHandlerRootView
-          style={{ flex: 1, backgroundColor: Colors[colorScheme].background }}
-        >
-          <ImageZoom
-            style={{ left: 0, width: "100%", height: "80%" }}
-            uri={
-              inView ? properties.url_overridden_by_dest : properties.thumbnail
-            }
-          />
-          <View style={{ padding: 70 }}>
-            <Button
-              color={corporate}
-              title="Schließen"
-              onPress={onModalClose}
-            />
-          </View>
-        </GestureHandlerRootView>
-      </Modal>
+      <ImageModal
+        uri={properties.url_overridden_by_dest}
+        visible={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
     </>
   );
 };

--- a/src/components/posts/RedditPost.tsx
+++ b/src/components/posts/RedditPost.tsx
@@ -5,9 +5,7 @@ import { TouchableOpacity } from "react-native";
 import View from "#/components/design/View";
 import ImageModal from "#/components/media/ImageModal";
 import UiText from "#/components/ui/UiText";
-import Colors from "#/constants/Colors";
 import { onShare as _onShare } from "#/helpers/Sharing";
-import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
 interface RedditImageSource {
   url: string;
@@ -39,7 +37,6 @@ interface RedditProperties {
 const RedditPost = (properties: RedditProperties) => {
   const [dims, setDims] = useState({ width: 0, height: 0 });
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const colorScheme = useAppColorScheme();
   const img_dim = properties.preview?.images[0].source ?? {
     width: 100,
     height: 100,

--- a/src/components/posts/RedditPost.tsx
+++ b/src/components/posts/RedditPost.tsx
@@ -21,14 +21,14 @@ interface RedditPreviewImage {
 }
 
 interface RedditProperties {
-  preview: { images: RedditPreviewImage[]; enabled: boolean };
+  preview?: { images: RedditPreviewImage[]; enabled: boolean };
   is_reddit_media_domain: boolean;
   url_overridden_by_dest: string;
   title: string;
   created_utc: number;
   permalink: string;
   author: string;
-  crosspost_parent_list: { author: string }[];
+  crosspost_parent_list?: { author: string }[];
   inView?: boolean;
   thumbnail: string;
 }
@@ -49,9 +49,7 @@ const RedditPost = (properties: RedditProperties) => {
     : 0.5125;
   const size = properties.title.length > 100 ? 16 : 18;
   const author =
-    properties?.crosspost_parent_list === undefined
-      ? properties.author
-      : properties.crosspost_parent_list[0].author;
+    properties.crosspost_parent_list?.[0]?.author ?? properties.author;
   const inView = properties.inView ?? true;
 
   const datebeautify = () => {

--- a/src/components/posts/RedditPost.tsx
+++ b/src/components/posts/RedditPost.tsx
@@ -10,16 +10,26 @@ import { styles } from "#/constants/Styles";
 import { onShare as _onShare } from "#/helpers/Sharing";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
+interface RedditImageSource {
+  url: string;
+  width: number;
+  height: number;
+}
+
+interface RedditPreviewImage {
+  source: RedditImageSource;
+  resolutions?: RedditImageSource[];
+}
+
 interface RedditProperties {
-  preview: { images: any; enabled: boolean };
+  preview: { images: RedditPreviewImage[]; enabled: boolean };
   is_reddit_media_domain: boolean;
   url_overridden_by_dest: string;
   title: string;
-  navigation: any;
   created_utc: number;
   permalink: string;
   author: string;
-  crosspost_parent_list: any[];
+  crosspost_parent_list: { author: string }[];
   inView?: boolean;
   thumbnail: string;
 }
@@ -44,7 +54,7 @@ const RedditPost = (properties: RedditProperties) => {
     properties?.crosspost_parent_list === undefined
       ? properties.author
       : properties.crosspost_parent_list[0].author;
-  properties.inView = properties.inView ?? true;
+  const inView = properties.inView ?? true;
 
   const datebeautify = () => {
     const date = new Date(properties.created_utc * 1000);
@@ -87,9 +97,7 @@ const RedditPost = (properties: RedditProperties) => {
               height: Math.round(height_relation * dims.width),
             }}
             uri={
-              properties.inView
-                ? properties.url_overridden_by_dest
-                : properties.thumbnail
+              inView ? properties.url_overridden_by_dest : properties.thumbnail
             }
           />
           <UiText
@@ -123,9 +131,7 @@ const RedditPost = (properties: RedditProperties) => {
           <ImageZoom
             style={{ left: 0, width: "100%", height: "80%" }}
             uri={
-              properties.inView
-                ? properties.url_overridden_by_dest
-                : properties.thumbnail
+              inView ? properties.url_overridden_by_dest : properties.thumbnail
             }
           />
           <View style={{ padding: 70 }}>

--- a/src/constants/Search.ts
+++ b/src/constants/Search.ts
@@ -1,0 +1,3 @@
+export const ALGOLIA_APP_ID = "W8YO8C6SIN";
+export const ALGOLIA_SEARCH_KEY = "f8211e7620b2d30da0d73f451fe36634";
+export const ALGOLIA_INDEX_NAME = "wp_searchable_posts";

--- a/src/helpers/Stores/AchievementStore.ts
+++ b/src/helpers/Stores/AchievementStore.ts
@@ -1,40 +1,40 @@
 import BaseStore from "#/helpers/Storage";
 
 const AchievementStore = {
-  /**
-   * Gets the value of an achievement.
-   * @param key The key of the achievement.
-   * @returns The value of the achievement.
-   */
-  async getAchievementValue(key: string) {
-    const value = await BaseStore.getItem(key);
-    return value === "true";
+  async getAchievementValue(key: string): Promise<boolean> {
+    try {
+      const value = await BaseStore.getItem(key);
+      return value === "true";
+    } catch (error) {
+      console.error("Error retrieving achievement:", error);
+      return false;
+    }
   },
 
-  /**
-   * Sets the value of an achievement.
-   * @param key The key of the achievement.
-   * @param value The value to set.
-   */
-  async setAchievementValue(key: string, value: boolean) {
-    await BaseStore.setItem(key, String(value));
+  async setAchievementValue(key: string, value: boolean): Promise<void> {
+    try {
+      await BaseStore.setItem(key, String(value));
+    } catch (error) {
+      console.error("Error saving achievement:", error);
+    }
   },
 
-  /**
-   * Sets the level of the user.
-   * @param level The level to set.
-   */
-  async setLevel(level: number) {
-    await BaseStore.setItem("level", String(level));
+  async setLevel(level: number): Promise<void> {
+    try {
+      await BaseStore.setItem("level", String(level));
+    } catch (error) {
+      console.error("Error saving level:", error);
+    }
   },
 
-  /**
-   * Gets the level of the user.
-   * @returns The level of the user.
-   */
-  async getLevel() {
-    const value = await BaseStore.getItem("level");
-    return Number.parseInt(value) || 0;
+  async getLevel(): Promise<number> {
+    try {
+      const value = await BaseStore.getItem("level");
+      return Number.parseInt(value) || 0;
+    } catch (error) {
+      console.error("Error retrieving level:", error);
+      return 0;
+    }
   },
 };
 

--- a/src/helpers/Stores/BadgeStore.ts
+++ b/src/helpers/Stores/BadgeStore.ts
@@ -1,44 +1,33 @@
 import BaseStore from "#/helpers/Storage";
 import type { BadgeState } from "#/helpers/provider/BadgeProvider";
 
-/**
- * Class for managing badge-related state.
- */
 const BadgeStore = {
-  /**
-   * Key used to store the badge state in local storage.
-   */
   key: "badge",
 
-  /**
-   * Default initial state of the badge.
-   */
   defaultState: {
     action: false,
     personal: false,
   } as BadgeState,
 
-  /**
-   * Sets the badge state asynchronously and saves it to storage.
-   *
-   * @param {BadgeState} badgeState - The new badge state to be set.
-   */
   async setBadgeStore(badgeState: BadgeState) {
-    const jsonValue = JSON.stringify(badgeState);
-    await BaseStore.setItem(this.key, jsonValue);
+    try {
+      await BaseStore.setItem(this.key, JSON.stringify(badgeState));
+    } catch (error) {
+      console.error("Error saving badge state:", error);
+    }
   },
 
-  /**
-   * Gets the stored badge state asynchronously and parses it into a `BadgeState` object.
-   *
-   * @returns {Promise<BadgeState>} - The parsed badge state.
-   */
   async getBadgeStore(): Promise<BadgeState> {
-    const jsonValue = await BaseStore.getItem(this.key);
-    return BaseStore.parseJSON<BadgeState>(jsonValue, {
-      action: false,
-      personal: false,
-    });
+    try {
+      const jsonValue = await BaseStore.getItem(this.key);
+      return BaseStore.parseJSON<BadgeState>(jsonValue, {
+        action: false,
+        personal: false,
+      });
+    } catch (error) {
+      console.error("Error retrieving badge state:", error);
+      return { action: false, personal: false };
+    }
   },
 };
 

--- a/src/helpers/Stores/SettingsStore.ts
+++ b/src/helpers/Stores/SettingsStore.ts
@@ -22,106 +22,95 @@ const SettingsStore = {
     notificationSettings: "notificationSettings",
   },
 
-  /**
-   * Default advanced settings.
-   *
-   * @type {AdvancedSettingType}
-   * @property {SettingType} alwaysDarkMode - Indicates if always dark mode is enabled.
-   */
   defaultAdvancedSettings: {
     advancedReporting: { value: false, name: "Erweitertes Reporting" },
     alwaysDarkMode: { value: false, name: "Immer Dark Mode" },
   } as AdvancedSettingType,
 
-  /**
-   * Represents the default notification settings.
-   *
-   * @type {NotificationSettingType}
-   * @property {SettingType} new_post - Indicates whether new post notifications are enabled.
-   * @property {SettingType} new_fact_check - Indicates whether new fact check notifications are enabled.
-   */
   defaultNotificationSettings: {
     new_post: { value: true, name: "Neuer Artikel" },
     new_fact_check: { value: true, name: "Neuer Faktencheck" },
   } as NotificationSettingType,
 
-  /**
-   * Retrieves the content settings from AsyncStorage.
-   * @returns A promise that resolves to a contentSettingType object representing the content settings.
-   */
   async getContentSettings(): Promise<ContentSettingType> {
-    const jsonValue = await BaseStore.getItem(this.keys.contentSettings);
-    const parsed = BaseStore.parseJSON<Record<string, any>>(jsonValue, {});
-    const result = {} as ContentSettingType;
-    const newStore: Record<string, boolean> = {};
-    for (const key in this.defaultContentSettings) {
-      const defaultSetting = this.defaultContentSettings[key];
-      const value =
-        typeof parsed[key] === "boolean"
-          ? parsed[key]
-          : (parsed[key]?.value ?? defaultSetting.value);
-      result[key] = { value: value, name: defaultSetting.name };
-      newStore[key] = value;
+    try {
+      const jsonValue = await BaseStore.getItem(this.keys.contentSettings);
+      const parsed = BaseStore.parseJSON<Record<string, any>>(jsonValue, {});
+      const result = {} as ContentSettingType;
+      const newStore: Record<string, boolean> = {};
+      for (const key in this.defaultContentSettings) {
+        const defaultSetting = this.defaultContentSettings[key];
+        const value =
+          typeof parsed[key] === "boolean"
+            ? parsed[key]
+            : (parsed[key]?.value ?? defaultSetting.value);
+        result[key] = { value: value, name: defaultSetting.name };
+        newStore[key] = value;
+      }
+      // Migrate storage to boolean-only shape
+      await BaseStore.setItem(
+        this.keys.contentSettings,
+        JSON.stringify(newStore),
+      );
+      return result;
+    } catch (error) {
+      console.error("Error retrieving content settings:", error);
+      return this.defaultContentSettings;
     }
-    // Migrate storage to boolean-only shape
-    await BaseStore.setItem(
-      this.keys.contentSettings,
-      JSON.stringify(newStore),
-    );
-    return result;
   },
 
-  /**
-   * Retrieves the advanced settings from AsyncStorage.
-   * @returns {Promise<AdvancedSettingType>} The advanced settings.
-   */
   async getAdvancedSettings(): Promise<AdvancedSettingType> {
-    const jsonValue = await BaseStore.getItem(this.keys.advancedSettings);
-    return BaseStore.parseJSON(jsonValue, this.defaultAdvancedSettings);
-  },
-
-  /**
-   * Stores the content settings in AsyncStorage.
-   * @param {ContentSettingType} settings - The content settings to store.
-   */
-  async setContentSettings(settings: ContentSettingType) {
-    // Persist only the boolean values
-    const bools: Record<string, boolean> = {};
-    for (const key in settings) {
-      bools[key] = settings[key].value;
+    try {
+      const jsonValue = await BaseStore.getItem(this.keys.advancedSettings);
+      return BaseStore.parseJSON(jsonValue, this.defaultAdvancedSettings);
+    } catch (error) {
+      console.error("Error retrieving advanced settings:", error);
+      return this.defaultAdvancedSettings;
     }
-    await BaseStore.setItem(this.keys.contentSettings, JSON.stringify(bools));
   },
 
-  /**
-   * Stores the advanced settings in AsyncStorage.
-   * @param {AdvancedSettingType} settings - The advanced settings to store.
-   */
+  async setContentSettings(settings: ContentSettingType) {
+    try {
+      const bools: Record<string, boolean> = {};
+      for (const key in settings) {
+        bools[key] = settings[key].value;
+      }
+      await BaseStore.setItem(this.keys.contentSettings, JSON.stringify(bools));
+    } catch (error) {
+      console.error("Error saving content settings:", error);
+    }
+  },
+
   async setAdvancedSettings(settings: AdvancedSettingType) {
-    await BaseStore.setItem(
-      this.keys.advancedSettings,
-      JSON.stringify(settings),
-    );
+    try {
+      await BaseStore.setItem(
+        this.keys.advancedSettings,
+        JSON.stringify(settings),
+      );
+    } catch (error) {
+      console.error("Error saving advanced settings:", error);
+    }
   },
 
-  /**
-   * Stores the notification settings in AsyncStorage.
-   * @param {NotificationSettingType} settings - The notification settings to store.
-   */
   async setNotificationSettings(settings: NotificationSettingType) {
-    await BaseStore.setItem(
-      this.keys.notificationSettings,
-      JSON.stringify(settings),
-    );
+    try {
+      await BaseStore.setItem(
+        this.keys.notificationSettings,
+        JSON.stringify(settings),
+      );
+    } catch (error) {
+      console.error("Error saving notification settings:", error);
+    }
   },
 
-  /**
-   * Retrieves the notification settings from AsyncStorage.
-   * @returns {Promise<NotificationSettingType>} The notification settings.
-   */
   async getNotificationSettings(): Promise<NotificationSettingType> {
-    const jsonValue = await BaseStore.getItem(this.keys.notificationSettings);
-    return BaseStore.parseJSON(jsonValue, this.defaultNotificationSettings);
+    try {
+      const jsonValue = await BaseStore.getItem(this.keys.notificationSettings);
+      return BaseStore.parseJSON(jsonValue, this.defaultNotificationSettings);
+    } catch (error) {
+      console.error("Error retrieving notification settings:", error);
+      return this.defaultNotificationSettings;
+    }
   },
 };
 

--- a/src/helpers/Stores/SettingsStore.ts
+++ b/src/helpers/Stores/SettingsStore.ts
@@ -52,7 +52,7 @@ const SettingsStore = {
   async getContentSettings(): Promise<ContentSettingType> {
     const jsonValue = await BaseStore.getItem(this.keys.contentSettings);
     const parsed = BaseStore.parseJSON<Record<string, any>>(jsonValue, {});
-    const result: ContentSettingType = {} as any;
+    const result = {} as ContentSettingType;
     const newStore: Record<string, boolean> = {};
     for (const key in this.defaultContentSettings) {
       const defaultSetting = this.defaultContentSettings[key];

--- a/src/helpers/Stores/SourcesStore.ts
+++ b/src/helpers/Stores/SourcesStore.ts
@@ -2,69 +2,65 @@ import { Achievements } from "#/helpers/Achievements";
 import BaseStore from "#/helpers/Storage";
 import type { HttpsUrl, StoredSources } from "#/types";
 
-/**
- * Manages stored sources in a persistent storage.
- */
 const SourcesStore = {
   sourcesKey: "sources",
 
-  /**
-   * Adds a new source to the stored sources.
-   *
-   * @param source - The URL of the source in the format `https://${string}`.
-   * @param slug - A unique identifier for the source.
-   * @param text - Optional additional text associated with the source.
-   */
-  async onAddSource(source: HttpsUrl, slug: string, text?: string) {
-    const storedSourcesJson =
-      (await BaseStore.getItem(this.sourcesKey)) ?? undefined;
-    const storedSources: StoredSources = BaseStore.parseJSON(
-      storedSourcesJson,
-      {},
-    );
-    const date = new Date().toISOString();
-    const newStoredSources = {
-      ...storedSources,
-      [source]: { slug, text, date },
-    };
-    await BaseStore.setItem(this.sourcesKey, JSON.stringify(newStoredSources));
-    Achievements.setAchievementValue("checksource");
+  async onAddSource(
+    source: HttpsUrl,
+    slug: string,
+    text?: string,
+  ): Promise<void> {
+    try {
+      const storedSourcesJson =
+        (await BaseStore.getItem(this.sourcesKey)) ?? undefined;
+      const storedSources: StoredSources = BaseStore.parseJSON(
+        storedSourcesJson,
+        {},
+      );
+      const date = new Date().toISOString();
+      await BaseStore.setItem(
+        this.sourcesKey,
+        JSON.stringify({ ...storedSources, [source]: { slug, text, date } }),
+      );
+      Achievements.setAchievementValue("checksource");
+    } catch (error) {
+      console.error("Error adding source:", error);
+    }
   },
 
-  /**
-   * Retrieves all stored sources.
-   *
-   * @returns A promise that resolves to a `StoredSources` object containing the
-   *          sources and their associated data.
-   */
   async getAllSources(): Promise<StoredSources> {
-    const storedSourcesJson =
-      (await BaseStore.getItem(this.sourcesKey)) ?? undefined;
-    return BaseStore.parseJSON(storedSourcesJson, {});
+    try {
+      const storedSourcesJson =
+        (await BaseStore.getItem(this.sourcesKey)) ?? undefined;
+      return BaseStore.parseJSON(storedSourcesJson, {});
+    } catch (error) {
+      console.error("Error retrieving sources:", error);
+      return {};
+    }
   },
 
-  /**
-   * Replaces all stored sources with the provided object.
-   *
-   * @param sources - The complete `StoredSources` object to persist.
-   */
   async setStoredSources(sources: StoredSources): Promise<void> {
-    await BaseStore.setItem(this.sourcesKey, JSON.stringify(sources));
+    try {
+      await BaseStore.setItem(this.sourcesKey, JSON.stringify(sources));
+    } catch (error) {
+      console.error("Error saving sources:", error);
+    }
   },
 
-  /**
-   * Removes a source by its URL from the stored sources.
-   *
-   * @param source - The URL of the source to remove in the format `https://${string}`.
-   */
   async removeSource(source: HttpsUrl): Promise<void> {
-    const storedSourcesJson =
-      (await BaseStore.getItem(this.sourcesKey)) ?? undefined;
-    const storedSources: StoredSources =
-      BaseStore.parseJSON(storedSourcesJson, {}) ?? ({} as StoredSources);
-    if (storedSources && storedSources[source]) {
-      delete storedSources[source];
-      await BaseStore.setItem(this.sourcesKey, JSON.stringify(storedSources));
+    try {
+      const storedSourcesJson =
+        (await BaseStore.getItem(this.sourcesKey)) ?? undefined;
+      const storedSources: StoredSources = BaseStore.parseJSON(
+        storedSourcesJson,
+        {},
+      );
+      if (storedSources[source]) {
+        const { [source]: _removed, ...rest } = storedSources;
+        await BaseStore.setItem(this.sourcesKey, JSON.stringify(rest));
+      }
+    } catch (error) {
+      console.error("Error removing source:", error);
     }
   },
 };

--- a/src/helpers/Stores/StatisticsStore.ts
+++ b/src/helpers/Stores/StatisticsStore.ts
@@ -1,9 +1,6 @@
 import BaseStore from "#/helpers/Storage";
 import type { StatisticsType } from "#/types";
 
-/**
- * Define the stats keys as a const object to enable type checking
- */
 const STATS_KEYS = {
   articlesRead: "articlesRead",
   articlesShared: "articlesShared",
@@ -11,47 +8,31 @@ const STATS_KEYS = {
   appOpened: "appOpened",
 } as const;
 
-/**
- * Type for the statistic keys
- */
 export type StatsKeyType = keyof typeof STATS_KEYS;
 
-/**
- * Stores and retrieves user statistics in local storage.
- *
- * This class provides methods to get and set user statistics, which are stored
- * as JSON objects in local storage. The keys used to store the statistics are
- * defined in the `keys` property.
- */
 const StatisticsStore = {
   keys: STATS_KEYS,
 
-  /**
-   * Retrieves a user's statistics from local storage for the specified key.
-   *
-   * @param key - The key associated with the statistic (e.g., 'articlesRead', 'articlesShared', etc.).
-   * @returns {Promise<StatisticsType>} A promise that resolves to the StatisticsType object retrieved from storage.
-   */
   async getStatistics(key: StatsKeyType): Promise<StatisticsType> {
-    const jsonValue = await BaseStore.getItem(StatisticsStore.keys[key]);
-    return BaseStore.parseJSON(jsonValue, {
-      streak: 0,
-      lastDate: 0,
-      count: 0,
-    });
+    try {
+      const jsonValue = await BaseStore.getItem(StatisticsStore.keys[key]);
+      return BaseStore.parseJSON(jsonValue, {
+        streak: 0,
+        lastDate: 0,
+        count: 0,
+      });
+    } catch (error) {
+      console.error("Error retrieving statistics:", error);
+      return { streak: 0, lastDate: 0, count: 0 };
+    }
   },
 
-  /**
-   * Sets a user's statistics in local storage for the specified key.
-   *
-   * @param key - The key associated with the stat (e.g., 'articlesRead', 'articlesShared', etc.).
-   * @param value - The StatsType object to be stored.
-   */
-  setStatistics: async (
-    key: StatsKeyType,
-    value: StatisticsType,
-  ): Promise<void> => {
-    await BaseStore.setItem(StatisticsStore.keys[key], JSON.stringify(value));
+  async setStatistics(key: StatsKeyType, value: StatisticsType): Promise<void> {
+    try {
+      await BaseStore.setItem(StatisticsStore.keys[key], JSON.stringify(value));
+    } catch (error) {
+      console.error("Error saving statistics:", error);
+    }
   },
 };
 

--- a/src/helpers/provider/SettingsProvider.tsx
+++ b/src/helpers/provider/SettingsProvider.tsx
@@ -35,11 +35,16 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
     Promise.all([
       SettingsStore.getContentSettings(),
       SettingsStore.getAdvancedSettings(),
-    ]).then(([contentSettings, advancedSettings]) => {
-      setContentSettings((previous) => ({ ...previous, ...contentSettings }));
-      setAdvancedSettings((previous) => ({ ...previous, ...advancedSettings }));
-      setSettingsLoaded(true);
-    });
+    ])
+      .then(([contentSettings, advancedSettings]) => {
+        setContentSettings((previous) => ({ ...previous, ...contentSettings }));
+        setAdvancedSettings((previous) => ({
+          ...previous,
+          ...advancedSettings,
+        }));
+      })
+      .catch(console.error)
+      .finally(() => setSettingsLoaded(true));
   }, []);
 
   //propagate state changes to storage:

--- a/src/screens/Home/components/EdgelessWebview.tsx
+++ b/src/screens/Home/components/EdgelessWebview.tsx
@@ -3,7 +3,6 @@ import { useRouter } from "expo-router";
 import { useCallback, useRef } from "react";
 import { Platform, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import type { WebViewNavigation } from "react-native-webview";
 import { WebView } from "react-native-webview";
 import type { WebViewErrorEvent } from "react-native-webview/lib/WebViewTypes";
 
@@ -142,11 +141,6 @@ const EdgelessWebview = ({
     return parts.join("; ");
   }, []);
 
-  const handleNavigationStateChange = useCallback(
-    (_navState: WebViewNavigation) => {},
-    [],
-  );
-
   return (
     <View
       style={[
@@ -187,7 +181,6 @@ const EdgelessWebview = ({
         }}
         onLoadEnd={onLoadEnd}
         onError={onError}
-        onNavigationStateChange={handleNavigationStateChange}
         onShouldStartLoadWithRequest={({ url, isTopFrame }) => {
           // Allow the first load of the provided URI
           const { path } = Linking.parse(url);

--- a/src/screens/Home/components/EdgelessWebview.tsx
+++ b/src/screens/Home/components/EdgelessWebview.tsx
@@ -5,6 +5,7 @@ import { Platform, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { WebViewNavigation } from "react-native-webview";
 import { WebView } from "react-native-webview";
+import type { WebViewErrorEvent } from "react-native-webview/lib/WebViewTypes";
 
 import NavBar from "#/components/bars/NavBar";
 import Colors from "#/constants/Colors";
@@ -39,7 +40,7 @@ interface EdgelessWebviewProperties {
   /**
    * Callback function when there's an error loading the WebView
    */
-  onError?: (error: any) => void;
+  onError?: (error: WebViewErrorEvent) => void;
   /**
    * Custom styles for the WebView container
    */
@@ -141,16 +142,8 @@ const EdgelessWebview = ({
     return parts.join("; ");
   }, []);
 
-  /**
-   * Handles navigation state changes in the WebView
-   * @param navState - The new navigation state
-   */
   const handleNavigationStateChange = useCallback(
-    (navState: WebViewNavigation) => {
-      // Navigation state changes can be handled here if needed
-      // console.warn is used instead of console.log as per linting rules
-      console.warn("Navigation state changed:", navState);
-    },
+    (_navState: WebViewNavigation) => {},
     [],
   );
 

--- a/src/screens/Home/components/article/Article.tsx
+++ b/src/screens/Home/components/article/Article.tsx
@@ -50,9 +50,10 @@ const ArticleScreen = (properties: ArticleScreenProperties) => {
   const corporate = Colors[colorScheme].primary;
   const backgroundColor = Colors[colorScheme].background;
 
-  let fullRead = false;
-  let savedPosition = 0;
-  let heightCaptured = false;
+  const fullRead = useRef(false);
+  const savedPosition = useRef(0);
+  const heightCaptured = useRef(false);
+  const mounted = useRef(true);
   const slug = article.slug;
   const article_image = article.imageUrl;
   const article_title = article.title;
@@ -68,6 +69,13 @@ const ArticleScreen = (properties: ArticleScreenProperties) => {
     _date.getDate() + "." + (_date.getMonth() + 1) + "." + _date.getFullYear();
 
   useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
     registerViews(article_link);
     Statistics.countArticleRead();
   }, [article_link]);
@@ -79,13 +87,13 @@ const ArticleScreen = (properties: ArticleScreenProperties) => {
    * @param event LayoutChangeEvent containing nativeEvent.layout.height
    */
   const onRender = (event: LayoutChangeEvent) => {
-    if (heightCaptured) return;
-    heightCaptured = true;
+    if (heightCaptured.current) return;
+    heightCaptured.current = true;
     const height = event.nativeEvent.layout.height;
     PersonalStore.getScrollPosition(slug).then((progress) => {
-      if (progress > 0.8) return;
-      savedPosition = progress;
-      scrollReference.current.scrollTo({
+      if (!mounted.current || progress > 0.8) return;
+      savedPosition.current = progress;
+      scrollReference.current?.scrollTo({
         y: height * progress,
         animated: false,
       });
@@ -102,13 +110,13 @@ const ArticleScreen = (properties: ArticleScreenProperties) => {
     const progress =
       event.nativeEvent.contentOffset.y / event.nativeEvent.contentSize.height;
     scrollProgress.setValue(progress * 1.1 * width);
-    if (progress > 0.7 && !fullRead) {
-      fullRead = true;
+    if (progress > 0.7 && !fullRead.current) {
+      fullRead.current = true;
       registerEvent(article_link, "FullRead");
       Achievements.setAchievementValue("reader", true);
     }
-    if (Math.abs(progress - savedPosition) > 0.02) {
-      savedPosition = progress;
+    if (Math.abs(progress - savedPosition.current) > 0.02) {
+      savedPosition.current = progress;
       PersonalStore.setScrollPosition(progress, slug);
     }
   };

--- a/src/screens/Home/components/article/Recommended.tsx
+++ b/src/screens/Home/components/article/Recommended.tsx
@@ -23,9 +23,15 @@ const Recommended = (properties: RecommendedProperties) => {
   const { article_link } = properties;
 
   useEffect(() => {
-    IntelligenceAPI.recommendations(article_link).then((data) => {
-      setMatches(data.results);
-    });
+    let mounted = true;
+    IntelligenceAPI.recommendations(article_link)
+      .then((data) => {
+        if (mounted) setMatches(data.results);
+      })
+      .catch(console.error);
+    return () => {
+      mounted = false;
+    };
   }, [article_link]);
 
   return (

--- a/src/screens/Home/components/article/renderer/ImageRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/ImageRenderer.tsx
@@ -1,13 +1,11 @@
-import { Zoomable } from "@likashefqet/react-native-image-zoom";
 import type { ImageLoadEventData } from "expo-image";
 import { Image } from "expo-image";
 import { useState } from "react";
-import { Button, Modal, Pressable, useWindowDimensions } from "react-native";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { Pressable, useWindowDimensions } from "react-native";
 import type { InternalRendererProps, TBlock } from "react-native-render-html";
 import { useInternalRenderer } from "react-native-render-html";
 
-import View from "#/components/design/View";
+import ImageModal from "#/components/media/ImageModal";
 import Colors from "#/constants/Colors";
 import { styles } from "#/constants/Styles";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
@@ -27,9 +25,7 @@ const ImageRenderer = (properties: InternalRendererProps<TBlock>) => {
     setIsLoaded(true);
     const { width, height } = event.source;
     const _ratio = Math.round((height / width) * 100) / 100;
-    if (ratio !== _ratio) {
-      setRatio(_ratio);
-    }
+    if (ratio !== _ratio) setRatio(_ratio);
   };
 
   return (
@@ -43,29 +39,11 @@ const ImageRenderer = (properties: InternalRendererProps<TBlock>) => {
         source={{ uri }}
         style={{ width, height: width * ratio, backgroundColor }}
       />
-      <Modal
-        style={styles.centered}
+      <ImageModal
+        uri={uri}
         visible={isModalOpen}
-        onRequestClose={() => setIsModalOpen(false)}
-      >
-        <GestureHandlerRootView
-          style={{ flex: 1, backgroundColor: Colors[colorScheme].background }}
-        >
-          <Zoomable
-            style={{ width, height: "90%", ...styles.centered }}
-            isDoubleTapEnabled
-            doubleTapScale={3}
-            maxScale={5}
-            isPanEnabled
-            isPinchEnabled
-          >
-            <Image source={{ uri }} style={{ width, height: width * ratio }} />
-          </Zoomable>
-        </GestureHandlerRootView>
-        <View style={{ padding: 50 }}>
-          <Button title="Schließen" onPress={() => setIsModalOpen(false)} />
-        </View>
-      </Modal>
+        onClose={() => setIsModalOpen(false)}
+      />
     </Pressable>
   );
 };

--- a/src/screens/PersonalTab/components/MySources.tsx
+++ b/src/screens/PersonalTab/components/MySources.tsx
@@ -34,9 +34,8 @@ const MySources = () => {
   const handleDelete = useCallback(async (href: HttpsUrl) => {
     await SourcesStore.removeSource(href);
     setSources((prev) => {
-      const updated = { ...prev };
-      delete (updated as any)[href];
-      return updated;
+      const { [href]: _removed, ...rest } = prev;
+      return rest as StoredSources;
     });
   }, []);
 

--- a/src/screens/Search/components/AlgoliaSearch.tsx
+++ b/src/screens/Search/components/AlgoliaSearch.tsx
@@ -8,6 +8,11 @@ import View from "#/components/design/View";
 import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
+import {
+  ALGOLIA_APP_ID,
+  ALGOLIA_INDEX_NAME,
+  ALGOLIA_SEARCH_KEY,
+} from "#/constants/Search";
 import { onLinkPress } from "#/helpers/Linking";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 import SearchResultItem from "#/screens/Search/components/SearchResultItem";
@@ -25,8 +30,7 @@ const AlgoliaSearchResults = ({
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
-  // Initialize Algolia client
-  const client = searchClient("W8YO8C6SIN", "f8211e7620b2d30da0d73f451fe36634");
+  const client = searchClient(ALGOLIA_APP_ID, ALGOLIA_SEARCH_KEY);
   const colorScheme = useAppColorScheme();
   const highlightColor = Colors[colorScheme].primary;
 
@@ -42,7 +46,7 @@ const AlgoliaSearchResults = ({
       try {
         // Search across multiple indices
         const { hits } = await client.searchSingleIndex({
-          indexName: "wp_searchable_posts",
+          indexName: ALGOLIA_INDEX_NAME,
           searchParams: {
             query,
             hitsPerPage: maxResults,


### PR DESCRIPTION
## Summary

### Performance

- **SettingsProvider Context-Value memoiert (#1)**: `useMemo` um das Context-Value-Objekt verhindert, dass alle Konsumenten bei jedem Provider-Render neu rendern

- **Feed `inView` als Ref (#2)**: `useState<Set<string>>` → `useRef<Set<string>>` + separater `rerenderCounter`-State. `onViewableItemsChanged` mutiert den Ref direkt und triggert nur einen Re-render wenn neue Items dazukommen. `renderItem` hat jetzt leere Deps (`[]`) und liest `inViewRef.current.has(item.id)` → stabiles Callback, keine unnötigen Re-renders beim Scrollen

- **`hasBeenInView`-State in GenericPost entfernt (#16)**: `useState` + `useEffect` in `GenericPost` erzeugten einen Extra-Re-render pro Item beim ersten Eintritt in den Viewport. Der Wert kommt jetzt direkt vom `inView`-Prop, das der Feed bereits korrekt verwaltet

### Fehlerbehandlung / Stabilität

- **Async-Fehler in SettingsProvider / index.tsx / Recommended.tsx abgefangen (#5)**:
  - `SettingsProvider`: `Promise.all([...]).catch(console.error).finally(...)` statt fire-and-forget
  - `index.tsx`: Async-IIFE auf `await` + single `try/catch` refaktoriert; doppelter `isOnboardingDone()`-Aufruf eliminiert
  - `Recommended.tsx`: `mounted`-Flag + `.catch(console.error)` hinzugefügt

- **Try/Catch in allen Stores (#34)**:
  - `BadgeStore`, `AchievementStore`, `StatisticsStore`, `SourcesStore`, `SettingsStore`
  - Alle async-Methoden geben bei Fehler sichere Defaults zurück statt unbehandelte Exceptions zu werfen

### Code-Qualität / `as any` entfernen (#7)

- `MySources`: `delete (updated as any)[href]` → Destructuring-Omit ohne Mutation
- `SettingsStore`: `{} as any` → `{} as ContentSettingType`
- `RedditPost`: `any`-Typen durch konkrete Reddit-API-Interfaces ersetzt, ungenutztes `navigation`-Prop entfernt, Prop-Mutation (`properties.inView = ...`) → `const inView = properties.inView ?? true`
- `EdgelessWebview`: `error: any` → `WebViewErrorEvent`; noisy `console.warn` auf jedem NavState-Event entfernt

### Shared Component

- **ImageModal extrahiert (#15)**: Inline-Modal-Code aus `ImageRenderer` und `RedditPost` in gemeinsame `src/components/media/ImageModal.tsx`-Komponente ausgelagert (Zoomable + expo-image, GestureHandlerRootView)

### Sonstiges

- **Algolia-Keys auslagern (#8)**: App-ID, Search-Key und Index-Name in `src/constants/Search.ts` zentralisiert
- **Lodash Debounce beibehalten (#9)**: `lodash/debounce` bleibt — Import auf `lodash/debounce` (tree-shakeable) korrigiert
- **Article Unmount-Cleanup (#10)**: `fullRead`, `savedPosition`, `heightCaptured` → `useRef`; `mounted`-Ref mit Cleanup verhindert Zugriff auf `scrollReference.current` nach Unmount

## Was ein Reviewer wissen sollte

- `as ContentSettingType`-Assertion in SettingsStore ist sicher, da die `for`-Schleife alle Felder befüllt
- `WebViewErrorEvent` muss aus `react-native-webview/lib/WebViewTypes` importiert werden, da es nicht aus dem Hauptmodul re-exportiert wird
- Der `inViewRef` in Feed ist bewusst kein State — React-Regeln erlauben direktes Mutieren von Refs, und der separate `rerenderCounter` stellt sicher, dass der FlatList trotzdem neu rendert wenn nötig

## Test plan

- [ ] Feed: Scrollen ist flüssig, Posts laden korrekt lazy (inView-Logik)
- [ ] Settings: Content- und Advanced-Settings laden und speichern korrekt
- [ ] Quellen-Tab: Quellen löschen via Swipe funktioniert noch
- [ ] Reddit-Posts: Bilder laden, Modal öffnet/schließt, Zoom funktioniert
- [ ] Artikel: Scroll-Position wird beim erneuten Öffnen wiederhergestellt
- [ ] Suche: Algolia-Suche liefert Ergebnisse, Debounce funktioniert
- [ ] Onboarding: Erster App-Start durchläuft korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)