### PR TITLE
refactor(engagement): extract useEngagementCount hook from counters

### DIFF
--- a/src/components/counter/FavCounter.tsx
+++ b/src/components/counter/FavCounter.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useState } from "react";
 import type { TextStyle } from "react-native";
 import { View } from "react-native";
 
@@ -8,6 +7,7 @@ import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
 import { getFavs } from "#/helpers/network/Engagement";
 import { useCorporateColor } from "#/hooks/useAppColorScheme";
+import { useEngagementCount } from "#/hooks/useEngagementCount";
 import { useFavorite } from "#/hooks/useFavorite";
 import type { FaveableType, ShareableType } from "#/types";
 
@@ -20,7 +20,6 @@ interface FavCounterProperties {
 }
 
 const FavCounter = (properties: FavCounterProperties) => {
-  const [favs, setFavs] = useState(0);
   const color = useCorporateColor();
   const {
     contentFavIdentifier,
@@ -33,18 +32,7 @@ const FavCounter = (properties: FavCounterProperties) => {
     contentType,
     shareable[0]?.url,
   );
-
-  const getAllFavs = useCallback(async () => {
-    let _favs = 0;
-    for (const item of shareable) {
-      _favs = _favs + ((await getFavs(item.url)) ?? 0);
-    }
-    setFavs(_favs);
-  }, [shareable]);
-
-  useEffect(() => {
-    if (Config.enableEngagement) getAllFavs();
-  }, [getAllFavs]);
+  const favs = useEngagementCount(shareable, getFavs);
 
   if (!Config.enableEngagement) return <View />;
 

--- a/src/components/counter/ShareCounter.tsx
+++ b/src/components/counter/ShareCounter.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useState } from "react";
 import { type TextStyle, View } from "react-native";
 
 import { ShareIcon } from "#/components/Icons";
@@ -6,6 +5,7 @@ import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
 import { getShares } from "#/helpers/network/Engagement";
+import { useEngagementCount } from "#/hooks/useEngagementCount";
 import type { ShareableType } from "#/types";
 
 interface ShareCounterProperties {
@@ -19,22 +19,12 @@ interface ShareCounterProperties {
 }
 
 const ShareCounter = (properties: ShareCounterProperties) => {
-  const [shares, setShares] = useState(0);
   const { color, size = 20, hideCount, onPress } = properties;
-
-  const getAllShares = useCallback(async () => {
-    let _shares = 0;
-    for (const shareable of properties.shareable) {
-      _shares = _shares + ((await getShares(shareable.url)) ?? 0);
-    }
-    setShares(_shares);
-  }, [properties.shareable]);
-
-  useEffect(() => {
-    if (!Config.enableEngagement) return;
-    if (hideCount) return;
-    getAllShares();
-  }, [getAllShares, hideCount]);
+  const shares = useEngagementCount(
+    properties.shareable,
+    getShares,
+    !hideCount,
+  );
 
   const hideCountResolved = hideCount || !Config.enableEngagement;
 

--- a/src/hooks/useEngagementCount.ts
+++ b/src/hooks/useEngagementCount.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from "react";
+
+import Config from "#/constants/Config";
+import type { HttpsUrl, ShareableType } from "#/types";
+
+/**
+ * Sums an engagement metric (favorites, shares, …) across a list of shareable
+ * URLs. Shared by FavCounter and ShareCounter, which otherwise duplicated the
+ * same fetch-and-sum loop and `Config.enableEngagement` gate.
+ *
+ * @param shareable The items whose counts should be summed
+ * @param fetcher Engagement getter for a single URL (e.g. getFavs, getShares)
+ * @param enabled Skip fetching when false (e.g. ShareCounter's hidden count)
+ */
+export const useEngagementCount = (
+  shareable: ShareableType[],
+  fetcher: (url?: HttpsUrl) => Promise<number | undefined>,
+  enabled = true,
+) => {
+  const [count, setCount] = useState(0);
+
+  const loadCount = useCallback(async () => {
+    let total = 0;
+    for (const item of shareable) {
+      total += (await fetcher(item.url)) ?? 0;
+    }
+    setCount(total);
+  }, [shareable, fetcher]);
+
+  useEffect(() => {
+    if (Config.enableEngagement && enabled) loadCount();
+  }, [loadCount, enabled]);
+
+  return count;
+};
+
+export default useEngagementCount;


### PR DESCRIPTION
## What
Extract the duplicated fetch-and-sum loop (over `shareable` URLs, gated on `Config.enableEngagement`) from `FavCounter` and `ShareCounter` into a reusable `useEngagementCount` hook.

```ts
const favs   = useEngagementCount(shareable, getFavs);
const shares = useEngagementCount(shareable, getShares, !hideCount);
```

## Why
Both counters had a near-identical count-fetching loop. `ShareCounter` passes `enabled = !hideCount` so it still skips the fetch when its count is hidden.

## Notes
- Behavior unchanged; full test suite passes (743 passed, 3 pre-existing skips).
- **Stacked on #342** — please merge that first. Base will retarget to `prerelease` once #342 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)