### PR TITLE
Add eslint-plugin-unicorn with a curated rule set

### DIFF
--- a/__tests__/components/Loader.test.tsx
+++ b/__tests__/components/Loader.test.tsx
@@ -35,7 +35,7 @@ const createDeferred = <T,>(): Deferred<T> => {
 
 describe("Loader", () => {
   beforeEach(() => {
-    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
+++ b/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
@@ -330,7 +330,7 @@ describe("MyFavs", () => {
     };
     const consoleErrorSpy = jest
       .spyOn(console, "error")
-      .mockImplementation(() => undefined);
+      .mockImplementation(() => {});
 
     (FavoritesStore.getAllFavorites as jest.Mock).mockResolvedValue({
       "example-article": { contentType: FAV_TYPE_ARTICLE },
@@ -399,7 +399,7 @@ describe("MyFavs", () => {
     };
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
+      .mockImplementation(() => {});
 
     (FavoritesStore.getAllFavorites as jest.Mock).mockResolvedValue({
       "stale-article": { contentType: FAV_TYPE_ARTICLE },

--- a/__tests__/helpers/Networking.test.ts
+++ b/__tests__/helpers/Networking.test.ts
@@ -3,20 +3,20 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import * as Networking from "#/helpers/utils/networking";
 
 // Mock AbortController
-(global as any).AbortController = class {
+(globalThis as any).AbortController = class {
   signal = {};
   abort = jest.fn();
 };
 
 // Mock fetch
-(global as any).fetch = jest.fn();
+(globalThis as any).fetch = jest.fn();
 
 // Mock setTimeout and clearTimeout
 const mockSetTimeout = jest.fn().mockImplementation(() => 123 as any) as any;
 const mockClearTimeout = jest.fn() as any;
 
-(global as any).setTimeout = mockSetTimeout;
-(global as any).clearTimeout = mockClearTimeout;
+(globalThis as any).setTimeout = mockSetTimeout;
+(globalThis as any).clearTimeout = mockClearTimeout;
 
 // Mock console.error
 (console.error as any) = jest.fn();
@@ -39,7 +39,7 @@ describe("Networking utilities", () => {
 
   it("createClient sends default headers on every request", async () => {
     const client = Networking.createClient("https://example.com" as any);
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(
       mockJsonResponse({}),
     );
 
@@ -61,7 +61,7 @@ describe("Networking utilities", () => {
     const client = Networking.createClient("https://example.com" as any, {
       Referer: "https://example.com",
     });
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(
       mockJsonResponse({}),
     );
 
@@ -114,7 +114,7 @@ describe("Networking utilities", () => {
   });
 
   it("fetchWithTimeout listens to external AbortSignal and aborts internal controller", async () => {
-    const originalAbortController = (global as any).AbortController;
+    const originalAbortController = (globalThis as any).AbortController;
     const createdControllers: any[] = [];
 
     class TestAbortController {
@@ -135,7 +135,7 @@ describe("Networking utilities", () => {
     };
 
     try {
-      (global as any).AbortController = TestAbortController;
+      (globalThis as any).AbortController = TestAbortController;
       const client = Networking.createClient("https://x" as any);
       const fakeResponse = { data: { ok: true } };
       const mockRequest = (jest.fn() as jest.Mock<any>).mockResolvedValue(
@@ -170,13 +170,13 @@ describe("Networking utilities", () => {
         expect.any(Function),
       );
     } finally {
-      (global as any).AbortController = originalAbortController;
+      (globalThis as any).AbortController = originalAbortController;
     }
   });
 
   it("FetchError preserves response body", async () => {
     const client = Networking.createClient("https://example.com" as any);
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(
       mockJsonResponse({ error: "not found" }, 404),
     );
 
@@ -187,12 +187,12 @@ describe("Networking utilities", () => {
   });
 
   it("fetchWithTimeout does not log when controller is already aborted", async () => {
-    const originalAbortController = (global as any).AbortController;
+    const originalAbortController = (globalThis as any).AbortController;
     class AbortedController {
       signal = { aborted: true };
       abort = jest.fn();
     }
-    (global as any).AbortController = AbortedController;
+    (globalThis as any).AbortController = AbortedController;
 
     try {
       const client = Networking.createClient("https://x" as any);
@@ -205,18 +205,18 @@ describe("Networking utilities", () => {
 
       expect(console.error).not.toHaveBeenCalled();
     } finally {
-      (global as any).AbortController = originalAbortController;
+      (globalThis as any).AbortController = originalAbortController;
     }
   });
 
   it("fetchWithTimeout aborts immediately when external signal is already aborted", async () => {
-    const originalAbortController = (global as any).AbortController;
+    const originalAbortController = (globalThis as any).AbortController;
     const abortMock = jest.fn();
     class TrackingController {
       signal = { aborted: false };
       abort = abortMock;
     }
-    (global as any).AbortController = TrackingController;
+    (globalThis as any).AbortController = TrackingController;
 
     const externalSignal = {
       aborted: true,
@@ -235,13 +235,13 @@ describe("Networking utilities", () => {
       expect(abortMock).toHaveBeenCalled();
       expect(externalSignal.addEventListener).not.toHaveBeenCalled();
     } finally {
-      (global as any).AbortController = originalAbortController;
+      (globalThis as any).AbortController = originalAbortController;
     }
   });
 
   it("createClient resolves absolute URLs without prepending baseURL", async () => {
     const client = Networking.createClient("https://base.com" as any);
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(
       mockJsonResponse({}),
     );
 
@@ -255,7 +255,7 @@ describe("Networking utilities", () => {
 
   it("createClient skips null and undefined params but includes falsy values", async () => {
     const client = Networking.createClient("https://example.com" as any);
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(
       mockJsonResponse({}),
     );
 
@@ -273,7 +273,7 @@ describe("Networking utilities", () => {
 
   it("createClient serialises POST body as JSON by default", async () => {
     const client = Networking.createClient("https://example.com" as any);
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(
       mockJsonResponse({}),
     );
 
@@ -289,7 +289,7 @@ describe("Networking utilities", () => {
 
   it("createClient passes string body as-is for POST", async () => {
     const client = Networking.createClient("https://example.com" as any);
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(
       mockJsonResponse({}),
     );
 
@@ -301,7 +301,7 @@ describe("Networking utilities", () => {
 
   it("createClient returns raw text when responseType is text", async () => {
     const client = Networking.createClient("https://example.com" as any);
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(() =>
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
         status: 200,
@@ -318,7 +318,7 @@ describe("Networking utilities", () => {
 
   it("createClient parses empty response body as null", async () => {
     const client = Networking.createClient("https://example.com" as any);
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(() =>
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
         status: 204,
@@ -335,7 +335,7 @@ describe("Networking utilities", () => {
 
   it("createClient falls back to raw text when response is not valid JSON", async () => {
     const client = Networking.createClient("https://example.com" as any);
-    (global.fetch as jest.Mock<any>).mockImplementationOnce(() =>
+    (globalThis.fetch as jest.Mock<any>).mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
         status: 200,

--- a/__tests__/helpers/Statistics.test.ts
+++ b/__tests__/helpers/Statistics.test.ts
@@ -246,22 +246,22 @@ describe("Statistics", () => {
         [StatisticsStore.keys.appOpened]: {
           count: 10,
           streak: 5,
-          lastDate: new Date().getTime(),
+          lastDate: Date.now(),
         },
         [StatisticsStore.keys.articlesRead]: {
           count: 20,
           streak: 3,
-          lastDate: new Date().getTime(),
+          lastDate: Date.now(),
         },
         [StatisticsStore.keys.articlesShared]: {
           count: 5,
           streak: 1,
-          lastDate: new Date().getTime(),
+          lastDate: Date.now(),
         },
         [StatisticsStore.keys.sourcesChecked]: {
           count: 15,
           streak: 2,
-          lastDate: new Date().getTime(),
+          lastDate: Date.now(),
         },
       };
 

--- a/__tests__/helpers/fetchers/FetcherUtilities.test.tsx
+++ b/__tests__/helpers/fetchers/FetcherUtilities.test.tsx
@@ -11,7 +11,7 @@ describe("FetcherUtils", () => {
     it("returns true for AbortError", () => {
       expect(
         FetcherUtilities.isAbortError(
-          Object.assign(new Error(), { name: "AbortError" }),
+          Object.assign(new Error("aborted"), { name: "AbortError" }),
         ),
       ).toBe(true);
     });
@@ -19,7 +19,7 @@ describe("FetcherUtils", () => {
     it("returns true for CanceledError", () => {
       expect(
         FetcherUtilities.isAbortError(
-          Object.assign(new Error(), { name: "CanceledError" }),
+          Object.assign(new Error("canceled"), { name: "CanceledError" }),
         ),
       ).toBe(true);
     });
@@ -27,7 +27,7 @@ describe("FetcherUtils", () => {
     it("returns true for ERR_CANCELED code", () => {
       expect(
         FetcherUtilities.isAbortError(
-          Object.assign(new Error(), { code: "ERR_CANCELED" }),
+          Object.assign(new Error("canceled"), { code: "ERR_CANCELED" }),
         ),
       ).toBe(true);
     });

--- a/__tests__/screens/Home/Feed.abort.test.tsx
+++ b/__tests__/screens/Home/Feed.abort.test.tsx
@@ -7,7 +7,7 @@ import FetcherUtilities from "#/screens/Home/fetchers/FetcherUtilities";
 jest.mock("expo-router", () => ({
   __esModule: true,
   useRouter: () => ({ push: jest.fn() }),
-  useScrollToTop: () => undefined,
+  useScrollToTop: () => {},
 }));
 
 jest.mock("#/components/Icons", () => ({

--- a/__tests__/screens/Home/Feed.render.test.tsx
+++ b/__tests__/screens/Home/Feed.render.test.tsx
@@ -8,7 +8,7 @@ import type { Post } from "#/types";
 jest.mock("expo-router", () => ({
   __esModule: true,
   useRouter: () => ({ push: jest.fn() }),
-  useScrollToTop: () => undefined,
+  useScrollToTop: () => {},
 }));
 jest.mock("#/components/Icons", () => ({
   SearchIcon: () => null,

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -4,6 +4,7 @@
   "words": [
     "armeabi",
     "atproto",
+    "bafyreiabc",
     "bsky",
     "bskyshare",
     "cmplz",
@@ -17,6 +18,7 @@
     "artikel",
     "fakten",
     "faktenbot",
+    "favorited",
     "favs",
     "fdroid",
     "foss",
@@ -39,9 +41,11 @@
     "tnode",
     "tracken",
     "trivago",
+    "unconfigured",
     "vseslav",
     "volksverpetzer",
     "vvpapp",
+    "wwwx",
     "yoast",
     "youtu"
   ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import cspellESLintPluginRecommended from "@cspell/eslint-plugin/recommended";
 import expoConfig from "eslint-config-expo/flat.js";
 import importAlias from "eslint-plugin-import-alias";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import eslintPluginUnicorn from "eslint-plugin-unicorn";
 import unusedImports from "eslint-plugin-unused-imports";
 import { defineConfig } from "eslint/config";
 import { fileURLToPath } from "node:url";
@@ -12,6 +13,43 @@ export default defineConfig([
   expoConfig,
   cspellESLintPluginRecommended,
   eslintPluginPrettierRecommended,
+  {
+    // Cherry-picked unicorn rules — the recommended preset is too noisy for
+    // React Native (filename-case, no-null, prevent-abbreviations, prefer-module
+    // all fight RN conventions). We opt in to the correctness/modernization
+    // rules that carry their weight instead.
+    plugins: { unicorn: eslintPluginUnicorn },
+    rules: {
+      "unicorn/prefer-array-find": "error",
+      "unicorn/prefer-array-some": "error",
+      "unicorn/no-array-push-push": "error",
+      "unicorn/no-useless-undefined": "error",
+      "unicorn/prefer-date-now": "error",
+      "unicorn/throw-new-error": "error",
+      "unicorn/error-message": "error",
+      "unicorn/no-instanceof-builtins": "error",
+      "unicorn/prefer-optional-catch-binding": "error",
+      "unicorn/prefer-string-slice": "error",
+      "unicorn/prefer-string-replace-all": "error",
+      "unicorn/prefer-node-protocol": "error",
+      "unicorn/prefer-set-has": "error",
+      "unicorn/no-useless-fallback-in-spread": "error",
+      "unicorn/no-useless-spread": "error",
+      "unicorn/consistent-existence-index-check": "error",
+      "unicorn/prefer-global-this": "error",
+    },
+  },
+  {
+    // The `import` plugin can't parse eslint-plugin-unicorn's dist (it uses
+    // import attributes / `with` syntax), producing false positives when this
+    // config file imports it. Disable those rules for the config file only.
+    files: ["eslint.config.mjs"],
+    rules: {
+      "import/namespace": "off",
+      "import/no-named-as-default": "off",
+      "import/no-named-as-default-member": "off",
+    },
+  },
   {
     ignores: [
       "**/pnpm-lock.yaml",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,9 @@ export default defineConfig([
       "unicorn/prefer-optional-catch-binding": "error",
       "unicorn/prefer-string-slice": "error",
       "unicorn/prefer-string-replace-all": "error",
-      "unicorn/prefer-node-protocol": "error",
+      // NOTE: prefer-node-protocol is intentionally omitted — Metro can't
+      // resolve the `node:` protocol for polyfilled builtins (e.g. node:buffer
+      // in src/hooks/useAISearch.ts), which breaks the bundle / EAS export.
       "unicorn/prefer-set-has": "error",
       "unicorn/no-useless-fallback-in-spread": "error",
       "unicorn/no-useless-spread": "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,15 @@ export default defineConfig([
       "unicorn/prefer-array-find": "error",
       "unicorn/prefer-array-some": "error",
       "unicorn/no-array-push-push": "error",
-      "unicorn/no-useless-undefined": "error",
+      // checkArguments off: passing an explicit `undefined` argument is
+      // legitimate and readable (e.g. tests calling fn(undefined) or
+      // mockResolvedValue(undefined)). checkArrowFunctionBody off so
+      // `() => undefined` callbacks aren't rewritten. Keeps the rule focused
+      // on genuinely useless `undefined` (e.g. `return undefined`).
+      "unicorn/no-useless-undefined": [
+        "error",
+        { checkArguments: false, checkArrowFunctionBody: false },
+      ],
       "unicorn/prefer-date-now": "error",
       "unicorn/throw-new-error": "error",
       "unicorn/error-message": "error",

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -7,7 +7,7 @@ declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
 
-global.IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 jest.mock("react-native/Libraries/Interaction/InteractionManager", () => ({
   createInteractionHandle: jest.fn(),
@@ -134,7 +134,7 @@ jest.mock("expo-application", () => ({
 }));
 
 jest.mock("expo/fetch", () => ({
-  fetch: (...args: unknown[]) => (global as any).fetch(...args),
+  fetch: (...args: unknown[]) => (globalThis as any).fetch(...args),
 }));
 
 const originalPlatform = Platform.OS;

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "eslint-config-expo": "56.0.4",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-import-alias": "1.2.0",
-    "eslint-plugin-unicorn": "^69.0.0",
+    "eslint-plugin-unicorn": "^65.0.1",
     "eslint-plugin-unused-imports": "4.4.1",
     "expo-atlas": "0.4.3",
     "expo-build-properties": "56.0.19",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "jest-react-native": "18.0.0",
     "license-checker-rseidelsohn": "5.0.1",
     "lint-staged": "17.0.8",
-    "prettier": "3.8.4",
+    "prettier": "3.9.0",
     "typedoc": "0.28.19",
     "typescript": "6.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "eslint-config-expo": "56.0.4",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-import-alias": "1.2.0",
-    "eslint-plugin-unicorn": "^65.0.1",
+    "eslint-plugin-unicorn": "65.0.1",
     "eslint-plugin-unused-imports": "4.4.1",
     "expo-atlas": "0.4.3",
     "expo-build-properties": "56.0.19",
@@ -147,7 +147,7 @@
     "jest-react-native": "18.0.0",
     "license-checker-rseidelsohn": "5.0.1",
     "lint-staged": "17.0.8",
-    "prettier": "3.9.0",
+    "prettier": "3.9.1",
     "typedoc": "0.28.19",
     "typescript": "6.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "eslint-config-expo": "56.0.4",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-import-alias": "1.2.0",
+    "eslint-plugin-unicorn": "^69.0.0",
     "eslint-plugin-unused-imports": "4.4.1",
     "expo-atlas": "0.4.3",
     "expo-build-properties": "56.0.19",

--- a/plugins/gradleproperties.plugin.ts
+++ b/plugins/gradleproperties.plugin.ts
@@ -7,7 +7,7 @@ function setGradlePropertiesValue(config: any, key: string, value: string) {
       (item: any) => item.type === "property" && item.key === key,
     );
 
-    if (keyIdx >= 0) {
+    if (keyIdx !== -1) {
       exportedConfig.modResults.splice(keyIdx, 1, {
         type: "property",
         key,

--- a/plugins/withSplitAbi.plugin.ts
+++ b/plugins/withSplitAbi.plugin.ts
@@ -5,7 +5,7 @@ const withSplitAbi = (config: any) => {
     let gradle = mod.modResults.contents;
 
     // Remove any existing splits block to avoid duplicates
-    gradle = gradle.replace(
+    gradle = gradle.replaceAll(
       /\n\s*splits\s*\{\s*abi\s*\{[\s\S]*?\}\s*\}\s/g,
       "\n",
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 4.0.2
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.4)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.9.0)
       expo:
         specifier: 56.0.12
         version: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -227,7 +227,7 @@ importers:
         version: 13.3.3(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
       '@trivago/prettier-plugin-sort-imports':
         specifier: 6.0.2
-        version: 6.0.2(prettier@3.8.4)
+        version: 6.0.2(prettier@3.9.0)
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -301,8 +301,8 @@ importers:
         specifier: 17.0.8
         version: 17.0.8
       prettier:
-        specifier: 3.8.4
-        version: 3.8.4
+        specifier: 3.9.0
+        version: 3.9.0
       typedoc:
         specifier: 0.28.19
         version: 0.28.19(typescript@6.0.3)
@@ -5514,8 +5514,8 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.0:
+    resolution: {integrity: sha512-LjIqSIC5VYLzs9WedVmJ2ljNAGnU+DteIClbahu4L/DBeWjZ6iT/k1lAYyu9JUh+1xINxWadaPw/Pl63y/agAw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -7835,7 +7835,7 @@ snapshots:
       debug: 4.4.3
       getenv: 2.0.0
       glob: 13.0.6
-      semver: 7.8.1
+      semver: 7.8.5
       slugify: 1.6.9
       xcode: 3.0.1
       xml2js: 0.6.0
@@ -9066,7 +9066,7 @@ snapshots:
 
   '@tootallnate/once@2.0.1': {}
 
-  '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.8.4)':
+  '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.9.0)':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
@@ -9076,7 +9076,7 @@ snapshots:
       lodash-es: 4.18.1
       minimatch: 9.0.9
       parse-imports-exports: 0.2.4
-      prettier: 3.8.4
+      prettier: 3.9.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10584,7 +10584,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
       eslint-plugin-expo: 1.0.3(eslint@9.39.4)(typescript@6.0.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
       eslint-plugin-react: 7.37.5(eslint@9.39.4)
@@ -10608,7 +10608,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10623,14 +10623,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -10656,7 +10656,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10674,10 +10674,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.4):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.9.0):
     dependencies:
       eslint: 9.39.4
-      prettier: 3.8.4
+      prettier: 3.9.0
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
@@ -13263,7 +13263,7 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier@3.8.4: {}
+  prettier@3.9.0: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 4.0.2
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.9.0)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.9.1)
       expo:
         specifier: 56.0.12
         version: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -227,7 +227,7 @@ importers:
         version: 13.3.3(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
       '@trivago/prettier-plugin-sort-imports':
         specifier: 6.0.2
-        version: 6.0.2(prettier@3.9.0)
+        version: 6.0.2(prettier@3.9.1)
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -271,7 +271,7 @@ importers:
         specifier: 1.2.0
         version: 1.2.0
       eslint-plugin-unicorn:
-        specifier: ^65.0.1
+        specifier: 65.0.1
         version: 65.0.1(eslint@9.39.4)
       eslint-plugin-unused-imports:
         specifier: 4.4.1
@@ -301,8 +301,8 @@ importers:
         specifier: 17.0.8
         version: 17.0.8
       prettier:
-        specifier: 3.9.0
-        version: 3.9.0
+        specifier: 3.9.1
+        version: 3.9.1
       typedoc:
         specifier: 0.28.19
         version: 0.28.19(typescript@6.0.3)
@@ -5514,8 +5514,8 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.9.0:
-    resolution: {integrity: sha512-LjIqSIC5VYLzs9WedVmJ2ljNAGnU+DteIClbahu4L/DBeWjZ6iT/k1lAYyu9JUh+1xINxWadaPw/Pl63y/agAw==}
+  prettier@3.9.1:
+    resolution: {integrity: sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -9066,7 +9066,7 @@ snapshots:
 
   '@tootallnate/once@2.0.1': {}
 
-  '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.9.0)':
+  '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.9.1)':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
@@ -9076,7 +9076,7 @@ snapshots:
       lodash-es: 4.18.1
       minimatch: 9.0.9
       parse-imports-exports: 0.2.4
-      prettier: 3.9.0
+      prettier: 3.9.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10584,7 +10584,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
       eslint-plugin-expo: 1.0.3(eslint@9.39.4)(typescript@6.0.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
       eslint-plugin-react: 7.37.5(eslint@9.39.4)
@@ -10608,7 +10608,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10623,14 +10623,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -10656,7 +10656,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10674,10 +10674,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.9.0):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.9.1):
     dependencies:
       eslint: 9.39.4
-      prettier: 3.9.0
+      prettier: 3.9.1
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
@@ -13262,7 +13262,7 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier@3.9.0: {}
+  prettier@3.9.1: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       eslint-plugin-import-alias:
         specifier: 1.2.0
         version: 1.2.0
+      eslint-plugin-unicorn:
+        specifier: ^69.0.0
+        version: 69.0.0(eslint@9.39.4)
       eslint-plugin-unused-imports:
         specifier: 4.4.1
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)
@@ -2745,6 +2748,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  builtin-modules@5.2.0:
+    resolution: {integrity: sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==}
+    engines: {node: '>=18.20'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -2803,6 +2810,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -2834,6 +2844,10 @@ packages:
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
   cjs-module-lexer@1.4.3:
@@ -3159,6 +3173,10 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-indent@7.0.2:
+    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
+    engines: {node: '>=12.20'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -3448,6 +3466,12 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-unicorn@69.0.0:
+    resolution: {integrity: sha512-ZN/KtHr9hQ6AOByANSNJpsDbo/+Nn+EyQ6blK4w+dcmS/xpYkqLLfrUc+NA/wOK6vF5uEUvhn8my5B/3sruB9g==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      eslint: '>=10.4'
 
   eslint-plugin-unused-imports@4.4.1:
     resolution: {integrity: sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==}
@@ -3908,6 +3932,10 @@ packages:
   find-babel-config@2.1.2:
     resolution: {integrity: sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==}
 
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
+    engines: {node: '>=18'}
+
   find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
     engines: {node: '>=6'}
@@ -4061,6 +4089,10 @@ packages:
 
   globals@16.5.0:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+    engines: {node: '>=18'}
+
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -4245,6 +4277,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -4295,6 +4331,10 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-builtin-module@5.0.0:
+    resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
+    engines: {node: '>=18.20'}
 
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
@@ -5443,6 +5483,10 @@ packages:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
 
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
@@ -5895,6 +5939,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
@@ -6201,6 +6250,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -9821,6 +9874,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  builtin-modules@5.2.0: {}
+
   bytes@3.1.2: {}
 
   cacache@20.0.4:
@@ -9885,6 +9940,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  change-case@5.4.4: {}
+
   char-regex@1.0.2: {}
 
   char-regex@2.0.2: {}
@@ -9917,6 +9974,8 @@ snapshots:
   ci-info@2.0.0: {}
 
   ci-info@3.9.0: {}
+
+  ci-info@4.4.0: {}
 
   cjs-module-lexer@1.4.3: {}
 
@@ -10276,6 +10335,8 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  detect-indent@7.0.2: {}
+
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
@@ -10523,7 +10584,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-expo: 1.0.3(eslint@9.39.4)(typescript@6.0.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
       eslint-plugin-react: 7.37.5(eslint@9.39.4)
@@ -10547,7 +10608,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10562,14 +10623,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -10595,7 +10656,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10654,6 +10715,26 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-unicorn@69.0.0(eslint@9.39.4):
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      browserslist: 4.28.2
+      change-case: 5.4.4
+      ci-info: 4.4.0
+      core-js-compat: 3.49.0
+      detect-indent: 7.0.2
+      eslint: 9.39.4
+      find-up-simple: 1.0.1
+      globals: 17.7.0
+      indent-string: 5.0.0
+      is-builtin-module: 5.0.0
+      jsesc: 3.1.0
+      pluralize: 8.0.0
+      regjsparser: 0.13.1
+      semver: 7.8.5
+      strip-indent: 4.1.1
 
   eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4):
     dependencies:
@@ -11263,6 +11344,8 @@ snapshots:
     dependencies:
       json5: 2.2.3
 
+  find-up-simple@1.0.1: {}
+
   find-up@3.0.0:
     dependencies:
       locate-path: 3.0.0
@@ -11418,6 +11501,8 @@ snapshots:
   globals@14.0.0: {}
 
   globals@16.5.0: {}
+
+  globals@17.7.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -11594,6 +11679,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  indent-string@5.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -11647,6 +11734,10 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-builtin-module@5.0.0:
+    dependencies:
+      builtin-modules: 5.2.0
 
   is-bun-module@2.0.0:
     dependencies:
@@ -13147,6 +13238,8 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
+  pluralize@8.0.0: {}
+
   pngjs@3.4.0: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -13662,6 +13755,8 @@ snapshots:
 
   semver@7.8.1: {}
 
+  semver@7.8.5: {}
+
   send@0.19.2:
     dependencies:
       debug: 2.6.9
@@ -14026,6 +14121,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-indent@4.1.1: {}
 
   strip-json-comments@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,8 +271,8 @@ importers:
         specifier: 1.2.0
         version: 1.2.0
       eslint-plugin-unicorn:
-        specifier: ^69.0.0
-        version: 69.0.0(eslint@9.39.4)
+        specifier: ^65.0.1
+        version: 65.0.1(eslint@9.39.4)
       eslint-plugin-unused-imports:
         specifier: 4.4.1
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)
@@ -3467,11 +3467,11 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-unicorn@69.0.0:
-    resolution: {integrity: sha512-ZN/KtHr9hQ6AOByANSNJpsDbo/+Nn+EyQ6blK4w+dcmS/xpYkqLLfrUc+NA/wOK6vF5uEUvhn8my5B/3sruB9g==}
-    engines: {node: '>=22'}
+  eslint-plugin-unicorn@65.0.1:
+    resolution: {integrity: sha512-daCrQrgxOoOz2uMPWB3Y3vvv/5q+ncwICI8IjoebiwtW87CaY4tAN5EEiRXTYVnf7qi1v1BGBdHOSnZLV0rx6A==}
+    engines: {node: ^20.10.0 || >=21.0.0}
     peerDependencies:
-      eslint: '>=10.4'
+      eslint: '>=9.38.0'
 
   eslint-plugin-unused-imports@4.4.1:
     resolution: {integrity: sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==}
@@ -7775,7 +7775,7 @@ snapshots:
       progress: 2.0.3
       prompts: 2.4.2
       resolve-from: 5.0.0
-      semver: 7.8.1
+      semver: 7.8.5
       send: 0.19.2
       slugify: 1.6.9
       stacktrace-parser: 0.1.11
@@ -7816,7 +7816,7 @@ snapshots:
       debug: 4.4.3
       getenv: 2.0.0
       glob: 13.0.6
-      semver: 7.8.1
+      semver: 7.8.5
       slugify: 1.6.9
       xcode: 3.0.1
       xml2js: 0.6.0
@@ -7905,7 +7905,7 @@ snapshots:
       ignore: 5.3.2
       minimatch: 10.2.5
       resolve-from: 5.0.0
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -7917,7 +7917,7 @@ snapshots:
       getenv: 2.0.0
       jimp-compact: 0.16.1
       parse-png: 2.1.0
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -8059,7 +8059,7 @@ snapshots:
       debug: 4.4.3
       expo-modules-autolinking: 56.0.16(typescript@6.0.3)
       resolve-from: 5.0.0
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -8492,7 +8492,7 @@ snapshots:
       proggy: 4.0.0
       promise-all-reject-late: 1.0.1
       promise-call-limit: 3.0.2
-      semver: 7.8.1
+      semver: 7.8.5
       ssri: 13.0.1
       treeverse: 3.0.0
       walk-up-path: 4.0.0
@@ -8501,7 +8501,7 @@ snapshots:
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@npmcli/git@7.0.2':
     dependencies:
@@ -8511,7 +8511,7 @@ snapshots:
       lru-cache: 11.4.0
       npm-pick-manifest: 11.0.3
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       which: 6.0.1
 
   '@npmcli/installed-package-contents@4.0.0':
@@ -8532,7 +8532,7 @@ snapshots:
       json-parse-even-better-errors: 5.0.0
       pacote: 21.5.0
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -8547,7 +8547,7 @@ snapshots:
       hosted-git-info: 9.0.3
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@9.0.1':
@@ -8861,7 +8861,7 @@ snapshots:
       metro: 0.84.4
       metro-config: 0.84.4
       metro-core: 0.84.4
-      semver: 7.8.1
+      semver: 7.8.5
     optionalDependencies:
       '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
     transitivePeerDependencies:
@@ -9312,7 +9312,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.61.0
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -9327,7 +9327,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.62.0
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -10584,7 +10584,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-expo: 1.0.3(eslint@9.39.4)(typescript@6.0.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
       eslint-plugin-react: 7.37.5(eslint@9.39.4)
@@ -10608,7 +10608,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10623,14 +10623,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -10656,7 +10656,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10716,11 +10716,10 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-unicorn@69.0.0(eslint@9.39.4):
+  eslint-plugin-unicorn@65.0.1(eslint@9.39.4):
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      browserslist: 4.28.2
       change-case: 5.4.4
       ci-info: 4.4.0
       core-js-compat: 3.49.0
@@ -11741,7 +11740,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   is-callable@1.2.7: {}
 
@@ -11876,7 +11875,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -12227,7 +12226,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -12553,7 +12552,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   make-error@1.3.6:
     optional: true
@@ -12919,7 +12918,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       tar: 7.5.15
       tinyglobby: 0.2.16
       undici: 6.25.0
@@ -12945,7 +12944,7 @@ snapshots:
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   npm-normalize-package-bin@5.0.0: {}
 
@@ -12953,14 +12952,14 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.8.1
+      semver: 7.8.5
       validate-npm-package-name: 5.0.1
 
   npm-package-arg@13.0.2:
     dependencies:
       hosted-git-info: 9.0.3
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       validate-npm-package-name: 7.0.2
 
   npm-packlist@10.0.4:
@@ -12973,7 +12972,7 @@ snapshots:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
       npm-package-arg: 13.0.2
-      semver: 7.8.1
+      semver: 7.8.5
 
   npm-registry-fetch@19.1.1:
     dependencies:

--- a/scripts/prepare-changelog.mjs
+++ b/scripts/prepare-changelog.mjs
@@ -5,9 +5,9 @@
  *
  * Usage: pnpm prepare:changelog
  */
-import { copyFileSync, existsSync, readFileSync, writeFileSync } from "fs";
-import { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");

--- a/scripts/prepare-licenses.js
+++ b/scripts/prepare-licenses.js
@@ -18,12 +18,12 @@ function normalizeRepoUrl(url) {
 }
 
 function buildLicenseUrl(repository, licenseFile) {
-  if (!repository || !licenseFile) return undefined;
+  if (!repository || !licenseFile) return;
   const basename = path.basename(licenseFile);
-  if (!/^(LICENSE|LICENCE|COPYING)/i.test(basename)) return undefined;
+  if (!/^(LICENSE|LICENCE|COPYING)/i.test(basename)) return;
   const normalized = normalizeRepoUrl(repository);
   const match = normalized.match(/^https?:\/\/github\.com\/([^/]+\/[^/]+)/);
-  if (!match) return undefined;
+  if (!match) return;
   return `https://github.com/${match[1]}/raw/HEAD/${basename}`;
 }
 

--- a/src/app/+native-intent.tsx
+++ b/src/app/+native-intent.tsx
@@ -32,7 +32,7 @@ export function redirectSystemPath({ path }: { path: string }) {
       if (shouldExcludeFromDeepLink(urlPath)) {
         // Return undefined to prevent routing for excluded paths
         // The app will not handle this path and it will be opened by OS
-        return undefined;
+        return;
       }
       // Secondary-site links must carry originalUrl so the article route
       // fetches from the right WordPress API; primary links use the default.

--- a/src/app/[category]/[slug].tsx
+++ b/src/app/[category]/[slug].tsx
@@ -144,7 +144,7 @@ const LoadArticle = () => {
       const trimmedBase = base.replace(/\/+$/, "");
       const path = segments
         .filter((s): s is string => Boolean(s))
-        .map((s) => s.replace(/^\/+|\/+$/g, ""))
+        .map((s) => s.replaceAll(/^\/+|\/+$/g, ""))
         .join("/");
       return path ? `${trimmedBase}/${path}` : trimmedBase;
     };

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -40,7 +40,7 @@ LogBox.ignoreLogs(["new NativeEventEmitter"]);
 // Prevent the splash screen from auto-hiding
 SplashScreen.preventAutoHideAsync();
 
-const SECONDARY_BG_SCREENS = ["action", "support"];
+const SECONDARY_BG_SCREENS = new Set(["action", "support"]);
 
 const TOAST_TEXT_STYLES = {
   text1Style: { fontSize: 16 },
@@ -57,7 +57,7 @@ const AppFrame = ({ children }: PropsWithChildren) => {
   const insets = useSafeAreaInsets();
   const segments = useSegments() as string[];
 
-  const isSecondaryBg = segments.some((s) => SECONDARY_BG_SCREENS.includes(s));
+  const isSecondaryBg = segments.some((s) => SECONDARY_BG_SCREENS.has(s));
   const backgroundColor = isSecondaryBg
     ? Colors[colorScheme].surface
     : Colors[colorScheme].background;

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -49,7 +49,7 @@ const Index = () => {
           }
 
           const hasPath =
-            typeof path === "string" && path.replace(/\//g, "").length > 0;
+            typeof path === "string" && path.replaceAll("/", "").length > 0;
           if (isBaseHost && hasPath) {
             appOpenRoutine();
             return;

--- a/src/components/posts/ArticlePost.tsx
+++ b/src/components/posts/ArticlePost.tsx
@@ -158,7 +158,7 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
   );
 
   const elevatedWrapperStyle = useMemo(() => {
-    if (!elevated) return undefined;
+    if (!elevated) return;
     const isDark = colorScheme === "dark";
     return {
       borderRadius: 15,

--- a/src/components/views/Donate.tsx
+++ b/src/components/views/Donate.tsx
@@ -64,7 +64,7 @@ const Donate = ({ article_link, ...properties }: DonateProperties) => {
 
   // Scroll to the default amount once the picker has measured its width
   useEffect(() => {
-    if (pickerWidth > 0 && initialIndex >= 0) {
+    if (pickerWidth > 0 && initialIndex !== -1) {
       scrollRef.current?.scrollTo({
         x: initialIndex * ITEM_WIDTH,
         animated: false,

--- a/src/helpers/Post.ts
+++ b/src/helpers/Post.ts
@@ -11,6 +11,7 @@ export default class Post<T> implements P<T> {
     public id: P<T>["id"],
     public component: P<T>["component"],
     public data: P<T>["data"],
+    // eslint-disable-next-line unicorn/no-useless-undefined -- the default makes this positional param optional for callers
     public shareable: P<T>["shareable"] = undefined,
     public priority: P<T>["priority"] = 1,
     public contentFavIdentifier?: P<T>["contentFavIdentifier"],

--- a/src/helpers/Post.ts
+++ b/src/helpers/Post.ts
@@ -11,8 +11,7 @@ export default class Post<T> implements P<T> {
     public id: P<T>["id"],
     public component: P<T>["component"],
     public data: P<T>["data"],
-    // eslint-disable-next-line unicorn/no-useless-undefined -- the default makes this positional param optional for callers
-    public shareable: P<T>["shareable"] = undefined,
+    public shareable?: P<T>["shareable"],
     public priority: P<T>["priority"] = 1,
     public contentFavIdentifier?: P<T>["contentFavIdentifier"],
     public contentType?: P<T>["contentType"],

--- a/src/helpers/Sharing.ts
+++ b/src/helpers/Sharing.ts
@@ -194,7 +194,7 @@ const multishare = async (
         type: "share",
         position: "bottom",
         autoHide: false,
-        onHide: () => undefined,
+        onHide: () => {},
         props: {
           items: shareable.map((item) => ({
             title: item.title,

--- a/src/helpers/network/Analytics.ts
+++ b/src/helpers/network/Analytics.ts
@@ -35,12 +35,7 @@ export type AnalyticsEvent =
  * letting it become a confusing no-op.
  */
 type ReservedPropKey =
-  | "platform"
-  | "OSversion"
-  | "appVersion"
-  | "appBuild"
-  | "buildLabel"
-  | "width";
+  "platform" | "OSversion" | "appVersion" | "appBuild" | "buildLabel" | "width";
 
 /**
  * Custom event properties: any keys/values, except that any reserved base-prop

--- a/src/helpers/utils/networking.ts
+++ b/src/helpers/utils/networking.ts
@@ -104,7 +104,7 @@ export function createClient(
       const requestUrl = buildUrl(baseURL, url, params);
       const mergedHeaders: FetchHeaders = {
         ...baseHeaders,
-        ...(headers ?? {}),
+        ...headers,
       };
 
       const init: RequestInit = { method, headers: mergedHeaders, signal };

--- a/src/hooks/useAISearch.ts
+++ b/src/hooks/useAISearch.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "node:buffer";
+import { Buffer } from "buffer";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { FaktenBotReaction } from "#/components/animations/FaktenBot";

--- a/src/hooks/useAISearch.ts
+++ b/src/hooks/useAISearch.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "buffer";
+import { Buffer } from "node:buffer";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { FaktenBotReaction } from "#/components/animations/FaktenBot";

--- a/src/screens/Home/components/Feed.tsx
+++ b/src/screens/Home/components/Feed.tsx
@@ -158,7 +158,7 @@ const Feed = (properties: FeedProperties) => {
   ]);
 
   const renderItem: ListRenderItem<Post<unknown>> = useCallback(({ item }) => {
-    if (typeof item.data !== "object") return;
+    if (typeof item.data !== "object") return null;
     return (
       <GenericPost
         key={item.id}

--- a/src/screens/Home/components/Feed.tsx
+++ b/src/screens/Home/components/Feed.tsx
@@ -158,7 +158,7 @@ const Feed = (properties: FeedProperties) => {
   ]);
 
   const renderItem: ListRenderItem<Post<unknown>> = useCallback(({ item }) => {
-    if (typeof item.data !== "object") return undefined;
+    if (typeof item.data !== "object") return;
     return (
       <GenericPost
         key={item.id}

--- a/src/screens/Home/components/article/ArticleStats.tsx
+++ b/src/screens/Home/components/article/ArticleStats.tsx
@@ -22,7 +22,7 @@ const ArticleStats = (properties: ArticleStatsProperties) => {
   const color = useCorporateColor();
   const showEngagement = Config.enableEngagement;
 
-  if (!showEngagement && !reading_time) return undefined;
+  if (!showEngagement && !reading_time) return;
 
   return (
     <View

--- a/src/screens/Home/components/article/ArticleStats.tsx
+++ b/src/screens/Home/components/article/ArticleStats.tsx
@@ -22,7 +22,7 @@ const ArticleStats = (properties: ArticleStatsProperties) => {
   const color = useCorporateColor();
   const showEngagement = Config.enableEngagement;
 
-  if (!showEngagement && !reading_time) return;
+  if (!showEngagement && !reading_time) return null;
 
   return (
     <View

--- a/src/screens/Home/components/article/renderer/BlockRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/BlockRenderer.tsx
@@ -21,7 +21,7 @@ const BlockRenderer = (properties: BlockRenderProperties) => {
   const { advancedSettings } = useContext(SettingsContext);
 
   if (!("TDefaultRenderer" in properties.renderProps)) {
-    return undefined;
+    return;
   }
 
   const defaultContent = (

--- a/src/screens/Home/components/article/renderer/BlockRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/BlockRenderer.tsx
@@ -21,7 +21,7 @@ const BlockRenderer = (properties: BlockRenderProperties) => {
   const { advancedSettings } = useContext(SettingsContext);
 
   if (!("TDefaultRenderer" in properties.renderProps)) {
-    return;
+    return null;
   }
 
   const defaultContent = (

--- a/src/screens/PersonalTab/components/MyFavs.tsx
+++ b/src/screens/PersonalTab/components/MyFavs.tsx
@@ -21,8 +21,7 @@ import type { ArticleProperties, HttpsUrl, InstaPostProperties } from "#/types";
 import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA } from "#/types";
 
 type FavoritePost =
-  | Post<{ article: ArticleProperties }>
-  | Post<InstaPostProperties>;
+  Post<{ article: ArticleProperties }> | Post<InstaPostProperties>;
 
 // Reuse one API client per secondary site instead of rebuilding it for every
 // favorite on every load.

--- a/src/types/feeds.ts
+++ b/src/types/feeds.ts
@@ -1,13 +1,7 @@
 import type { HttpsUrl } from "./config";
 
 export type FeedType =
-  | "reddit"
-  | "wp"
-  | "insta"
-  | "yt"
-  | "tiktok"
-  | "bsky"
-  | "bot";
+  "reddit" | "wp" | "insta" | "yt" | "tiktok" | "bsky" | "bot";
 
 export type FeedEntry = {
   handle?: string;
@@ -35,9 +29,7 @@ export type InstaFeedKey = `insta:${string}`;
 
 /** Key of an enabled feed: either a plain feed type or a per-account key */
 export type FeedKey =
-  | Exclude<FeedType, "wp" | "insta">
-  | WpFeedKey
-  | InstaFeedKey;
+  Exclude<FeedType, "wp" | "insta"> | WpFeedKey | InstaFeedKey;
 
 export type FeedsConfig = Partial<
   Record<Exclude<FeedType, "wp" | "insta">, FeedEntry>


### PR DESCRIPTION
## What

Adopts [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn), but **skips the `recommended` preset** — it's too noisy for React Native (`filename-case`, `no-null`, `prevent-abbreviations`, `prefer-module` all fight RN conventions; ~1250 problems, ~73% non-fixable).

Instead we opt in to a **curated set** of correctness/modernization rules and apply their autofixes.

> Pinned to **eslint-plugin-unicorn 65.0.1** — the last release whose peer dependency supports ESLint 9 (`>=9.38.0`). 66+ require `eslint >=10.4`, which this repo isn't on yet.

This PR also carries two smaller related changes that rode along: a **prettier bump** and a few **cspell dictionary** additions (see below).

## Why curated vs recommended

| | total problems | auto-fixable |
|---|---|---|
| `recommended` | 1254 | 333 (27%) |
| curated set | 58 | 55 (95%) |

The recommended preset's biggest fixable chunk was `name-replacements` (131 local-variable renames) — reviewer-hostile churn for cosmetic gain. The curated set is high-signal: nearly everything auto-fixes and the fixes are real improvements.

## Autofixes applied across the tree

- `global` → `globalThis`
- `new Date().getTime()` → `Date.now()`
- `.replace(/x/g, …)` → `.replaceAll(…)`
- array `.includes` on a constant list → `Set.has`
- `indexOf >= 0` → `!== -1`
- redundant `undefined` removed

## Prettier 3.8.4 → 3.9.0

Pulled in during the unicorn install. Prettier 3.9.0 changes union-type formatting (collapses short unions onto one line and drops the leading `|`), which reformats `Analytics.ts`, `MyFavs.tsx`, and `feeds.ts`. Kept as its own commit so the reformatting is reviewable separately. Note: going forward, files touched by the lint-staged hook with multi-line unions will get this same collapse-reformatting — expected behavior of the bump.

## cspell dictionary

Added words surfaced by `@cspell/eslint-plugin` over the test files: `bafyreiabc`, `favorited`, `unconfigured`, `wwwx`.

## Rules deliberately omitted / tuned

- **`prefer-node-protocol` omitted** — it rewrote `import { Buffer } from "buffer"` to `"node:buffer"`, but **Metro can't resolve the `node:` protocol** for polyfilled builtins, breaking the EAS export / Expo Preview build (`Unable to resolve module node:buffer`). Reverted that import and dropped the rule. (`node:` imports in `scripts/` are fine — those run in plain Node.)
- **`no-useless-undefined` tuned** with `{ checkArguments: false, checkArrowFunctionBody: false }` — explicit `undefined` arguments are legitimate/readable (tests calling `fn(undefined)`, `mockResolvedValue(undefined)`), and `() => undefined` callbacks shouldn't be rewritten. Keeps the rule focused on genuinely useless `undefined` like `return undefined`.

## Other gotchas hit

- **`no-useless-undefined` made a harmful autofix** in `Post.ts`: it stripped `= undefined` off the `shareable` param, turning an optional positional param into a required one and breaking 4-arg callers (caught by `tsc`). Fixed properly by making the param optional (`shareable?`) — honors the type, keeps 4-arg callers working, no `eslint-disable`.
- **`return undefined` → `return null` in render paths**: the rule had rewritten `return undefined` to bare `return` in three React render paths (`ArticleStats`, `BlockRenderer`, `Feed`'s `renderItem`); a component returning undefined trips React's "Nothing was returned from render". Switched to `return null`.
- Disabled `import/namespace` & friends **for `eslint.config.mjs` only** — the `import` plugin can't parse unicorn's dist (import attributes).

## Checks

- ✅ `pnpm lint` — 0 errors
- ✅ `pnpm check:ts`
- ✅ `pnpm test` — 104 suites, 797 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)