### PR TITLE
refactor: extract reusable favorites & engagement hooks

### DIFF
--- a/src/components/counter/FavCounter.tsx
+++ b/src/components/counter/FavCounter.tsx
@@ -6,11 +6,9 @@ import { StarIcon } from "#/components/Icons";
 import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
-import { Achievements } from "#/helpers/Achievements";
-import FavoritesStore from "#/helpers/Stores/FavoritesStore";
-import { getFavs, registerFav } from "#/helpers/network/Engagement";
-import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
+import { getFavs } from "#/helpers/network/Engagement";
 import { useCorporateColor } from "#/hooks/useAppColorScheme";
+import { useFavorite } from "#/hooks/useFavorite";
 import type { FaveableType, ShareableType } from "#/types";
 
 interface FavCounterProperties {
@@ -23,7 +21,6 @@ interface FavCounterProperties {
 
 const FavCounter = (properties: FavCounterProperties) => {
   const [favs, setFavs] = useState(0);
-  const [isFav, setIsFav] = useState(false);
   const color = useCorporateColor();
   const {
     contentFavIdentifier,
@@ -31,6 +28,11 @@ const FavCounter = (properties: FavCounterProperties) => {
     shareable,
     size = 20,
   } = properties;
+  const { isFav, toggleFavorite } = useFavorite(
+    contentFavIdentifier,
+    contentType,
+    shareable[0]?.url,
+  );
 
   const getAllFavs = useCallback(async () => {
     let _favs = 0;
@@ -42,32 +44,14 @@ const FavCounter = (properties: FavCounterProperties) => {
 
   useEffect(() => {
     if (Config.enableEngagement) getAllFavs();
-    if (contentFavIdentifier) {
-      FavoritesStore.isFavorite(contentFavIdentifier).then(setIsFav);
-    }
-  }, [contentFavIdentifier, getAllFavs]);
+  }, [getAllFavs]);
 
   if (!Config.enableEngagement) return <View />;
-
-  const handleFav = async () => {
-    if (contentFavIdentifier) {
-      if (isFav) {
-        await FavoritesStore.removeFavorite(contentFavIdentifier);
-        setIsFav(false);
-      } else {
-        setIsFav(true);
-        Achievements.setAchievementValue("favorite");
-        FavoritesStore.addFavorite(contentFavIdentifier, contentType);
-        updateBadgeState({ personal: true });
-        await registerFav(shareable[0].url);
-      }
-    }
-  };
 
   return (
     <UiPressable
       accessibilityRole="button"
-      onPress={handleFav}
+      onPress={toggleFavorite}
       hitSlop={20}
       style={{
         flexDirection: "row",

--- a/src/components/counter/FavCounter.tsx
+++ b/src/components/counter/FavCounter.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useState } from "react";
 import type { TextStyle } from "react-native";
 import { View } from "react-native";
 
@@ -8,6 +7,7 @@ import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
 import { getFavs } from "#/helpers/network/Engagement";
 import { useCorporateColor } from "#/hooks/useAppColorScheme";
+import { useEngagementCount } from "#/hooks/useEngagementCount";
 import { useFavorite } from "#/hooks/useFavorite";
 import type { FaveableType, ShareableType } from "#/types";
 
@@ -20,7 +20,6 @@ interface FavCounterProperties {
 }
 
 const FavCounter = (properties: FavCounterProperties) => {
-  const [favs, setFavs] = useState(0);
   const color = useCorporateColor();
   const {
     contentFavIdentifier,
@@ -33,18 +32,7 @@ const FavCounter = (properties: FavCounterProperties) => {
     contentType,
     shareable[0]?.url,
   );
-
-  const getAllFavs = useCallback(async () => {
-    let _favs = 0;
-    for (const item of shareable) {
-      _favs = _favs + ((await getFavs(item.url)) ?? 0);
-    }
-    setFavs(_favs);
-  }, [shareable]);
-
-  useEffect(() => {
-    if (Config.enableEngagement) getAllFavs();
-  }, [getAllFavs]);
+  const favs = useEngagementCount(shareable, getFavs);
 
   if (!Config.enableEngagement) return <View />;
 

--- a/src/components/counter/ShareCounter.tsx
+++ b/src/components/counter/ShareCounter.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useState } from "react";
 import { type TextStyle, View } from "react-native";
 
 import { ShareIcon } from "#/components/Icons";
@@ -6,6 +5,7 @@ import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
 import { getShares } from "#/helpers/network/Engagement";
+import { useEngagementCount } from "#/hooks/useEngagementCount";
 import type { ShareableType } from "#/types";
 
 interface ShareCounterProperties {
@@ -19,22 +19,12 @@ interface ShareCounterProperties {
 }
 
 const ShareCounter = (properties: ShareCounterProperties) => {
-  const [shares, setShares] = useState(0);
   const { color, size = 20, hideCount, onPress } = properties;
-
-  const getAllShares = useCallback(async () => {
-    let _shares = 0;
-    for (const shareable of properties.shareable) {
-      _shares = _shares + ((await getShares(shareable.url)) ?? 0);
-    }
-    setShares(_shares);
-  }, [properties.shareable]);
-
-  useEffect(() => {
-    if (!Config.enableEngagement) return;
-    if (hideCount) return;
-    getAllShares();
-  }, [getAllShares, hideCount]);
+  const shares = useEngagementCount(
+    properties.shareable,
+    getShares,
+    !hideCount,
+  );
 
   const hideCountResolved = hideCount || !Config.enableEngagement;
 

--- a/src/hooks/useEngagementCount.ts
+++ b/src/hooks/useEngagementCount.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from "react";
+
+import Config from "#/constants/Config";
+import type { HttpsUrl, ShareableType } from "#/types";
+
+/**
+ * Sums an engagement metric (favorites, shares, …) across a list of shareable
+ * URLs. Shared by FavCounter and ShareCounter, which otherwise duplicated the
+ * same fetch-and-sum loop and `Config.enableEngagement` gate.
+ *
+ * @param shareable The items whose counts should be summed
+ * @param fetcher Engagement getter for a single URL (e.g. getFavs, getShares)
+ * @param enabled Skip fetching when false (e.g. ShareCounter's hidden count)
+ */
+export const useEngagementCount = (
+  shareable: ShareableType[],
+  fetcher: (url?: HttpsUrl) => Promise<number | undefined>,
+  enabled = true,
+) => {
+  const [count, setCount] = useState(0);
+
+  const loadCount = useCallback(async () => {
+    let total = 0;
+    for (const item of shareable) {
+      total += (await fetcher(item.url)) ?? 0;
+    }
+    setCount(total);
+  }, [shareable, fetcher]);
+
+  useEffect(() => {
+    if (Config.enableEngagement && enabled) loadCount();
+  }, [loadCount, enabled]);
+
+  return count;
+};
+
+export default useEngagementCount;

--- a/src/hooks/useFavorite.ts
+++ b/src/hooks/useFavorite.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+import { Achievements } from "#/helpers/Achievements";
+import FavoritesStore from "#/helpers/Stores/FavoritesStore";
+import { registerFav } from "#/helpers/network/Engagement";
+import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
+import type { FaveableType } from "#/types";
+
+/**
+ * Encapsulates the "is this content saved as a favorite" state and the toggle behavior
+ * shared between FavCounter and the native article toolbar.
+ *
+ * @param contentFavIdentifier Local-storage identifier for the favorite (e.g. slug)
+ * @param contentType The type of content being saved as a favorite
+ * @param registerUrl URL reported to the engagement backend when a favorite is added
+ */
+export const useFavorite = (
+  contentFavIdentifier?: string,
+  contentType?: FaveableType,
+  registerUrl?: string,
+) => {
+  const [isFav, setIsFav] = useState(false);
+
+  useEffect(() => {
+    if (contentFavIdentifier) {
+      FavoritesStore.isFavorite(contentFavIdentifier).then(setIsFav);
+    }
+  }, [contentFavIdentifier]);
+
+  const toggleFavorite = async () => {
+    if (!contentFavIdentifier) return;
+
+    if (isFav) {
+      await FavoritesStore.removeFavorite(contentFavIdentifier);
+      setIsFav(false);
+    } else {
+      setIsFav(true);
+      Achievements.setAchievementValue("favorite");
+      FavoritesStore.addFavorite(contentFavIdentifier, contentType);
+      updateBadgeState({ personal: true });
+      if (registerUrl) await registerFav(registerUrl);
+    }
+  };
+
+  return { isFav, toggleFavorite };
+};
+
+export default useFavorite;


### PR DESCRIPTION
## What
Extract reusable logic out of the favorite/share counters into two hooks. This now contains the **whole hook refactor** (the `useEngagementCount` work from #343 was merged into this branch).

### `useFavorite`
Favorite toggle state + side effects (favorites store, achievement, badge update, engagement `registerFav`), extracted from `FavCounter` so the toggle has a single source of truth that other UI can reuse.

### `useEngagementCount`
The duplicated fetch-and-sum loop over `shareable` URLs (gated on `Config.enableEngagement`), extracted from `FavCounter` and `ShareCounter`:

```ts
const favs   = useEngagementCount(shareable, getFavs);
const shares = useEngagementCount(shareable, getShares, !hideCount);
```

`ShareCounter` passes `enabled = !hideCount` to keep skipping the fetch when its count is hidden.

## Why
Pure, behavior-preserving refactors. They split the two concerns (toggle vs. count) into reusable hooks and remove ~30 lines of duplicated logic.

## Engagement gating
`Config.enableEngagement` is respected exactly as before: counts aren't fetched when disabled, `registerFav` self-guards, and the counter UIs still hide when disabled.

## Tests
Full suite passes (743 passed, 3 pre-existing skips).

## Related
- Consolidates #343 (already merged into this branch).
- #344 (native `Stack.Toolbar`) is stacked on this branch and builds on `useFavorite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)