### PR TITLE
Skip Plausible analytics on beta builds

### DIFF
--- a/src/helpers/network/Analytics.ts
+++ b/src/helpers/network/Analytics.ts
@@ -41,9 +41,9 @@ const registerEvent = async (
       OSversion: Platform.Version,
       appVersion: Application?.nativeApplicationVersion,
       appBuild: Application?.nativeBuildVersion,
-      // Marks non-production store builds (e.g. "beta") so beta traffic can be
-      // filtered out in the Plausible dashboard. Production builds set no
-      // buildLabel, so they report "production".
+      // Marks non-production store builds so traffic can be segmented in Plausible.
+      // Note: "beta" builds are skipped entirely above (no events sent).
+      // Production builds set no buildLabel, so we default to "production" for consistency.
       buildLabel: Config.buildLabel ?? "production",
       width: Dimensions.get("window").width,
       ...properties,

--- a/src/helpers/network/Analytics.ts
+++ b/src/helpers/network/Analytics.ts
@@ -24,6 +24,9 @@ const registerEvent = async (
   utm_source = "app",
 ): Promise<void> => {
   if (!Config.enableAnalytics) return;
+  // Skip beta store builds so pre-release testing traffic doesn't distort the
+  // real user analytics. Production builds set no buildLabel.
+  if (Config.buildLabel === "beta") return;
   // Fall back to the primary site when no resource link is provided (e.g. an
   // outbound link tapped without article context), so the event URL and site
   // are always well-formed instead of "undefined?...".
@@ -38,6 +41,10 @@ const registerEvent = async (
       OSversion: Platform.Version,
       appVersion: Application?.nativeApplicationVersion,
       appBuild: Application?.nativeBuildVersion,
+      // Marks non-production store builds (e.g. "beta") so beta traffic can be
+      // filtered out in the Plausible dashboard. Production builds set no
+      // buildLabel, so they report "production".
+      buildLabel: Config.buildLabel ?? "production",
       width: Dimensions.get("window").width,
       ...properties,
     },


### PR DESCRIPTION
## Why

Pre-release beta builds generate testing traffic that distorts the real user analytics in Plausible. We'd rather have no data from beta than data that pollutes production metrics.

## What

Adds a guard in `registerEvent` (`src/helpers/network/Analytics.ts`) that returns early when `Config.buildLabel === "beta"`, so beta builds send **zero** Plausible events.

- `Config.buildLabel` is set via `eas.json` `env.BUILD_LABEL` for non-production store builds and flows through `app.config.ts` → `Config.extra.buildLabel`. Production builds set nothing, so they're unaffected.
- All Plausible paths (page views via `registerViews`, favorites via `registerFav`, and custom events) funnel through `registerEvent`, so the single guard covers everything. `Analytics.ts` is the only file that posts to `plausible.io`.

## Testing

- `pnpm test -- __tests__/helpers/Networking/Analytics.test.ts` — 8 passed
- `pnpm check:ts` — clean
- `pnpm lint` (Analytics.ts) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)