### PR TITLE
Prepare 2.3.0: version bump + beta build label

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -24,6 +24,12 @@ const variableConfig = loadVariant(
 );
 const buildFossOnly = process.env.BUILD_FOSS_ONLY === "true";
 
+// Optional build label shown on the settings screen to mark non-production
+// store builds (e.g. "beta"). Set per profile via eas.json `env.BUILD_LABEL`
+// (the same mechanism as `APP`, and the only env that reaches EAS cloud build
+// workers). Production profiles set nothing, so production builds show no label.
+const buildLabel = process.env.BUILD_LABEL;
+
 const config = ({ config }: ConfigContext): ExpoConfig => {
   return {
     ...config,
@@ -151,6 +157,7 @@ const config = ({ config }: ConfigContext): ExpoConfig => {
     extra: {
       ...variableConfig.extraConfig,
       isFoss: buildFossOnly,
+      ...(buildLabel && { buildLabel }),
       ...(buildFossOnly && { enableAnalytics: false }),
     },
     ...(buildFossOnly && {

--- a/eas.json
+++ b/eas.json
@@ -24,7 +24,8 @@
         "image": "auto"
       },
       "env": {
-        "APP": "volksverpetzer"
+        "APP": "volksverpetzer",
+        "BUILD_LABEL": "beta"
       }
     },
     "preview": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vvp_app",
-  "version": "2.2.3",
-  "versionCode": 2606251,
+  "version": "2.3.0",
+  "versionCode": 2606261,
   "main": "expo-router/entry",
   "expo": {
     "install": {

--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -262,6 +262,7 @@ const SettingsScreen = () => {
             Versionskennung: {Application.nativeApplicationVersion}
             &nbsp;-&nbsp;
             {Application.nativeBuildVersion}
+            {Config.buildLabel && ` - ${Config.buildLabel}`}
             {Config.isFoss && " - FOSS"}
             {!Config.isFoss && `\nToken: ${token}`}
           </UiText>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -51,4 +51,5 @@ export interface ExtraConfigType {
   importantCats: Record<number, string>;
   audioCdnUrl?: HttpsUrl; // Base URL for AI-generated article audio (e.g. https://audio.example.com/audio)
   isFoss?: boolean; // true when built as a FOSS variant (Stripe and other proprietary modules are excluded)
+  buildLabel?: string; // optional label (e.g. "beta") shown on the settings screen to mark non-production store builds
 }


### PR DESCRIPTION
Preparation branch for the next release (**2.3.0**).

## Changes

### 1. Version bump → 2.3.0
`package.json`: `version` `2.2.3 → 2.3.0`, `versionCode` `2606251 → 2606261` (date-based, strictly greater).

### 2. "beta" label on the settings screen for beta store builds
The beta store build (`eas` **internal** profile — auto-submitted to the Play internal track and TestFlight) now sets `BUILD_LABEL=beta` in `eas.json`. `app.config.ts` exposes it as `extra.buildLabel`, and the settings screen appends it to the version line:

```
Versionskennung: 2.3.0 - <build> - beta
```

- Uses the same env mechanism as `APP` — the only env that reaches EAS **cloud** build workers (a shell/CI env var does not).
- **Production** and **mimikama** profiles set nothing, so production store builds show **no** label.
- Local `expo run` / `--local` builds also show nothing unless `BUILD_LABEL` is set — intentional; the label is only meant to mark the beta store build.

## Notes
- Based on `prerelease`, which already includes the merged #347 apex config flip.
- Changelog / release notes are **not** included here — add them as part of cutting the actual release.

## Tests
Types, lint (0 errors), and the full suite (759 passed / 3 skipped) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)