### PR TITLE
Fill analytics gaps: report submissions, Prüfpunkt adoption, social views

### DIFF
--- a/__tests__/helpers/Networking/Analytics.test.ts
+++ b/__tests__/helpers/Networking/Analytics.test.ts
@@ -4,7 +4,10 @@ import * as Linking from "expo-linking";
 import { Platform } from "react-native";
 
 import Config from "#/constants/Config";
-import { registerEvent } from "#/helpers/network/Analytics";
+import {
+  registerEvent,
+  registerPostInteraction,
+} from "#/helpers/network/Analytics";
 import { registerFav, registerViews } from "#/helpers/network/Engagement";
 import * as Networking from "#/helpers/utils/networking";
 
@@ -174,6 +177,28 @@ describe("Analytics (Plausible)", () => {
 
       const [, , body] = postSpy.mock.calls[0];
       expect(body.name).toBe("favorite");
+    });
+
+    it("registerPostInteraction should forward to registerEvent with platform/action props", async () => {
+      parseSpy.mockReturnValue({ hostname: "www.volksverpetzer.de" });
+      postSpy.mockResolvedValue({ success: true });
+
+      await registerPostInteraction(
+        "https://youtu.be/abc123",
+        "youtube",
+        "play",
+      );
+
+      const [, , body] = postSpy.mock.calls[0];
+      expect(body.name).toBe("Post Interaction");
+      expect(body.props).toEqual(
+        expect.objectContaining({
+          post_platform: "youtube",
+          action: "play",
+          // OS platform prop must survive — not overwritten by post_platform
+          platform: Platform.OS,
+        }),
+      );
     });
   });
 

--- a/src/app/(tabs)/report.tsx
+++ b/src/app/(tabs)/report.tsx
@@ -18,8 +18,10 @@ import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
 import UiTextInput from "#/components/ui/UiTextInput";
 import Colors from "#/constants/Colors";
+import Config from "#/constants/Config";
 import { globalStyles } from "#/constants/GlobalStyles";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
+import { registerEvent } from "#/helpers/network/Analytics";
 import API from "#/helpers/network/ServerAPI";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 import ReportStatusList from "#/screens/ReportTab/components/ReportStatusList";
@@ -117,6 +119,10 @@ const ReportScreen = () => {
       more_info: moreInfo,
       url,
       allowed_public: allowedPublic,
+    });
+    registerEvent(Config.wpUrl, "Report Submitted", {
+      allowed_public: allowedPublic,
+      has_url: url.trim().length > 0,
     });
     const updatedReports = [...reports, data];
     setReports(updatedReports);

--- a/src/components/posts/TiktokPost.tsx
+++ b/src/components/posts/TiktokPost.tsx
@@ -42,7 +42,11 @@ const TiktokPost = (properties: TiktokPostProperties) => {
       <View style={[styles.container, { height }]}>
         <UiPressable
           onPress={() => {
-            registerPostInteraction(share_url ?? embed_link, "tiktok", "play");
+            registerPostInteraction(
+              (share_url ?? embed_link).split("?")[0],
+              "tiktok",
+              "play",
+            );
             setIsVideoLoaded(true);
           }}
           style={styles.thumbnailContainer}

--- a/src/components/posts/TiktokPost.tsx
+++ b/src/components/posts/TiktokPost.tsx
@@ -7,6 +7,7 @@ import { PlayIcon } from "#/components/Icons";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpinner from "#/components/ui/UiSpinner";
 import { globalStyles } from "#/constants/GlobalStyles";
+import { registerPostInteraction } from "#/helpers/network/Analytics";
 import type { TiktokPostProperties } from "#/types";
 
 const TIKTOK_BRAND_COLOR = "#FF0050";
@@ -22,6 +23,7 @@ const TiktokPost = (properties: TiktokPostProperties) => {
     title,
     cover_image_url,
     embed_link,
+    share_url,
     width: videoWidth,
     height: videoHeight,
   } = properties;
@@ -39,7 +41,10 @@ const TiktokPost = (properties: TiktokPostProperties) => {
     return (
       <View style={[styles.container, { height }]}>
         <UiPressable
-          onPress={() => setIsVideoLoaded(true)}
+          onPress={() => {
+            registerPostInteraction(share_url ?? embed_link, "tiktok", "play");
+            setIsVideoLoaded(true);
+          }}
           style={styles.thumbnailContainer}
           accessibilityRole="button"
           accessibilityLabel={playButtonLabel}

--- a/src/components/posts/YouTubePost.tsx
+++ b/src/components/posts/YouTubePost.tsx
@@ -7,6 +7,7 @@ import { PlayIcon } from "#/components/Icons";
 import UiPressable from "#/components/ui/UiPressable";
 import Config from "#/constants/Config";
 import { globalStyles } from "#/constants/GlobalStyles";
+import { registerPostInteraction } from "#/helpers/network/Analytics";
 import { useCorporateColor } from "#/hooks/useAppColorScheme";
 import type { YouTubePostProperties } from "#/types";
 
@@ -36,7 +37,14 @@ const YouTubePost = (properties: YouTubePostProperties) => {
       <View style={{ flex: 1, overflow: "hidden", width: "100%", height }}>
         <UiPressable
           accessibilityRole="button"
-          onPress={() => setLoaded(true)}
+          onPress={() => {
+            registerPostInteraction(
+              `https://www.youtube.com/watch?v=${id}`,
+              "youtube",
+              "play",
+            );
+            setLoaded(true);
+          }}
           style={{ width: "100%", height, backgroundColor: corporate }}
         >
           <Image

--- a/src/components/posts/YouTubePost.tsx
+++ b/src/components/posts/YouTubePost.tsx
@@ -39,7 +39,7 @@ const YouTubePost = (properties: YouTubePostProperties) => {
           accessibilityRole="button"
           onPress={() => {
             registerPostInteraction(
-              `https://www.youtube.com/watch?v=${id}`,
+              `https://youtu.be/${id}`,
               "youtube",
               "play",
             );

--- a/src/components/posts/bsky/BlueskyPostCard.tsx
+++ b/src/components/posts/bsky/BlueskyPostCard.tsx
@@ -16,6 +16,7 @@ import {
 } from "#/constants/GlobalStyles";
 import { onLinkPress } from "#/helpers/Linking";
 import ContentStore from "#/helpers/Stores/ContentStore";
+import { registerPostInteraction } from "#/helpers/network/Analytics";
 import { hasCreatedAt, hasText } from "#/helpers/utils/typePredicates";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 import type { BlueskyPostProperties, HttpsUrl } from "#/types";
@@ -40,6 +41,11 @@ const BlueskyPostCard = (properties: BlueskyPostProperties) => {
   }, [inView, postId, properties]);
 
   const navigateToPost = () => {
+    registerPostInteraction(
+      `https://bsky.app/profile/${author.handle}/post/${postId}`,
+      "bluesky",
+      "open",
+    );
     router.push(`/bsky/${postId}`);
   };
 

--- a/src/components/posts/bsky/BlueskyPostCard.tsx
+++ b/src/components/posts/bsky/BlueskyPostCard.tsx
@@ -9,7 +9,6 @@ import { BlueskyPostHeader } from "#/components/posts/bsky/BlueskyPostHeader";
 import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
-import Config from "#/constants/Config";
 import {
   POST_PADDING_HORIZONTAL,
   globalStyles,
@@ -29,7 +28,6 @@ const htmlPattern = /<[^>]+>/g;
 const BlueskyPostCard = (properties: BlueskyPostProperties) => {
   const { post, inView, replies } = properties;
   const { record, author, uri } = post.post;
-  const { wpUrl } = Config;
   const router = useRouter();
   const colorScheme = useAppColorScheme();
   const corporate = Colors[colorScheme].primary;
@@ -88,7 +86,7 @@ const BlueskyPostCard = (properties: BlueskyPostProperties) => {
         <UiPressable
           accessibilityRole="button"
           style={{ position: "absolute", top: 20, right: 20, zIndex: 100 }}
-          onPress={() => onLinkPress(url, router, wpUrl)}
+          onPress={() => onLinkPress(url, router, url)}
           hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
         >
           <ExternalLinkIcon color={Colors[colorScheme].iconMuted} />

--- a/src/components/posts/insta/InstaPostCard.tsx
+++ b/src/components/posts/insta/InstaPostCard.tsx
@@ -13,6 +13,7 @@ import {
 import { Achievements } from "#/helpers/Achievements";
 import { onShare } from "#/helpers/Sharing";
 import ContentStore from "#/helpers/Stores/ContentStore";
+import { registerPostInteraction } from "#/helpers/network/Analytics";
 import { registerViews } from "#/helpers/network/Engagement";
 import { useCorporateColor } from "#/hooks/useAppColorScheme";
 import { useFeedDimensions } from "#/hooks/useFeedDimensions";
@@ -40,8 +41,9 @@ const InstaPostCard = (properties: InstaPostProperties) => {
   );
 
   const handlePress = useCallback(() => {
+    registerPostInteraction(computedPermalink, "instagram", "open");
     router.push(`/insta/${id}`);
-  }, [id, router]);
+  }, [computedPermalink, id, router]);
 
   const handleLongPress = useCallback((source: string) => {
     onShare(source, { location: "longPressImage" });

--- a/src/helpers/network/Analytics.ts
+++ b/src/helpers/network/Analytics.ts
@@ -114,14 +114,18 @@ type PostAction = "play" | "open";
  * Records a real interaction with a social post in the feed, beyond the fav and
  * share buttons that are already tracked: playing a video, opening a thread, or
  * expanding a card. All such interactions share one Plausible event so feed
- * engagement can be compared across post types, broken down by the `platform`
- * and `action` props.
+ * engagement can be compared across post types, broken down by the
+ * `post_platform` and `action` props. The key is `post_platform` rather than
+ * `platform` to avoid overwriting the OS `platform` prop set by registerEvent.
  */
 const registerPostInteraction = (
   permalink: string,
-  platform: PostPlatform,
+  postPlatform: PostPlatform,
   action: PostAction,
 ): Promise<void> =>
-  registerEvent(permalink, "Post Interaction", { platform, action });
+  registerEvent(permalink, "Post Interaction", {
+    post_platform: postPlatform,
+    action,
+  });
 
 export { registerEvent, registerPostInteraction };

--- a/src/helpers/network/Analytics.ts
+++ b/src/helpers/network/Analytics.ts
@@ -107,4 +107,21 @@ const registerEvent = async <T extends Record<string, unknown>>(
   }
 };
 
-export { registerEvent };
+type PostPlatform = "youtube" | "tiktok" | "instagram" | "bluesky";
+type PostAction = "play" | "open";
+
+/**
+ * Records a real interaction with a social post in the feed, beyond the fav and
+ * share buttons that are already tracked: playing a video, opening a thread, or
+ * expanding a card. All such interactions share one Plausible event so feed
+ * engagement can be compared across post types, broken down by the `platform`
+ * and `action` props.
+ */
+const registerPostInteraction = (
+  permalink: string,
+  platform: PostPlatform,
+  action: PostAction,
+): Promise<void> =>
+  registerEvent(permalink, "Post Interaction", { platform, action });
+
+export { registerEvent, registerPostInteraction };

--- a/src/screens/Home/components/article/Article.tsx
+++ b/src/screens/Home/components/article/Article.tsx
@@ -10,6 +10,7 @@ import { Animated, ScrollView, View, useWindowDimensions } from "react-native";
 import NavBar from "#/components/bars/NavBar";
 import Footer from "#/components/views/Footer";
 import Colors from "#/constants/Colors";
+import Config from "#/constants/Config";
 import { globalStyles } from "#/constants/GlobalStyles";
 import { Achievements } from "#/helpers/Achievements";
 import { onLinkPress } from "#/helpers/Linking";
@@ -18,6 +19,7 @@ import Statistics from "#/helpers/Statistics";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
 import { registerEvent } from "#/helpers/network/Analytics";
 import { registerViews } from "#/helpers/network/Engagement";
+import { findSecondaryWpFeed } from "#/helpers/utils/feeds";
 import { stripVisualComposerShortcodes } from "#/helpers/utils/posts";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 import type { ArticleProperties, HttpsUrl } from "#/types";
@@ -78,6 +80,20 @@ const ArticleScreen = (properties: ArticleScreenProperties) => {
   useEffect(() => {
     registerViews(article_link);
     Statistics.countArticleRead();
+    // Adoption signal for secondary WordPress feeds (currently only Prüfpunkt):
+    // emit a distinct, countable event on the primary site so feed engagement
+    // can be tracked alongside the rest of the app's analytics.
+    const secondaryFeed = findSecondaryWpFeed(
+      article_link,
+      Config.wpUrl,
+      Config.feeds?.wp,
+    );
+    if (secondaryFeed?.sourceName) {
+      registerEvent(Config.wpUrl, "Pruefpunkt View", {
+        source: secondaryFeed.sourceName,
+        url: article_link,
+      });
+    }
   }, [article_link]);
 
   /**


### PR DESCRIPTION
## Why

Several shipped features had no Plausible instrumentation, leaving us blind on core actions and on engagement with feed content. This PR fills three gaps.

## What

**#1 — Report submission** (`src/app/(tabs)/report.tsx`)
Fires a `Report Submitted` event after a successful `API.reportFake()` call, with props:
- `allowed_public` — whether the user allowed public listing
- `has_url` — whether a source URL was included

**#2 — Prüfpunkt adoption** (`src/screens/Home/components/article/Article.tsx`)
When a secondary WordPress feed article (currently only Prüfpunkt) is opened, emits a `Pruefpunkt View` event on the primary site, tagged with the feed's `sourceName`. Detection is config-driven via the existing `findSecondaryWpFeed` helper — no host is hardcoded.

**#4 — Social post interactions** (`Analytics.ts` + post cards)
Tracks *real interactions* with social feed posts (beyond the fav and share buttons already tracked), not mere scroll-into-view impressions:
- **YouTube / TikTok** — tapping the play button (loads the embed)
- **Instagram** — tapping the card / "mehr" to open the post
- **Bluesky** — opening the thread

All go through a new `registerPostInteraction(permalink, postPlatform, action)` helper that emits one `Post Interaction` event with `post_platform` (`youtube` | `tiktok` | `instagram` | `bluesky`) and `action` (`play` | `open`) props, so feed engagement can be compared across post types in a single Plausible goal. The prop is `post_platform` rather than `platform` to avoid overwriting the OS `platform` prop. Existing Instagram view tracking and fav/share events are unchanged.

**Bluesky outbound-click attribution** (`src/components/posts/bsky/BlueskyPostCard.tsx`)
The external-link (↗) icon on a Bluesky card already fired an `Outbound Link: Click` event via `onLinkPress`, but passed `wpUrl` as the analytics context, attributing the click to the primary site. It now passes the post's `bsky.app` URL instead, so the source of the outbound click is clear in Plausible. (The now-unused `Config`/`wpUrl` references were removed.)

Net result on a Bluesky card: opening the thread → `Post Interaction` (bluesky / open); tapping ↗ → `Outbound Link: Click` attributed to the post URL. Two distinct, non-overlapping signals.

## Notes / follow-ups

- The Instagram **Prüfpunkt** path (#2) is left for a follow-up: those views use a synthetic primary-site permalink that doesn't carry the source account.
- All new events go through `registerEvent`, so they respect the beta-skip guard once #354 lands.

## Testing

- `pnpm check:ts` — clean
- `pnpm lint` (all touched files) — clean
- `pnpm test` — report, article, Feed, and Analytics suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
