### PR TITLE
Fix foss apk builds in github releases

### DIFF
--- a/.github/workflows/expo-release-beta.yml
+++ b/.github/workflows/expo-release-beta.yml
@@ -75,7 +75,6 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         run: |
           tar -xzvf "${APK_NAME}-foss.tar.gz"
-          find . -iname "*.apk"
           mv release/app-arm64-v8a-release.apk "${APK_NAME}-foss-arm64-v8a.apk"
           mv release/app-armeabi-v7a-release.apk "${APK_NAME}-foss-armeabi-v7a.apk"
 

--- a/.github/workflows/expo-release-beta.yml
+++ b/.github/workflows/expo-release-beta.yml
@@ -49,6 +49,8 @@ jobs:
   build-and-release-apk:
     needs: build-and-release-stores
     runs-on: ubuntu-latest
+    env:
+      APK_NAME: vvp-app-v${{ github.ref_name }}
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
@@ -61,21 +63,21 @@ jobs:
           setup-expo-token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 🚀 EAS Build - android apk
-        run: eas build --profile local-apk --platform android --local --output ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}.apk
+        run: eas build --profile local-apk --platform android --local --output ${{ github.workspace }}/build/${{ env.APK_NAME }}.apk
 
       - name: 🛠 Prepare F-Droid build
         run: pnpm prepare:fdroid
 
       - name: 🚀 EAS Build - android apk (FOSS)
-        run: eas build --profile fdroid --platform android --local --output ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss.tar.gz
+        run: eas build --profile fdroid --platform android --local --output ${{ github.workspace }}/build/${{ env.APK_NAME }}-foss.tar.gz
 
       - name: 📦 Extract FOSS per-ABI APKs
         working-directory: ${{ github.workspace }}/build
         run: |
-          tar -xzvf vvp-app-${{ github.ref_name }}-foss.tar.gz
+          tar -xzvf "${APK_NAME}-foss.tar.gz"
           find . -iname "*.apk"
-          mv release/app-arm64-v8a-release.apk vvp-app-${{ github.ref_name }}-foss-arm64-v8a.apk
-          mv release/app-armeabi-v7a-release.apk vvp-app-${{ github.ref_name }}-foss-armeabi-v7a.apk
+          mv release/app-arm64-v8a-release.apk "${APK_NAME}-foss-arm64-v8a.apk"
+          mv release/app-armeabi-v7a-release.apk "${APK_NAME}-foss-armeabi-v7a.apk"
 
       - name: 🎂 Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -86,6 +88,6 @@ jobs:
           prerelease: true
           generate_release_notes: true
           files: |
-            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}.apk
-            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss-arm64-v8a.apk
-            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss-armeabi-v7a.apk
+            ${{ github.workspace }}/build/${{ env.APK_NAME }}.apk
+            ${{ github.workspace }}/build/${{ env.APK_NAME }}-foss-arm64-v8a.apk
+            ${{ github.workspace }}/build/${{ env.APK_NAME }}-foss-armeabi-v7a.apk

--- a/.github/workflows/expo-release-beta.yml
+++ b/.github/workflows/expo-release-beta.yml
@@ -67,7 +67,15 @@ jobs:
         run: pnpm prepare:fdroid
 
       - name: 🚀 EAS Build - android apk (FOSS)
-        run: eas build --profile fdroid --platform android --local --output ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss.apk
+        run: eas build --profile fdroid --platform android --local --output ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss.tar.gz
+
+      - name: 📦 Extract FOSS per-ABI APKs
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          tar -xzvf vvp-app-${{ github.ref_name }}-foss.tar.gz
+          find . -iname "*.apk"
+          mv release/app-arm64-v8a-release.apk vvp-app-${{ github.ref_name }}-foss-arm64-v8a.apk
+          mv release/app-armeabi-v7a-release.apk vvp-app-${{ github.ref_name }}-foss-armeabi-v7a.apk
 
       - name: 🎂 Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -79,4 +87,5 @@ jobs:
           generate_release_notes: true
           files: |
             ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}.apk
-            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss.apk
+            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss-arm64-v8a.apk
+            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss-armeabi-v7a.apk

--- a/.github/workflows/expo-release.yml
+++ b/.github/workflows/expo-release.yml
@@ -48,6 +48,8 @@ jobs:
   build-and-release-apk:
     needs: build-and-release-stores
     runs-on: ubuntu-latest
+    env:
+      APK_NAME: vvp-app-${{ github.ref_name }}
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
@@ -60,21 +62,21 @@ jobs:
           setup-expo-token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 🚀 EAS Build - android apk
-        run: eas build --profile local-apk --platform android --local --output ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}.apk
+        run: eas build --profile local-apk --platform android --local --output ${{ github.workspace }}/build/${{ env.APK_NAME }}.apk
 
       - name: 🛠 Prepare F-Droid build
         run: pnpm prepare:fdroid
 
       - name: 🚀 EAS Build - android apk (FOSS)
-        run: eas build --profile fdroid --platform android --local --output ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss.tar.gz
+        run: eas build --profile fdroid --platform android --local --output ${{ github.workspace }}/build/${{ env.APK_NAME }}-foss.tar.gz
 
       - name: 📦 Extract FOSS per-ABI APKs
         working-directory: ${{ github.workspace }}/build
         run: |
-          tar -xzvf vvp-app-${{ github.ref_name }}-foss.tar.gz
+          tar -xzvf "${APK_NAME}-foss.tar.gz"
           find . -iname "*.apk"
-          mv release/app-arm64-v8a-release.apk vvp-app-${{ github.ref_name }}-foss-arm64-v8a.apk
-          mv release/app-armeabi-v7a-release.apk vvp-app-${{ github.ref_name }}-foss-armeabi-v7a.apk
+          mv release/app-arm64-v8a-release.apk "${APK_NAME}-foss-arm64-v8a.apk"
+          mv release/app-armeabi-v7a-release.apk "${APK_NAME}-foss-armeabi-v7a.apk"
 
       - name: 🎂 Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -85,6 +87,6 @@ jobs:
           prerelease: false
           generate_release_notes: true
           files: |
-            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}.apk
-            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss-arm64-v8a.apk
-            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss-armeabi-v7a.apk
+            ${{ github.workspace }}/build/${{ env.APK_NAME }}.apk
+            ${{ github.workspace }}/build/${{ env.APK_NAME }}-foss-arm64-v8a.apk
+            ${{ github.workspace }}/build/${{ env.APK_NAME }}-foss-armeabi-v7a.apk

--- a/.github/workflows/expo-release.yml
+++ b/.github/workflows/expo-release.yml
@@ -74,7 +74,6 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         run: |
           tar -xzvf "${APK_NAME}-foss.tar.gz"
-          find . -iname "*.apk"
           mv release/app-arm64-v8a-release.apk "${APK_NAME}-foss-arm64-v8a.apk"
           mv release/app-armeabi-v7a-release.apk "${APK_NAME}-foss-armeabi-v7a.apk"
 

--- a/.github/workflows/expo-release.yml
+++ b/.github/workflows/expo-release.yml
@@ -66,7 +66,15 @@ jobs:
         run: pnpm prepare:fdroid
 
       - name: 🚀 EAS Build - android apk (FOSS)
-        run: eas build --profile fdroid --platform android --local --output ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss.apk
+        run: eas build --profile fdroid --platform android --local --output ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss.tar.gz
+
+      - name: 📦 Extract FOSS per-ABI APKs
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          tar -xzvf vvp-app-${{ github.ref_name }}-foss.tar.gz
+          find . -iname "*.apk"
+          mv release/app-arm64-v8a-release.apk vvp-app-${{ github.ref_name }}-foss-arm64-v8a.apk
+          mv release/app-armeabi-v7a-release.apk vvp-app-${{ github.ref_name }}-foss-armeabi-v7a.apk
 
       - name: 🎂 Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -78,4 +86,5 @@ jobs:
           generate_release_notes: true
           files: |
             ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}.apk
-            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss.apk
+            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss-arm64-v8a.apk
+            ${{ github.workspace }}/build/vvp-app-${{ github.ref_name }}-foss-armeabi-v7a.apk


### PR DESCRIPTION
## What

Fixes the FOSS APKs that ship in GitHub Releases and makes the APK
filenames consistent with a leading `v`.

## Why

The `fdroid` EAS profile produces **split per-ABI APKs**, which a local
EAS build bundles into a **tarball**. The previous workflow named that
archive `vvp-app-…-foss.apk` — a tarball with an `.apk` extension that
users couldn't actually install.

## Changes

- FOSS build output renamed to `…-foss.tar.gz` and extracted into the
  real per-ABI APKs (`-foss-arm64-v8a.apk`, `-foss-armeabi-v7a.apk`),
  which are what gets attached to the release.
- APK filenames factored into an `APK_NAME` env var per job:
  - beta: `vvp-app-v${ref_name}` (beta tags have no `v`, so one is added)
  - stable: `vvp-app-${ref_name}` (stable tags already carry the `v`)

## Testing

Lint/analyze/preview checks pass. The release jobs are tag-triggered and
not exercised by PR CI — the tarball extraction (hardcoded `release/`
layout) should be confirmed with one beta tag before relying on it for a
stable release.