### PR TITLE
Fix Prüfpunkt favorites (articles + Instagram) missing from MyFavs

### DIFF
--- a/__tests__/components/FavCounter.test.tsx
+++ b/__tests__/components/FavCounter.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import FavCounter from "#/components/counter/FavCounter";
 import { Achievements } from "#/helpers/Achievements";
+import ContentStore from "#/helpers/Stores/ContentStore";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { getFavs, registerFav } from "#/helpers/network/Engagement";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
@@ -43,6 +44,13 @@ jest.mock("#/helpers/Stores/FavoritesStore", () => ({
   },
 }));
 
+jest.mock("#/helpers/Stores/ContentStore", () => ({
+  __esModule: true,
+  default: {
+    getStoredInstaPost: jest.fn(),
+  },
+}));
+
 jest.mock("#/helpers/Achievements", () => ({
   Achievements: { setAchievementValue: jest.fn() },
 }));
@@ -66,6 +74,7 @@ describe("FavCounter", () => {
     jest.mocked(FavoritesStore.isFavorite).mockResolvedValue(false);
     jest.mocked(FavoritesStore.addFavorite).mockResolvedValue(undefined);
     jest.mocked(FavoritesStore.removeFavorite).mockResolvedValue(undefined);
+    jest.mocked(ContentStore.getStoredInstaPost).mockResolvedValue(undefined);
     jest.mocked(getFavs).mockResolvedValue(0);
     jest.mocked(registerFav).mockResolvedValue(undefined);
   });
@@ -92,6 +101,17 @@ describe("FavCounter", () => {
 
   it("adds a favorite, registers engagement, and increments the visible count", async () => {
     jest.mocked(getFavs).mockResolvedValue(2);
+    const instaSnapshot = {
+      id: contentFavIdentifier,
+      media_type: "IMAGE",
+      media_url: "https://example.com/image.jpg",
+      caption: "Snapshot caption",
+      timestamp: "2026-01-01T12:00:00Z",
+      permalink: "https://www.instagram.com/p/abc/",
+    };
+    jest
+      .mocked(ContentStore.getStoredInstaPost)
+      .mockResolvedValue(instaSnapshot as never);
 
     const { getByRole, getByText, queryByText } = render(
       <FavCounter
@@ -116,10 +136,16 @@ describe("FavCounter", () => {
 
     expect(queryByText("2")).toBeNull();
     expect(Achievements.setAchievementValue).toHaveBeenCalledWith("favorite");
+    // The cached Instagram post is snapshotted into the favorite so it can be
+    // rebuilt without the account-scoped by-id proxy.
+    expect(ContentStore.getStoredInstaPost).toHaveBeenCalledWith(
+      contentFavIdentifier,
+    );
     expect(FavoritesStore.addFavorite).toHaveBeenCalledWith(
       contentFavIdentifier,
       contentType,
       "https://example.com/one",
+      instaSnapshot,
     );
     expect(updateBadgeState).toHaveBeenCalledWith({ personal: true });
     expect(registerFav).toHaveBeenCalledWith("https://example.com/one");

--- a/__tests__/components/FavCounter.test.tsx
+++ b/__tests__/components/FavCounter.test.tsx
@@ -5,7 +5,7 @@ import { Achievements } from "#/helpers/Achievements";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { getFavs, registerFav } from "#/helpers/network/Engagement";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
-import type { FaveableType, ShareableType } from "#/types";
+import type { FaveableType, InstaPostProperties, ShareableType } from "#/types";
 
 jest.mock("#/constants/Config", () => ({
   __esModule: true,
@@ -92,7 +92,7 @@ describe("FavCounter", () => {
 
   it("adds a favorite, registers engagement, and increments the visible count", async () => {
     jest.mocked(getFavs).mockResolvedValue(2);
-    const instaSnapshot = {
+    const instaSnapshot: InstaPostProperties = {
       id: contentFavIdentifier,
       media_type: "IMAGE",
       media_url: "https://example.com/image.jpg",
@@ -107,7 +107,7 @@ describe("FavCounter", () => {
         style={{}}
         contentFavIdentifier={contentFavIdentifier}
         contentType={contentType}
-        favPayload={instaSnapshot as never}
+        favPayload={instaSnapshot}
       />,
     );
 

--- a/__tests__/components/FavCounter.test.tsx
+++ b/__tests__/components/FavCounter.test.tsx
@@ -119,6 +119,7 @@ describe("FavCounter", () => {
     expect(FavoritesStore.addFavorite).toHaveBeenCalledWith(
       contentFavIdentifier,
       contentType,
+      "https://example.com/one",
     );
     expect(updateBadgeState).toHaveBeenCalledWith({ personal: true });
     expect(registerFav).toHaveBeenCalledWith("https://example.com/one");

--- a/__tests__/components/FavCounter.test.tsx
+++ b/__tests__/components/FavCounter.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import FavCounter from "#/components/counter/FavCounter";
 import { Achievements } from "#/helpers/Achievements";
-import ContentStore from "#/helpers/Stores/ContentStore";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { getFavs, registerFav } from "#/helpers/network/Engagement";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
@@ -44,13 +43,6 @@ jest.mock("#/helpers/Stores/FavoritesStore", () => ({
   },
 }));
 
-jest.mock("#/helpers/Stores/ContentStore", () => ({
-  __esModule: true,
-  default: {
-    getStoredInstaPost: jest.fn(),
-  },
-}));
-
 jest.mock("#/helpers/Achievements", () => ({
   Achievements: { setAchievementValue: jest.fn() },
 }));
@@ -74,7 +66,6 @@ describe("FavCounter", () => {
     jest.mocked(FavoritesStore.isFavorite).mockResolvedValue(false);
     jest.mocked(FavoritesStore.addFavorite).mockResolvedValue(undefined);
     jest.mocked(FavoritesStore.removeFavorite).mockResolvedValue(undefined);
-    jest.mocked(ContentStore.getStoredInstaPost).mockResolvedValue(undefined);
     jest.mocked(getFavs).mockResolvedValue(0);
     jest.mocked(registerFav).mockResolvedValue(undefined);
   });
@@ -109,9 +100,6 @@ describe("FavCounter", () => {
       timestamp: "2026-01-01T12:00:00Z",
       permalink: "https://www.instagram.com/p/abc/",
     };
-    jest
-      .mocked(ContentStore.getStoredInstaPost)
-      .mockResolvedValue(instaSnapshot as never);
 
     const { getByRole, getByText, queryByText } = render(
       <FavCounter
@@ -119,6 +107,7 @@ describe("FavCounter", () => {
         style={{}}
         contentFavIdentifier={contentFavIdentifier}
         contentType={contentType}
+        favPayload={instaSnapshot as never}
       />,
     );
 
@@ -136,15 +125,13 @@ describe("FavCounter", () => {
 
     expect(queryByText("2")).toBeNull();
     expect(Achievements.setAchievementValue).toHaveBeenCalledWith("favorite");
-    // The cached Instagram post is snapshotted into the favorite so it can be
-    // rebuilt without the account-scoped by-id proxy.
-    expect(ContentStore.getStoredInstaPost).toHaveBeenCalledWith(
-      contentFavIdentifier,
-    );
+    // The Instagram post passed in via favPayload is snapshotted into the
+    // favorite so it can be rebuilt without the account-scoped by-id proxy.
+    // originalUrl stays undefined — only articles are re-fetched by URL.
     expect(FavoritesStore.addFavorite).toHaveBeenCalledWith(
       contentFavIdentifier,
       contentType,
-      "https://example.com/one",
+      undefined,
       instaSnapshot,
     );
     expect(updateBadgeState).toHaveBeenCalledWith({ personal: true });

--- a/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
+++ b/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
@@ -20,6 +20,9 @@ jest.mock("#/constants/Config", () => ({
   __esModule: true,
   default: {
     wpUrl: "https://www.volksverpetzer.de",
+    feeds: {
+      wp: [{ handle: "https://www.pruefpunkt.org", enabled: true }],
+    },
   },
 }));
 jest.mock("#/components/Icons", () => ({
@@ -79,6 +82,7 @@ jest.mock("#/helpers/network/WordPressAPI", () => ({
   __esModule: true,
   default: {
     getPost: jest.fn(),
+    create: jest.fn(),
   },
 }));
 
@@ -195,6 +199,62 @@ describe("MyFavs", () => {
         }),
       ]),
     );
+  });
+
+  it("loads a secondary-feed (Prüfpunkt) favorite from its own site instead of purging it", async () => {
+    const pruefpunktApiResponse = {
+      id: 7,
+      date: "2026-01-03T12:00:00Z",
+      date_gmt: "2026-01-03T12:00:00Z",
+      link: "https://www.pruefpunkt.org/faktencheck/pp-article",
+      slug: "pp-article",
+      title: { rendered: "Prüfpunkt Article" },
+      yoast_head_json: { description: "PP description" },
+      _links: { "wp:featuredmedia": [{ href: "https://example.com/image" }] },
+      categories: [],
+      authors: [],
+    };
+    const mappedPruefpunktPost = {
+      id: "pp-article",
+      component: jest.fn(),
+      data: {
+        article: {
+          title: "Prüfpunkt Article",
+          link: pruefpunktApiResponse.link,
+        },
+      },
+      shareable: [{ url: pruefpunktApiResponse.link, title: "Artikel teilen" }],
+      contentFavIdentifier: "pp-article",
+      contentType: FAV_TYPE_ARTICLE,
+    };
+    const secondaryGetPost = jest.fn().mockResolvedValue(pruefpunktApiResponse);
+
+    (FavoritesStore.getAllFavorites as jest.Mock).mockResolvedValue({
+      "pp-article": {
+        contentType: FAV_TYPE_ARTICLE,
+        originalUrl: "https://www.pruefpunkt.org/faktencheck/pp-article",
+      },
+    });
+    (WordPressAPI.create as jest.Mock).mockReturnValue({
+      getPost: secondaryGetPost,
+    });
+    (WordPressFetcher.mapArticleToPost as jest.Mock).mockReturnValue(
+      mappedPruefpunktPost,
+    );
+
+    render(<MyFavs />);
+
+    await waitFor(() => {
+      expect(GenericPost).toHaveBeenCalledTimes(1);
+    });
+
+    // Resolved via the secondary site's API, never the primary one.
+    expect(WordPressAPI.create).toHaveBeenCalledWith(
+      "https://www.pruefpunkt.org",
+    );
+    expect(secondaryGetPost).toHaveBeenCalledWith("pp-article");
+    expect(WordPressAPI.getPost).not.toHaveBeenCalled();
+    expect(FavoritesStore.removeFavorite).not.toHaveBeenCalled();
   });
 
   it("skips a failing Instagram favorite without aborting the rest of the list", async () => {

--- a/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
+++ b/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, waitFor } from "@testing-library/react-native";
 
 import GenericPost from "#/components/posts/GenericPost";
+import ContentStore from "#/helpers/Stores/ContentStore";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { registerViews } from "#/helpers/network/Engagement";
 import API from "#/helpers/network/ServerAPI";
@@ -75,6 +76,13 @@ jest.mock("#/helpers/network/ServerAPI", () => ({
   __esModule: true,
   default: {
     getInstaPost: jest.fn(),
+  },
+}));
+
+jest.mock("#/helpers/Stores/ContentStore", () => ({
+  __esModule: true,
+  default: {
+    getStoredInstaPost: jest.fn(),
   },
 }));
 
@@ -255,6 +263,52 @@ describe("MyFavs", () => {
     expect(secondaryGetPost).toHaveBeenCalledWith("pp-article");
     expect(WordPressAPI.getPost).not.toHaveBeenCalled();
     expect(FavoritesStore.removeFavorite).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds a secondary-account (Prüfpunkt) Instagram favorite from its stored snapshot", async () => {
+    const snapshot = {
+      id: "18100522658117977",
+      media_type: "IMAGE",
+      media_url: "https://example.com/pp.jpg",
+      caption: "Prüfpunkt insta caption",
+      timestamp: "2026-01-04T12:00:00Z",
+      permalink: "https://www.instagram.com/p/ppShortcode/",
+    };
+
+    (FavoritesStore.getAllFavorites as jest.Mock).mockResolvedValue({
+      "18100522658117977": {
+        contentType: FAV_TYPE_INSTA,
+        payload: snapshot,
+      },
+    });
+
+    render(<MyFavs />);
+
+    await waitFor(() => {
+      expect(GenericPost).toHaveBeenCalledTimes(1);
+    });
+
+    // Rendered straight from the snapshot — no account-scoped by-id proxy call,
+    // no local-cache lookup, and the favorite is not purged.
+    expect(API.getInstaPost).not.toHaveBeenCalled();
+    expect(ContentStore.getStoredInstaPost).not.toHaveBeenCalled();
+    expect(FavoritesStore.removeFavorite).not.toHaveBeenCalled();
+
+    const genericPostCalls = (
+      GenericPost as unknown as jest.Mock
+    ).mock.calls.map(([properties]) => properties);
+    expect(genericPostCalls[0]).toEqual(
+      expect.objectContaining({
+        contentFavIdentifier: "18100522658117977",
+        contentType: FAV_TYPE_INSTA,
+        shareable: [
+          {
+            title: "Instagram Post teilen",
+            url: "https://www.instagram.com/p/ppShortcode/",
+          },
+        ],
+      }),
+    );
   });
 
   it("skips a failing Instagram favorite without aborting the rest of the list", async () => {

--- a/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
+++ b/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
@@ -1,7 +1,6 @@
 import { act, render, waitFor } from "@testing-library/react-native";
 
 import GenericPost from "#/components/posts/GenericPost";
-import ContentStore from "#/helpers/Stores/ContentStore";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { registerViews } from "#/helpers/network/Engagement";
 import API from "#/helpers/network/ServerAPI";
@@ -76,13 +75,6 @@ jest.mock("#/helpers/network/ServerAPI", () => ({
   __esModule: true,
   default: {
     getInstaPost: jest.fn(),
-  },
-}));
-
-jest.mock("#/helpers/Stores/ContentStore", () => ({
-  __esModule: true,
-  default: {
-    getStoredInstaPost: jest.fn(),
   },
 }));
 
@@ -289,9 +281,8 @@ describe("MyFavs", () => {
     });
 
     // Rendered straight from the snapshot — no account-scoped by-id proxy call,
-    // no local-cache lookup, and the favorite is not purged.
+    // and the favorite is not purged.
     expect(API.getInstaPost).not.toHaveBeenCalled();
-    expect(ContentStore.getStoredInstaPost).not.toHaveBeenCalled();
     expect(FavoritesStore.removeFavorite).not.toHaveBeenCalled();
 
     const genericPostCalls = (

--- a/src/app/insta/[post_id].tsx
+++ b/src/app/insta/[post_id].tsx
@@ -107,6 +107,7 @@ const InstaScreen = () => {
         shareable={[{ url: data.permalink, title: data.caption }]}
         contentFavIdentifier={parameters.post_id}
         contentType="insta"
+        favPayload={data}
       />
     </View>
   );

--- a/src/components/bars/NavBar.tsx
+++ b/src/components/bars/NavBar.tsx
@@ -11,13 +11,19 @@ import Colors from "#/constants/Colors";
 import { onShare } from "#/helpers/Sharing";
 import { hexToRgb } from "#/helpers/utils/color";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
-import type { FaveableType, HttpsUrl, ShareableType } from "#/types";
+import type {
+  FaveableType,
+  HttpsUrl,
+  InstaPostProperties,
+  ShareableType,
+} from "#/types";
 
 interface NavBarProperties {
   link?: HttpsUrl;
   shareable?: ShareableType[];
   contentFavIdentifier?: string;
   contentType?: FaveableType;
+  favPayload?: InstaPostProperties;
 }
 /**
  * NavBar component renders a top navigation bar with a customizable
@@ -37,7 +43,8 @@ interface NavBarProperties {
  * visible, it displays the share count and allows the link to be shared.
  */
 const NavBar = (properties: NavBarProperties) => {
-  const { contentFavIdentifier, contentType, link, shareable } = properties;
+  const { contentFavIdentifier, contentType, favPayload, link, shareable } =
+    properties;
   const router = useRouter();
   const colorScheme = useAppColorScheme();
   const corporate = Colors[colorScheme].primary;
@@ -99,6 +106,7 @@ const NavBar = (properties: NavBarProperties) => {
             shareable={shareable}
             contentFavIdentifier={contentFavIdentifier}
             contentType={contentType}
+            favPayload={favPayload}
             style={{
               color: corporate,
               fontSize: 16,

--- a/src/components/bars/ShareBar.tsx
+++ b/src/components/bars/ShareBar.tsx
@@ -6,18 +6,24 @@ import ShareCounter from "#/components/counter/ShareCounter";
 import { globalStyles } from "#/constants/GlobalStyles";
 import { multishare } from "#/helpers/Sharing";
 import { useCorporateColor } from "#/hooks/useAppColorScheme";
-import type { FaveableType, ShareableType } from "#/types";
+import type { FaveableType, InstaPostProperties, ShareableType } from "#/types";
 
 interface ShareBarProperties {
   shareable: ShareableType[];
   contentFavIdentifier?: string;
   contentType?: FaveableType;
+  favPayload?: InstaPostProperties;
   hideShareCount?: boolean;
 }
 
 const ShareBar = (properties: ShareBarProperties) => {
-  const { shareable, hideShareCount, contentFavIdentifier, contentType } =
-    properties;
+  const {
+    shareable,
+    hideShareCount,
+    contentFavIdentifier,
+    contentType,
+    favPayload,
+  } = properties;
   const [shares, setShares] = useState(0);
 
   const onPress = async () => {
@@ -52,6 +58,7 @@ const ShareBar = (properties: ShareBarProperties) => {
           shareable={shareable}
           contentFavIdentifier={contentFavIdentifier}
           contentType={contentType}
+          favPayload={favPayload}
           style={{ color, fontSize }}
         />
       )}

--- a/src/components/counter/FavCounter.tsx
+++ b/src/components/counter/FavCounter.tsx
@@ -9,7 +9,7 @@ import { getFavs } from "#/helpers/network/Engagement";
 import { useCorporateColor } from "#/hooks/useAppColorScheme";
 import { useEngagementCount } from "#/hooks/useEngagementCount";
 import { useFavorite } from "#/hooks/useFavorite";
-import type { FaveableType, ShareableType } from "#/types";
+import type { FaveableType, InstaPostProperties, ShareableType } from "#/types";
 
 interface FavCounterProperties {
   shareable: ShareableType[];
@@ -17,6 +17,7 @@ interface FavCounterProperties {
   style: TextStyle;
   contentFavIdentifier?: string;
   contentType?: FaveableType;
+  favPayload?: InstaPostProperties;
 }
 
 const FavCounter = (properties: FavCounterProperties) => {
@@ -24,6 +25,7 @@ const FavCounter = (properties: FavCounterProperties) => {
   const {
     contentFavIdentifier,
     contentType,
+    favPayload,
     shareable,
     size = 20,
   } = properties;
@@ -31,6 +33,7 @@ const FavCounter = (properties: FavCounterProperties) => {
     contentFavIdentifier,
     contentType,
     shareable[0]?.url,
+    favPayload,
   );
   const favs = useEngagementCount(shareable, getFavs);
 

--- a/src/components/posts/GenericPost.tsx
+++ b/src/components/posts/GenericPost.tsx
@@ -6,7 +6,8 @@ import { View } from "react-native";
 import ShareBar from "#/components/bars/ShareBar";
 import UiCard from "#/components/ui/UiCard";
 import { POST_PADDING_HORIZONTAL } from "#/constants/GlobalStyles";
-import type { FaveableType, ShareableType } from "#/types";
+import type { FaveableType, InstaPostProperties, ShareableType } from "#/types";
+import { FAV_TYPE_INSTA } from "#/types";
 
 interface ComponentProperty<T> {
   component: FC<{ inView: boolean } & T>;
@@ -45,6 +46,13 @@ const GenericPost = (properties: ComponentProperty<object>) => {
           hideShareCount={!inView}
           contentFavIdentifier={contentFavIdentifier}
           contentType={contentType}
+          // For Instagram posts `data` is the post itself; snapshot it into the
+          // favorite so it survives without the account-scoped by-id proxy.
+          favPayload={
+            contentType === FAV_TYPE_INSTA
+              ? (data as InstaPostProperties)
+              : undefined
+          }
         />
       ) : (
         <View

--- a/src/helpers/Stores/FavoritesStore.ts
+++ b/src/helpers/Stores/FavoritesStore.ts
@@ -1,5 +1,10 @@
 import BaseStore from "#/helpers/Storage";
-import type { FaveableType, HttpsUrl, StoredFavs } from "#/types";
+import type {
+  FaveableType,
+  HttpsUrl,
+  InstaPostProperties,
+  StoredFavs,
+} from "#/types";
 
 const FavoritesStore = {
   favKey: "favs",
@@ -36,11 +41,14 @@ const FavoritesStore = {
    * @param {FaveableType} contentType The type of content.
    * @param {HttpsUrl} [originalUrl] Full source URL, used to reload favorites
    *   from a secondary WordPress feed (e.g. Prüfpunkt) from the correct site.
+   * @param {InstaPostProperties} [payload] Snapshot of an Instagram post so it
+   *   can be rebuilt without the account-scoped by-id proxy (see StoredFav).
    */
   async addFavorite(
     contentFavIdentifier: string,
     contentType: FaveableType,
     originalUrl?: HttpsUrl,
+    payload?: InstaPostProperties,
   ): Promise<void> {
     const storedFavs = await this.getStoredFavs();
     const newStoredFavs = {
@@ -48,6 +56,7 @@ const FavoritesStore = {
       [contentFavIdentifier]: {
         contentType,
         ...(originalUrl && { originalUrl }),
+        ...(payload && { payload }),
       },
     };
     await this.setStoredFavs(newStoredFavs);

--- a/src/helpers/Stores/FavoritesStore.ts
+++ b/src/helpers/Stores/FavoritesStore.ts
@@ -1,5 +1,5 @@
 import BaseStore from "#/helpers/Storage";
-import type { FaveableType, StoredFavs } from "#/types";
+import type { FaveableType, HttpsUrl, StoredFavs } from "#/types";
 
 const FavoritesStore = {
   favKey: "favs",
@@ -34,15 +34,21 @@ const FavoritesStore = {
    * Adds a new favorite to storage.
    * @param {string} contentFavIdentifier The unique identifier for the content.
    * @param {FaveableType} contentType The type of content.
+   * @param {HttpsUrl} [originalUrl] Full source URL, used to reload favorites
+   *   from a secondary WordPress feed (e.g. Prüfpunkt) from the correct site.
    */
   async addFavorite(
     contentFavIdentifier: string,
     contentType: FaveableType,
+    originalUrl?: HttpsUrl,
   ): Promise<void> {
     const storedFavs = await this.getStoredFavs();
     const newStoredFavs = {
       ...storedFavs,
-      [contentFavIdentifier]: { contentType },
+      [contentFavIdentifier]: {
+        contentType,
+        ...(originalUrl && { originalUrl }),
+      },
     };
     await this.setStoredFavs(newStoredFavs);
   },

--- a/src/hooks/useFavorite.ts
+++ b/src/hooks/useFavorite.ts
@@ -4,7 +4,7 @@ import { Achievements } from "#/helpers/Achievements";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { registerFav } from "#/helpers/network/Engagement";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
-import type { FaveableType } from "#/types";
+import type { FaveableType, HttpsUrl } from "#/types";
 
 /**
  * Encapsulates the "is this content saved as a favorite" state and the toggle behavior
@@ -17,7 +17,7 @@ import type { FaveableType } from "#/types";
 export const useFavorite = (
   contentFavIdentifier?: string,
   contentType?: FaveableType,
-  registerUrl?: string,
+  registerUrl?: HttpsUrl,
 ) => {
   const [isFav, setIsFav] = useState(false);
 
@@ -41,7 +41,13 @@ export const useFavorite = (
       if (!contentType) return;
       setIsFav(true);
       Achievements.setAchievementValue("favorite");
-      FavoritesStore.addFavorite(contentFavIdentifier, contentType);
+      // registerUrl is the content's own source URL; persist it so favorites
+      // from a secondary WP feed (Prüfpunkt) reload from the right site.
+      FavoritesStore.addFavorite(
+        contentFavIdentifier,
+        contentType,
+        registerUrl,
+      );
       updateBadgeState({ personal: true });
       if (registerUrl) await registerFav(registerUrl);
     }

--- a/src/hooks/useFavorite.ts
+++ b/src/hooks/useFavorite.ts
@@ -1,12 +1,11 @@
 import { useEffect, useState } from "react";
 
 import { Achievements } from "#/helpers/Achievements";
-import ContentStore from "#/helpers/Stores/ContentStore";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { registerFav } from "#/helpers/network/Engagement";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
-import type { FaveableType, HttpsUrl } from "#/types";
-import { FAV_TYPE_INSTA } from "#/types";
+import type { FaveableType, HttpsUrl, InstaPostProperties } from "#/types";
+import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA } from "#/types";
 
 /**
  * Encapsulates the "is this content saved as a favorite" state and the toggle behavior
@@ -15,11 +14,14 @@ import { FAV_TYPE_INSTA } from "#/types";
  * @param contentFavIdentifier Local-storage identifier for the favorite (e.g. slug)
  * @param contentType The type of content being saved as a favorite
  * @param registerUrl URL reported to the engagement backend when a favorite is added
+ * @param favPayload Instagram post to snapshot into the favorite, so it can be
+ *   rebuilt without the account-scoped by-id proxy
  */
 export const useFavorite = (
   contentFavIdentifier?: string,
   contentType?: FaveableType,
   registerUrl?: HttpsUrl,
+  favPayload?: InstaPostProperties,
 ) => {
   const [isFav, setIsFav] = useState(false);
 
@@ -43,20 +45,14 @@ export const useFavorite = (
       if (!contentType) return;
       setIsFav(true);
       Achievements.setAchievementValue("favorite");
-      // Instagram posts can't be re-fetched by id across accounts (the by-id
-      // proxy only serves the default account), so snapshot the post — it is in
-      // ContentStore because the user just viewed it — and store it with the fav.
-      const payload =
-        contentType === FAV_TYPE_INSTA
-          ? await ContentStore.getStoredInstaPost(contentFavIdentifier)
-          : undefined;
-      // registerUrl is the content's own source URL; persist it so favorites
-      // from a secondary WP feed (Prüfpunkt) reload from the right site.
+      // Articles are re-fetched by URL, so persist the source URL to reload them
+      // from the right site (e.g. a secondary Prüfpunkt feed). Instagram posts
+      // can't be re-fetched by id across accounts, so snapshot the post instead.
       await FavoritesStore.addFavorite(
         contentFavIdentifier,
         contentType,
-        registerUrl,
-        payload,
+        contentType === FAV_TYPE_ARTICLE ? registerUrl : undefined,
+        contentType === FAV_TYPE_INSTA ? favPayload : undefined,
       );
       updateBadgeState({ personal: true });
       if (registerUrl) await registerFav(registerUrl);

--- a/src/hooks/useFavorite.ts
+++ b/src/hooks/useFavorite.ts
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 
 import { Achievements } from "#/helpers/Achievements";
+import ContentStore from "#/helpers/Stores/ContentStore";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { registerFav } from "#/helpers/network/Engagement";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
 import type { FaveableType, HttpsUrl } from "#/types";
+import { FAV_TYPE_INSTA } from "#/types";
 
 /**
  * Encapsulates the "is this content saved as a favorite" state and the toggle behavior
@@ -41,12 +43,20 @@ export const useFavorite = (
       if (!contentType) return;
       setIsFav(true);
       Achievements.setAchievementValue("favorite");
+      // Instagram posts can't be re-fetched by id across accounts (the by-id
+      // proxy only serves the default account), so snapshot the post — it is in
+      // ContentStore because the user just viewed it — and store it with the fav.
+      const payload =
+        contentType === FAV_TYPE_INSTA
+          ? await ContentStore.getStoredInstaPost(contentFavIdentifier)
+          : undefined;
       // registerUrl is the content's own source URL; persist it so favorites
       // from a secondary WP feed (Prüfpunkt) reload from the right site.
-      FavoritesStore.addFavorite(
+      await FavoritesStore.addFavorite(
         contentFavIdentifier,
         contentType,
         registerUrl,
+        payload,
       );
       updateBadgeState({ personal: true });
       if (registerUrl) await registerFav(registerUrl);

--- a/src/screens/PersonalTab/components/MyFavs.tsx
+++ b/src/screens/PersonalTab/components/MyFavs.tsx
@@ -17,12 +17,27 @@ import WordPressAPI from "#/helpers/network/WordPressAPI";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
 import { findSecondaryWpFeed } from "#/helpers/utils/feeds";
 import { WordPressFetcher } from "#/screens/Home/fetchers/WordPressFetcher";
-import type { ArticleProperties, InstaPostProperties } from "#/types";
+import type { ArticleProperties, HttpsUrl, InstaPostProperties } from "#/types";
 import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA } from "#/types";
 
 type FavoritePost =
   | Post<{ article: ArticleProperties }>
   | Post<InstaPostProperties>;
+
+// Reuse one API client per secondary site instead of rebuilding it for every
+// favorite on every load.
+const secondaryApiCache = new Map<
+  HttpsUrl,
+  ReturnType<typeof WordPressAPI.create>
+>();
+const secondaryApiFor = (handle: HttpsUrl) => {
+  let api = secondaryApiCache.get(handle);
+  if (!api) {
+    api = WordPressAPI.create(handle);
+    secondaryApiCache.set(handle, api);
+  }
+  return api;
+};
 
 const loadFavoriteArticlePost = async (
   slug: string,
@@ -36,7 +51,7 @@ const loadFavoriteArticlePost = async (
     Config.wpUrl,
     Config.feeds?.wp,
   );
-  const api = secondaryWp ? WordPressAPI.create(secondaryWp.handle) : null;
+  const api = secondaryWp ? secondaryApiFor(secondaryWp.handle) : null;
   const article = api
     ? await api.getPost(slug)
     : await WordPressAPI.getPost(slug);

--- a/src/screens/PersonalTab/components/MyFavs.tsx
+++ b/src/screens/PersonalTab/components/MyFavs.tsx
@@ -41,7 +41,7 @@ const secondaryApiFor = (handle: HttpsUrl) => {
 
 const loadFavoriteArticlePost = async (
   slug: string,
-  originalUrl?: string,
+  originalUrl?: HttpsUrl,
 ): Promise<Post<{ article: ArticleProperties }> | undefined> => {
   // Articles from a secondary WordPress feed (e.g. Prüfpunkt) live on their own
   // site, so reload them from that site's API instead of the primary one — which

--- a/src/screens/PersonalTab/components/MyFavs.tsx
+++ b/src/screens/PersonalTab/components/MyFavs.tsx
@@ -10,7 +10,6 @@ import UiSpace from "#/components/ui/UiSpace";
 import UiSpinner from "#/components/ui/UiSpinner";
 import Config from "#/constants/Config";
 import Post from "#/helpers/Post";
-import ContentStore from "#/helpers/Stores/ContentStore";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { registerViews } from "#/helpers/network/Engagement";
 import API from "#/helpers/network/ServerAPI";
@@ -58,11 +57,8 @@ const loadFavoriteInstaPost = async (
 ): Promise<Post<InstaPostProperties> | undefined> => {
   try {
     // Prefer the snapshot stored with the favorite (works for any account and
-    // without the backend), then the local cache, then the by-id proxy.
-    const post =
-      payload ??
-      (await ContentStore.getStoredInstaPost(id)) ??
-      (await API.getInstaPost(id));
+    // without the backend); otherwise re-fetch from the by-id proxy.
+    const post = payload ?? (await API.getInstaPost(id));
     if (
       !post ||
       (post.media_type !== "IMAGE" && post.media_type !== "CAROUSEL_ALBUM")

--- a/src/screens/PersonalTab/components/MyFavs.tsx
+++ b/src/screens/PersonalTab/components/MyFavs.tsx
@@ -15,6 +15,7 @@ import { registerViews } from "#/helpers/network/Engagement";
 import API from "#/helpers/network/ServerAPI";
 import WordPressAPI from "#/helpers/network/WordPressAPI";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
+import { findSecondaryWpFeed } from "#/helpers/utils/feeds";
 import { WordPressFetcher } from "#/screens/Home/fetchers/WordPressFetcher";
 import type { ArticleProperties, InstaPostProperties } from "#/types";
 import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA } from "#/types";
@@ -25,8 +26,20 @@ type FavoritePost =
 
 const loadFavoriteArticlePost = async (
   slug: string,
+  originalUrl?: string,
 ): Promise<Post<{ article: ArticleProperties }> | undefined> => {
-  const article = await WordPressAPI.getPost(slug);
+  // Articles from a secondary WordPress feed (e.g. Prüfpunkt) live on their own
+  // site, so reload them from that site's API instead of the primary one — which
+  // would 404 and purge the favorite below.
+  const secondaryWp = findSecondaryWpFeed(
+    originalUrl,
+    Config.wpUrl,
+    Config.feeds?.wp,
+  );
+  const api = secondaryWp ? WordPressAPI.create(secondaryWp.handle) : null;
+  const article = api
+    ? await api.getPost(slug)
+    : await WordPressAPI.getPost(slug);
   if (!article) {
     console.warn(
       `Article not found for slug: ${slug}, removing from favorites`,
@@ -79,11 +92,11 @@ const MyFavs = () => {
       const results = await Promise.allSettled(
         Object.entries(favs)
           .reverse()
-          .map(async ([fav, { contentType }]) => {
+          .map(async ([fav, { contentType, originalUrl }]) => {
             try {
               switch (contentType) {
                 case FAV_TYPE_ARTICLE:
-                  return await loadFavoriteArticlePost(fav);
+                  return await loadFavoriteArticlePost(fav, originalUrl);
                 case FAV_TYPE_INSTA:
                   return await loadFavoriteInstaPost(fav);
               }

--- a/src/screens/PersonalTab/components/MyFavs.tsx
+++ b/src/screens/PersonalTab/components/MyFavs.tsx
@@ -10,6 +10,7 @@ import UiSpace from "#/components/ui/UiSpace";
 import UiSpinner from "#/components/ui/UiSpinner";
 import Config from "#/constants/Config";
 import Post from "#/helpers/Post";
+import ContentStore from "#/helpers/Stores/ContentStore";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { registerViews } from "#/helpers/network/Engagement";
 import API from "#/helpers/network/ServerAPI";
@@ -53,10 +54,19 @@ const loadFavoriteArticlePost = async (
 
 const loadFavoriteInstaPost = async (
   id: string,
+  payload?: InstaPostProperties,
 ): Promise<Post<InstaPostProperties> | undefined> => {
   try {
-    const post = await API.getInstaPost(id);
-    if (post.media_type !== "IMAGE" && post.media_type !== "CAROUSEL_ALBUM") {
+    // Prefer the snapshot stored with the favorite (works for any account and
+    // without the backend), then the local cache, then the by-id proxy.
+    const post =
+      payload ??
+      (await ContentStore.getStoredInstaPost(id)) ??
+      (await API.getInstaPost(id));
+    if (
+      !post ||
+      (post.media_type !== "IMAGE" && post.media_type !== "CAROUSEL_ALBUM")
+    ) {
       return undefined;
     }
 
@@ -92,13 +102,13 @@ const MyFavs = () => {
       const results = await Promise.allSettled(
         Object.entries(favs)
           .reverse()
-          .map(async ([fav, { contentType, originalUrl }]) => {
+          .map(async ([fav, { contentType, originalUrl, payload }]) => {
             try {
               switch (contentType) {
                 case FAV_TYPE_ARTICLE:
                   return await loadFavoriteArticlePost(fav, originalUrl);
                 case FAV_TYPE_INSTA:
-                  return await loadFavoriteInstaPost(fav);
+                  return await loadFavoriteInstaPost(fav, payload);
               }
             } catch (error) {
               console.error(

--- a/src/types/stores.ts
+++ b/src/types/stores.ts
@@ -12,6 +12,10 @@ export type ShareableType = {
 
 export type StoredFav = {
   contentType: FaveableType;
+  // Full source URL of the saved content. Needed so favorites from a
+  // secondary WordPress feed (e.g. Prüfpunkt) can be reloaded from the correct
+  // site instead of the primary one, which would 404 and purge the favorite.
+  originalUrl?: HttpsUrl;
 };
 
 export type StoredFavs = Record<string, StoredFav>;

--- a/src/types/stores.ts
+++ b/src/types/stores.ts
@@ -17,7 +17,7 @@ export type StoredFav = {
   // secondary WordPress feed (e.g. Prüfpunkt) can be reloaded from the correct
   // site instead of the primary one, which would 404 and purge the favorite.
   originalUrl?: HttpsUrl;
-  // Snapshot of an Instagram post, captured when it is favorited. The by-id
+  // Snapshot of an Instagram post, captured when it is saved. The by-id
   // proxy (/proxy/instaById) only serves the default account, so a post from a
   // secondary account (e.g. Prüfpunkt) can't be re-fetched; this lets MyFavs
   // rebuild it directly. Also survives the cold-start ContentStore.clear().

--- a/src/types/stores.ts
+++ b/src/types/stores.ts
@@ -1,4 +1,5 @@
 import type { HttpsUrl } from "#/types/config";
+import type { InstaPostProperties } from "#/types/posts";
 
 export const FAV_TYPE_ARTICLE = "article";
 export const FAV_TYPE_INSTA = "insta";
@@ -16,6 +17,11 @@ export type StoredFav = {
   // secondary WordPress feed (e.g. Prüfpunkt) can be reloaded from the correct
   // site instead of the primary one, which would 404 and purge the favorite.
   originalUrl?: HttpsUrl;
+  // Snapshot of an Instagram post, captured when it is favorited. The by-id
+  // proxy (/proxy/instaById) only serves the default account, so a post from a
+  // secondary account (e.g. Prüfpunkt) can't be re-fetched; this lets MyFavs
+  // rebuild it directly. Also survives the cold-start ContentStore.clear().
+  payload?: InstaPostProperties;
 };
 
 export type StoredFavs = Record<string, StoredFav>;


### PR DESCRIPTION
## Problem

Favoriting Prüfpunkt content didn't work: the star toggled on, but the item never appeared in **MyFavs**. Two distinct root causes, both stemming from favorites losing which *source* their content came from.

### Articles
Prüfpunkt is a **secondary** WordPress feed (`wp:pruefpunkt.org`). Favorites were keyed only by slug, so MyFavs reloaded them from the **primary** site's API, got a 404, and — by design — **deleted them** as stale. The star filled, then the entry was purged on the next read.

### Instagram
Instagram posts carry no account field, and the by-id proxy (`/proxy/instaById`) only serves the default (volksverpetzer) account, so a `pruefpunkt`-owned post could never be re-fetched. The local `ContentStore` cache that might help is wiped on every cold start (`app/index.tsx`).

## Fix

- **Articles** — persist the article's source URL on the favorite and reload via `findSecondaryWpFeed` from the correct site, mirroring the article-detail route.
- **Instagram** — snapshot the post into the favorite record at favorite-time and render MyFavs from that snapshot (else re-fetch). Works for any account, survives the cold-start cache clear, and is resilient to the `instaById` backend being unavailable.
- The snapshot is threaded down as a `favPayload` prop from where the post is already in scope (feed `GenericPost`/`ShareBar`, detail `NavBar` → `FavCounter` → `useFavorite`), rather than re-reading the cache by id — so capture is deterministic, not a timing bet.
- Each type stores only what its read path uses: `originalUrl` for articles, `payload` for insta.
- `MyFavs` reuses one `WordPressAPI` client per secondary host instead of rebuilding it per favorite per load.

Backward compatible: favorites saved before this change fall through to the previous behavior. Existing Prüfpunkt favorites were already purged/unrenderable, so re-tap the star once to capture them.

## Commits
1. Fix Prüfpunkt article favorites being purged from MyFavs
2. Fix Prüfpunkt Instagram favorites missing from MyFavs (snapshot)
3. Simplify insta favorite loading to snapshot-or-refetch
4. Pass insta snapshot via props instead of re-reading the cache (+ scope originalUrl/payload)
5. Reuse one WordPress client per secondary feed in MyFavs

## Testing
- `pnpm check:ts` clean
- `pnpm lint` 0 errors
- `pnpm test` — full suite green (794 passed, 3 skipped); added regression tests for the secondary-feed article path and the Instagram snapshot path

🤖 Generated with [Claude Code](https://claude.com/claude-code)