### PR TITLE
Size UiSpinner loading image to the spinner size

### DIFF
--- a/src/components/ui/UiSpinner.tsx
+++ b/src/components/ui/UiSpinner.tsx
@@ -16,9 +16,18 @@ type UiSpinnerProperties = ActivityIndicatorProps & {
   text?: string;
 };
 
+// Branded loading image size per named spinner size: double React Native's
+// stock ActivityIndicator sizes (small ~20, large ~36) so the image reads at a
+// comparable visual weight to the old fixed 100px.
+const IMAGE_SIZE = { small: 40, large: 72 } as const;
+
 const UiSpinner = (props: UiSpinnerProperties) => {
   const { containerStyle, text, ...indicatorProps } = props;
   const corporate = useCorporateColor();
+  const imageSize =
+    typeof indicatorProps.size === "number"
+      ? indicatorProps.size
+      : IMAGE_SIZE[indicatorProps.size ?? "small"];
   return (
     <View
       style={[
@@ -30,7 +39,7 @@ const UiSpinner = (props: UiSpinnerProperties) => {
       {AppImages.loadingAnimation ? (
         <Image
           source={AppImages.loadingAnimation}
-          style={{ width: 100, height: 100 }}
+          style={{ width: imageSize, height: imageSize }}
         />
       ) : (
         <ActivityIndicator color={corporate} {...indicatorProps} />


### PR DESCRIPTION
## What

The `UiSpinner` loading image was hardcoded to `100×100` regardless of the requested spinner `size`. This makes the branded loading image scale with the `size` prop instead.

## How

- Named sizes map to **double React Native's stock `ActivityIndicator` sizes** (small ~20 → 40, large ~36 → 72), so the branded image reads at a comparable visual weight to a regular spinner.
- A numeric `size` is used as the exact image px (explicit override).
- Falls back to `small` when no size is given, matching RN's `ActivityIndicator` default.

## Behavioral note

Relative to the previous fixed `100px`, the image is now smaller everywhere:
- `size="large"` callers: 100 → 72
- default / `size="small"` callers: 100 → 40

This is intentional — the image is now tied to the spinner size rather than a fixed prominence.

## Testing

- `pnpm check:ts` clean
- `pnpm lint` clean
- `pnpm test` — UiSpinner suite green (8 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)