### PR TITLE
Make deep-link/share host matching www-insensitive

### DIFF
--- a/__tests__/app/native-intent.test.ts
+++ b/__tests__/app/native-intent.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { redirectSystemPath } from "#/app/+native-intent";
+
+jest.mock("#/constants/Config", () => ({
+  __esModule: true,
+  default: { wpUrl: "https://www.volksverpetzer.de" },
+}));
+
+jest.mock("#/helpers/DeepLinkFilter", () => ({
+  __esModule: true,
+  shouldExcludeFromDeepLink: (path: string) =>
+    path.startsWith("/wp-content/uploads/"),
+}));
+
+describe("redirectSystemPath", () => {
+  it("routes the share-intent host to /handle-share", () => {
+    expect(redirectSystemPath({ path: "myapp://expo-sharing" })).toBe(
+      "/handle-share",
+    );
+  });
+
+  it("strips the origin for a www link matching wpUrl", () => {
+    expect(
+      redirectSystemPath({ path: "https://www.volksverpetzer.de/cat/slug/" }),
+    ).toBe("/cat/slug/");
+  });
+
+  it("treats a non-www link as the same host (www-insensitive)", () => {
+    expect(
+      redirectSystemPath({ path: "https://volksverpetzer.de/cat/slug/" }),
+    ).toBe("/cat/slug/");
+  });
+
+  it("returns undefined for excluded paths so the OS handles them", () => {
+    expect(
+      redirectSystemPath({
+        path: "https://volksverpetzer.de/wp-content/uploads/file.pdf",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("passes through unrelated/relative paths unchanged", () => {
+    expect(redirectSystemPath({ path: "/home" })).toBe("/home");
+    expect(redirectSystemPath({ path: "https://example.com/x" })).toBe(
+      "https://example.com/x",
+    );
+  });
+});

--- a/__tests__/helpers/utils/host.test.ts
+++ b/__tests__/helpers/utils/host.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  isSameHost,
+  normalizeHost,
+  normalizedHostOf,
+} from "#/helpers/utils/host";
+
+describe("normalizeHost", () => {
+  it("strips a leading www. and lower-cases", () => {
+    expect(normalizeHost("www.Volksverpetzer.de")).toBe("volksverpetzer.de");
+  });
+
+  it("leaves a host without www. unchanged", () => {
+    expect(normalizeHost("volksverpetzer.de")).toBe("volksverpetzer.de");
+  });
+
+  it("only strips a leading www., not www inside the host", () => {
+    expect(normalizeHost("wwwx.example.com")).toBe("wwwx.example.com");
+  });
+
+  it("returns an empty string for null/undefined", () => {
+    expect(normalizeHost(undefined)).toBe("");
+    expect(normalizeHost(null)).toBe("");
+  });
+});
+
+describe("normalizedHostOf", () => {
+  it("extracts and normalizes the host from a URL", () => {
+    expect(normalizedHostOf("https://www.volksverpetzer.de/foo/bar")).toBe(
+      "volksverpetzer.de",
+    );
+  });
+
+  it("returns '' for a non-absolute or empty value", () => {
+    expect(normalizedHostOf("/foo/bar")).toBe("");
+    expect(normalizedHostOf(undefined)).toBe("");
+  });
+});
+
+describe("isSameHost", () => {
+  it("matches www and non-www variants of the same host", () => {
+    expect(
+      isSameHost(
+        "https://volksverpetzer.de/x",
+        "https://www.volksverpetzer.de",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match different hosts", () => {
+    expect(
+      isSameHost("https://pruefpunkt.org/x", "https://www.volksverpetzer.de"),
+    ).toBe(false);
+  });
+
+  it("returns false when a host cannot be determined", () => {
+    expect(isSameHost("/relative", "https://www.volksverpetzer.de")).toBe(
+      false,
+    );
+  });
+});

--- a/config/volksverpetzer.config.ts
+++ b/config/volksverpetzer.config.ts
@@ -129,6 +129,9 @@ const packageName = "de.volksverpetzer.app";
 
 const googleServicesFile = process.env.google_services;
 
+// Both the www and apex hosts are registered so deep links resolve regardless
+// of which form the link uses (the site is moving off the www subdomain, but
+// previously shared links and the redirect still use www).
 const AndroidIntentFilters: ExpoConfig["android"]["intentFilters"][number]["data"] =
   [
     {
@@ -136,9 +139,17 @@ const AndroidIntentFilters: ExpoConfig["android"]["intentFilters"][number]["data
       host: "www.volksverpetzer.de",
       pathPattern: "/.*/.*",
     },
+    {
+      scheme: "https",
+      host: "volksverpetzer.de",
+      pathPattern: "/.*/.*",
+    },
   ];
 
-const iOSAssociatedDomains = ["applinks:www.volksverpetzer.de"];
+const iOSAssociatedDomains = [
+  "applinks:www.volksverpetzer.de",
+  "applinks:volksverpetzer.de",
+];
 
 const config = {
   extraConfig,

--- a/src/app/+native-intent.tsx
+++ b/src/app/+native-intent.tsx
@@ -1,5 +1,6 @@
 import Config from "#/constants/Config";
 import { shouldExcludeFromDeepLink } from "#/helpers/DeepLinkFilter";
+import { normalizeHost } from "#/helpers/utils/host";
 
 export function redirectSystemPath({ path }: { path: string }) {
   const wpUrl = Config.wpUrl;
@@ -14,16 +15,24 @@ export function redirectSystemPath({ path }: { path: string }) {
     // Ignore parse errors and continue with the normal deep-link handling below.
   }
 
-  // 2. Option: the URL is from our registered url handler
-  if (path.startsWith(wpUrl)) {
-    const urlPath = path.replace(wpUrl, "");
-    // Check if path should be excluded from deep linking
-    if (shouldExcludeFromDeepLink(urlPath)) {
-      // Return undefined to prevent routing for excluded paths
-      // The app will not handle this path and it will be opened by OS
-      return undefined;
+  // 2. Option: the URL is from our registered url handler. Match on host
+  // (ignoring a www. prefix) rather than a literal wpUrl prefix, so links
+  // arrive the same whether or not they carry www.
+  try {
+    const parsedUrl = new URL(path);
+    const wpHost = new URL(wpUrl).hostname;
+    if (normalizeHost(parsedUrl.hostname) === normalizeHost(wpHost)) {
+      const urlPath = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
+      // Check if path should be excluded from deep linking
+      if (shouldExcludeFromDeepLink(urlPath)) {
+        // Return undefined to prevent routing for excluded paths
+        // The app will not handle this path and it will be opened by OS
+        return undefined;
+      }
+      return urlPath;
     }
-    return urlPath;
+  } catch {
+    // Not an absolute URL (e.g. an already-relative in-app path); fall through.
   }
 
   // 3. Option: Profit

--- a/src/app/handle-share.tsx
+++ b/src/app/handle-share.tsx
@@ -10,6 +10,7 @@ import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
 import { shouldExcludeFromDeepLink } from "#/helpers/DeepLinkFilter";
+import { normalizeHost } from "#/helpers/utils/host";
 
 const URL_SHARE_TYPE: ShareType = "url";
 const TEXT_SHARE_TYPE: ShareType = "text";
@@ -32,7 +33,7 @@ const HandleShare = () => {
         const { hostname, path } = Linking.parse(sharedUrl);
         const { hostname: baseHostname } = Linking.parse(Config.wpUrl);
 
-        if (hostname !== baseHostname) {
+        if (normalizeHost(hostname) !== normalizeHost(baseHostname)) {
           router.replace({
             pathname: "/search",
             params: { tag: sharedUrl },

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -9,6 +9,7 @@ import NotificationManager from "#/helpers/Notifications";
 import Statistics from "#/helpers/Statistics";
 import ContentStore from "#/helpers/Stores/ContentStore";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
+import { normalizeHost } from "#/helpers/utils/host";
 
 /**
  * This is the entry point of the app.
@@ -36,8 +37,10 @@ const Index = () => {
         if (initialUrl) {
           const { hostname, path } = Linking.parse(initialUrl);
           const { hostname: baseHost } = Linking.parse(Config.wpUrl);
+          const isBaseHost =
+            normalizeHost(hostname) === normalizeHost(baseHost);
 
-          if (hostname === baseHost && shouldExcludeFromDeepLink(path)) {
+          if (isBaseHost && shouldExcludeFromDeepLink(path)) {
             await Linking.openURL(initialUrl);
             appOpenRoutine();
             const onboarded = await PersonalStore.isOnboardingDone();
@@ -47,7 +50,7 @@ const Index = () => {
 
           const hasPath =
             typeof path === "string" && path.replace(/\//g, "").length > 0;
-          if (hostname === baseHost && hasPath) {
+          if (isBaseHost && hasPath) {
             appOpenRoutine();
             return;
           }

--- a/src/helpers/utils/host.ts
+++ b/src/helpers/utils/host.ts
@@ -1,0 +1,33 @@
+/**
+ * Normalizes a hostname for comparison: lower-cased and without a leading
+ * `www.`, so that `www.volksverpetzer.de` and `volksverpetzer.de` are treated
+ * as the same host.
+ *
+ * Article and share links can arrive with or without the `www.` prefix
+ * depending on the source (WordPress output, user-shared links, OS deep
+ * links), so host matching must not depend on the prefix.
+ */
+export const normalizeHost = (host?: string | null): string =>
+  (host ?? "").replace(/^www\./i, "").toLowerCase();
+
+/**
+ * Extracts the normalized host from a full URL string, returning "" when the
+ * value is missing or not a parseable absolute URL.
+ */
+export const normalizedHostOf = (url?: string | null): string => {
+  if (!url) return "";
+  try {
+    return normalizeHost(new URL(url).hostname);
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * True when both URLs resolve to the same host, ignoring the `www.` prefix.
+ * Returns false if either host cannot be determined.
+ */
+export const isSameHost = (a?: string | null, b?: string | null): boolean => {
+  const hostA = normalizedHostOf(a);
+  return hostA.length > 0 && hostA === normalizedHostOf(b);
+};

--- a/src/screens/Home/components/article/Body.tsx
+++ b/src/screens/Home/components/article/Body.tsx
@@ -18,6 +18,7 @@ import { SOURCE_SANS_FONTS } from "#/constants/GlobalStyles";
 import Statistics from "#/helpers/Statistics";
 import SourcesStore from "#/helpers/Stores/SourcesStore";
 import { getTagStyles } from "#/helpers/utils/color";
+import { isSameHost } from "#/helpers/utils/host";
 import { isHttpsUrl } from "#/helpers/utils/networking";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 import BlockRenderer from "#/screens/Home/components/article/renderer/BlockRenderer";
@@ -124,7 +125,7 @@ const Body = (properties: BodyProperties) => {
             return;
           }
           if (!isHttpsUrl(href)) return;
-          if (!href.includes(Config.wpUrl) && Config.enableEngagement) {
+          if (!isSameHost(href, Config.wpUrl) && Config.enableEngagement) {
             SourcesStore.onAddSource(href, slug, article_title);
             Statistics.countSourceChecked();
           }

--- a/src/screens/Home/components/article/Recommended.tsx
+++ b/src/screens/Home/components/article/Recommended.tsx
@@ -5,6 +5,7 @@ import LoadArticlePost from "#/components/loader/LoadArticlePost";
 import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
 import IntelligenceAPI from "#/helpers/network/IntelligenceAPI";
+import { isSameHost } from "#/helpers/utils/host";
 import type { HttpsUrl } from "#/types";
 
 interface RecommendedProperties {
@@ -54,7 +55,7 @@ const Recommended = (properties: RecommendedProperties) => {
         </UiText>
       )}
       {matches?.map((match, index) => {
-        if (!match.url.includes(Config.wpUrl)) {
+        if (!isSameHost(match.url, Config.wpUrl)) {
           return null;
         }
         const url = new URL(match.url);


### PR DESCRIPTION
## Why

Prep for moving `volksverpetzer.de` off the `www.` subdomain. Several entry points compare the URL host **exactly** against `Config.wpUrl`:

- `app/index.tsx` — `hostname === baseHost`
- `app/handle-share.tsx` — `hostname !== baseHostname`
- `app/+native-intent.tsx` — `path.startsWith(wpUrl)`
- `Body.tsx` / `Recommended.tsx` — `.includes(Config.wpUrl)`

After the migration, links can arrive with or without `www` depending on the source (WordPress's emitted `link` field, previously-shared links, OS deep links). An exact comparison would treat in-app links as **external**, breaking deep linking, share handling, and source-click counting.

## Change

- New `helpers/utils/host.ts`: `normalizeHost` / `normalizedHostOf` / `isSameHost`, all ignoring a leading `www.`.
- Use them in the five spots above. The set of internal hosts is unchanged — only the `www`/non-`www` distinction is relaxed.
- `+native-intent.tsx` now matches on host and rebuilds the path from `pathname + search + hash` instead of string-stripping `wpUrl`.

This is **safe under either host**, so it ships before any infra (WordPress siteurl / Bunny redirect / config) change — step 1 of the migration plan.

## Tests

- `host.test.ts` — unit tests for the helper (www stripping, casing, non-absolute URLs, host match/mismatch).
- `native-intent.test.ts` — `redirectSystemPath` routes www and non-www links identically, handles excluded paths and pass-through.
- Full suite: 758 passed / 3 skipped, lint and types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)