### PR TITLE
Deep linking: pruefpunkt.org association files + reliable wp-content/uploads exclusion

### DIFF
--- a/__tests__/app/native-intent.test.ts
+++ b/__tests__/app/native-intent.test.ts
@@ -40,12 +40,20 @@ describe("redirectSystemPath", () => {
     ).toBe("/cat/slug/");
   });
 
-  it("returns undefined for excluded paths so the OS handles them", () => {
-    expect(
-      redirectSystemPath({
-        path: "https://volksverpetzer.de/wp-content/uploads/file.pdf",
-      }),
-    ).toBeUndefined();
+  it("routes excluded upload paths to the external-link screen so they open in the browser", () => {
+    const uploadUrl =
+      "https://volksverpetzer.de/wp-content/uploads/2024/11/file.pdf";
+    expect(redirectSystemPath({ path: uploadUrl })).toBe(
+      `/external-link?url=${encodeURIComponent(uploadUrl)}`,
+    );
+  });
+
+  it("routes a secondary-host (Prüfpunkt) upload path to the external-link screen too", () => {
+    const uploadUrl =
+      "https://www.pruefpunkt.org/wp-content/uploads/2024/11/file.pdf";
+    expect(redirectSystemPath({ path: uploadUrl })).toBe(
+      `/external-link?url=${encodeURIComponent(uploadUrl)}`,
+    );
   });
 
   it("passes through unrelated/relative paths unchanged", () => {

--- a/__tests__/helpers/Linking.test.ts
+++ b/__tests__/helpers/Linking.test.ts
@@ -4,6 +4,7 @@ import type { ImperativeRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 
 import {
+  isInternalUploadUrl,
   onLinkPress,
   openExternalDownload,
   outBoundLinkPress,
@@ -370,6 +371,62 @@ describe("Linking helpers", () => {
       await openExternalDownload(uploadUrl);
 
       expect(Linking.openURL).toHaveBeenCalledWith(uploadUrl);
+    });
+
+    it("does not reject when both the browser and openURL fail", async () => {
+      const uploadUrl =
+        "https://www.volksverpetzer.de/wp-content/uploads/file.pdf";
+      (
+        WebBrowser.openBrowserAsync as jest.MockedFunction<
+          typeof WebBrowser.openBrowserAsync
+        >
+      ).mockRejectedValueOnce(new Error("no browser"));
+      (
+        Linking.openURL as jest.MockedFunction<typeof Linking.openURL>
+      ).mockRejectedValueOnce(new Error("no handler"));
+
+      // Fire-and-forget callers rely on this never rejecting.
+      await expect(openExternalDownload(uploadUrl)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("isInternalUploadUrl", () => {
+    it("accepts https uploads URLs on our WordPress hosts", () => {
+      expect(
+        isInternalUploadUrl(
+          "https://www.volksverpetzer.de/wp-content/uploads/2024/11/file.pdf",
+        ),
+      ).toBe(true);
+      // www-insensitive + secondary feed host (pruefpunkt.org)
+      expect(
+        isInternalUploadUrl(
+          "https://pruefpunkt.org/wp-content/uploads/image.jpg",
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects non-uploads paths on our hosts", () => {
+      expect(
+        isInternalUploadUrl("https://www.volksverpetzer.de/politik/some-slug/"),
+      ).toBe(false);
+    });
+
+    it("rejects foreign hosts even for an uploads path", () => {
+      expect(
+        isInternalUploadUrl("https://evil.com/wp-content/uploads/file.pdf"),
+      ).toBe(false);
+    });
+
+    it("rejects non-https schemes", () => {
+      expect(
+        isInternalUploadUrl(
+          "http://www.volksverpetzer.de/wp-content/uploads/file.pdf",
+        ),
+      ).toBe(false);
+    });
+
+    it("rejects unparseable input", () => {
+      expect(isInternalUploadUrl("not a url")).toBe(false);
     });
   });
 });

--- a/__tests__/helpers/Linking.test.ts
+++ b/__tests__/helpers/Linking.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import * as Linking from "expo-linking";
 import type { ImperativeRouter } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
 
-import { onLinkPress, outBoundLinkPress, parsePath } from "#/helpers/Linking";
+import {
+  onLinkPress,
+  openExternalDownload,
+  outBoundLinkPress,
+  parsePath,
+} from "#/helpers/Linking";
 import { registerEvent } from "#/helpers/network/Analytics";
 
 // Mock dependencies
@@ -10,6 +16,11 @@ jest.mock("expo-linking", () => ({
   __esModule: true,
   parse: jest.fn(),
   openURL: jest.fn(),
+}));
+
+jest.mock("expo-web-browser", () => ({
+  __esModule: true,
+  openBrowserAsync: jest.fn(() => Promise.resolve({ type: "opened" })),
 }));
 
 jest.mock("#/helpers/network/Analytics", () => ({
@@ -86,7 +97,7 @@ describe("Linking helpers", () => {
       expect(Linking.openURL).not.toHaveBeenCalled();
     });
 
-    it("should treat wp-content/uploads paths as external links", () => {
+    it("should open wp-content/uploads paths externally (browser tab, not the app)", () => {
       // Setup
       const uploadUrl =
         "https://www.volksverpetzer.de/wp-content/uploads/2024/11/file.pdf";
@@ -114,7 +125,10 @@ describe("Linking helpers", () => {
         "Outbound Link: Click",
         { url: uploadUrl },
       );
-      expect(Linking.openURL).toHaveBeenCalledWith(uploadUrl);
+      // Opened in a Custom Tab (expo-web-browser), not Linking.openURL — the
+      // latter could re-trigger the app on Android < 31 and loop.
+      expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(uploadUrl);
+      expect(Linking.openURL).not.toHaveBeenCalled();
     });
 
     it("should handle internal links without path", () => {
@@ -324,6 +338,38 @@ describe("Linking helpers", () => {
         { url: externalUrl },
       );
       expect(Linking.openURL).toHaveBeenCalledWith(externalUrl);
+    });
+  });
+
+  describe("openExternalDownload", () => {
+    it("opens the URL in a browser tab and registers analytics", async () => {
+      const uploadUrl =
+        "https://www.volksverpetzer.de/wp-content/uploads/2024/11/file.pdf";
+      const articleContext = "https://www.volksverpetzer.de/article";
+
+      await openExternalDownload(uploadUrl, articleContext);
+
+      expect(registerEvent).toHaveBeenCalledWith(
+        articleContext,
+        "Outbound Link: Click",
+        { url: uploadUrl },
+      );
+      expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(uploadUrl);
+      expect(Linking.openURL).not.toHaveBeenCalled();
+    });
+
+    it("falls back to Linking.openURL when the browser tab fails", async () => {
+      const uploadUrl =
+        "https://www.volksverpetzer.de/wp-content/uploads/file.pdf";
+      (
+        WebBrowser.openBrowserAsync as jest.MockedFunction<
+          typeof WebBrowser.openBrowserAsync
+        >
+      ).mockRejectedValueOnce(new Error("no browser"));
+
+      await openExternalDownload(uploadUrl);
+
+      expect(Linking.openURL).toHaveBeenCalledWith(uploadUrl);
     });
   });
 });

--- a/config/mimikama.config.ts
+++ b/config/mimikama.config.ts
@@ -126,12 +126,16 @@ const packageName = "de.mimikama.app";
 
 const googleServicesFile = process.env.google_services_mimikama;
 
+// Match only a 2-segment article path `/{category}/{slug}` (optional trailing
+// slash) so the OS does not open the app for `/wp-content/uploads/…` files,
+// which should download in the browser instead. `pathAdvancedPattern` is honored
+// on Android 12+; on older versions the in-app fallback opens uploads externally.
 const AndroidIntentFilters: ExpoConfig["android"]["intentFilters"][number]["data"] =
   [
     {
       scheme: "https",
       host: "*.mimikama.org",
-      pathPrefix: "/*/*/",
+      pathAdvancedPattern: "/[^/]+/[^/]+/{0,1}",
     },
   ];
 

--- a/config/mimikama.config.ts
+++ b/config/mimikama.config.ts
@@ -126,18 +126,18 @@ const packageName = "de.mimikama.app";
 
 const googleServicesFile = process.env.google_services_mimikama;
 
-// Match only a 2-segment article path `/{category}/{slug}` (optional trailing
-// slash) so the OS does not open the app for `/wp-content/uploads/…` files,
-// which should download in the browser instead. `pathAdvancedPattern` is honored
-// on Android 12+; on older versions the in-app fallback opens uploads externally.
+// Match a 1-segment page and a 2-segment article `/{category}/{slug}` (each with
+// an optional trailing slash) so the OS does not open the app for
+// `/wp-content/uploads/…` files (3+ segments), which should download in the
+// browser instead. Advanced glob has no grouping, so the two cases are separate
+// patterns. `pathAdvancedPattern` is honored on Android 12+; on older versions
+// the in-app fallback opens uploads externally.
 const AndroidIntentFilters: ExpoConfig["android"]["intentFilters"][number]["data"] =
-  [
-    {
-      scheme: "https",
-      host: "*.mimikama.org",
-      pathAdvancedPattern: "/[^/]+/[^/]+/{0,1}",
-    },
-  ];
+  ["/[^/]+/{0,1}", "/[^/]+/[^/]+/{0,1}"].map((pathAdvancedPattern) => ({
+    scheme: "https",
+    host: "*.mimikama.org",
+    pathAdvancedPattern,
+  }));
 
 const iOSAssociatedDomains = ["applinks:www.mimikama.org"];
 

--- a/config/volksverpetzer.config.ts
+++ b/config/volksverpetzer.config.ts
@@ -155,38 +155,38 @@ const googleServicesFile = process.env.google_services;
 // Both the www and apex hosts are registered so deep links resolve regardless
 // of which form the link uses (the site is moving off the www subdomain, but
 // previously shared links and the redirect still use www).
-// Match only the app's single deep-linkable shape — a 2-segment article path
-// `/{category}/{slug}` (route src/app/[category]/[slug].tsx) with an optional
-// trailing slash — so the OS does NOT open the app for `/wp-content/uploads/…`
-// files (3+ segments), which should download in the browser instead.
+//
+// Match only the app's deep-linkable shapes — a 1-segment page like
+// `/impressum-volksverpetzer/` (rendered in-app via the category webview) and a
+// 2-segment article `/{category}/{slug}` (route src/app/[category]/[slug].tsx),
+// each with an optional trailing slash. This deliberately does NOT match
+// `/wp-content/uploads/…` files (3+ segments), which should download in the
+// browser instead. Advanced glob has no grouping, so the 1- and 2-segment cases
+// are two separate patterns.
+//
 // `pathAdvancedPattern` is honored on Android 12+ (API 31); on older versions it
 // is ignored and the filter falls back to matching all paths, where the in-app
 // fallback (src/app/external-link.tsx) opens uploads externally instead.
-const ARTICLE_PATH_PATTERN = "/[^/]+/[^/]+/{0,1}";
+const ARTICLE_PATH_PATTERNS = [
+  "/[^/]+/{0,1}", // 1 segment, e.g. /impressum-volksverpetzer/
+  "/[^/]+/[^/]+/{0,1}", // 2 segments, e.g. /aktuelles/slug/
+];
+
+const DEEP_LINK_HOSTS = [
+  "www.volksverpetzer.de",
+  "volksverpetzer.de",
+  "www.pruefpunkt.org",
+  "pruefpunkt.org",
+];
 
 const AndroidIntentFilters: ExpoConfig["android"]["intentFilters"][number]["data"] =
-  [
-    {
+  DEEP_LINK_HOSTS.flatMap((host) =>
+    ARTICLE_PATH_PATTERNS.map((pathAdvancedPattern) => ({
       scheme: "https",
-      host: "www.volksverpetzer.de",
-      pathAdvancedPattern: ARTICLE_PATH_PATTERN,
-    },
-    {
-      scheme: "https",
-      host: "volksverpetzer.de",
-      pathAdvancedPattern: ARTICLE_PATH_PATTERN,
-    },
-    {
-      scheme: "https",
-      host: "www.pruefpunkt.org",
-      pathAdvancedPattern: ARTICLE_PATH_PATTERN,
-    },
-    {
-      scheme: "https",
-      host: "pruefpunkt.org",
-      pathAdvancedPattern: ARTICLE_PATH_PATTERN,
-    },
-  ];
+      host,
+      pathAdvancedPattern,
+    })),
+  );
 
 const iOSAssociatedDomains = [
   "applinks:www.volksverpetzer.de",

--- a/config/volksverpetzer.config.ts
+++ b/config/volksverpetzer.config.ts
@@ -155,27 +155,36 @@ const googleServicesFile = process.env.google_services;
 // Both the www and apex hosts are registered so deep links resolve regardless
 // of which form the link uses (the site is moving off the www subdomain, but
 // previously shared links and the redirect still use www).
+// Match only the app's single deep-linkable shape — a 2-segment article path
+// `/{category}/{slug}` (route src/app/[category]/[slug].tsx) with an optional
+// trailing slash — so the OS does NOT open the app for `/wp-content/uploads/…`
+// files (3+ segments), which should download in the browser instead.
+// `pathAdvancedPattern` is honored on Android 12+ (API 31); on older versions it
+// is ignored and the filter falls back to matching all paths, where the in-app
+// fallback (src/app/external-link.tsx) opens uploads externally instead.
+const ARTICLE_PATH_PATTERN = "/[^/]+/[^/]+/{0,1}";
+
 const AndroidIntentFilters: ExpoConfig["android"]["intentFilters"][number]["data"] =
   [
     {
       scheme: "https",
       host: "www.volksverpetzer.de",
-      pathPattern: "/.*/.*",
+      pathAdvancedPattern: ARTICLE_PATH_PATTERN,
     },
     {
       scheme: "https",
       host: "volksverpetzer.de",
-      pathPattern: "/.*/.*",
+      pathAdvancedPattern: ARTICLE_PATH_PATTERN,
     },
     {
       scheme: "https",
       host: "www.pruefpunkt.org",
-      pathPattern: "/.*/.*",
+      pathAdvancedPattern: ARTICLE_PATH_PATTERN,
     },
     {
       scheme: "https",
       host: "pruefpunkt.org",
-      pathPattern: "/.*/.*",
+      pathAdvancedPattern: ARTICLE_PATH_PATTERN,
     },
   ];
 

--- a/deeplink/README.md
+++ b/deeplink/README.md
@@ -1,0 +1,52 @@
+# Universal / App Links association files
+
+These static files must be served by the web/CDN layer so iOS (Universal Links)
+and Android (App Links) verify our domains and open the app for article links.
+They are **not** bundled into the app — they live on the websites. This folder is
+the source of truth for what each domain must serve.
+
+| File                                                      | Must be served at                                                  | Content-Type       | Status                                   |
+| --------------------------------------------------------- | ------------------------------------------------------------------ | ------------------ | ---------------------------------------- |
+| `well-known/pruefpunkt.org/apple-app-site-association`    | `https://pruefpunkt.org/.well-known/apple-app-site-association`    | `application/json` | **deploy** (404 today)                   |
+| `well-known/pruefpunkt.org/assetlinks.json`               | `https://pruefpunkt.org/.well-known/assetlinks.json`               | `application/json` | **deploy** (404 today)                   |
+| `well-known/volksverpetzer.de/apple-app-site-association` | `https://volksverpetzer.de/.well-known/apple-app-site-association` | `application/json` | **update** (add uploads exclude)         |
+| `well-known/volksverpetzer.de/assetlinks.json`            | `https://volksverpetzer.de/.well-known/assetlinks.json`            | `application/json` | already live — reference copy, no change |
+
+Requirements:
+
+- **No file extension** on `apple-app-site-association`, served over HTTPS with no
+  redirect, `Content-Type: application/json`.
+- `assetlinks.json` served over HTTPS as `application/json`.
+- `www.` hosts: the sites redirect `www → apex`, so a single apex-hosted file
+  suffices. If a `www` host is ever served independently, it needs the same files.
+
+## Status (as of this change)
+
+- **pruefpunkt.org** — both files are currently **404**. Deploy both. This is what
+  blocks Prüfpunkt links from opening the app.
+- **volksverpetzer.de** — both files already live (HTTP 200). The
+  `apple-app-site-association` here is an **update**: it adds
+  `"NOT /wp-content/uploads/*"` ahead of `"/*/*"` so iOS stops opening the app for
+  upload/download links (PDFs, images) — those should download in Safari instead.
+  iOS evaluates `paths` top-down (first match wins), so the `NOT` rule must come
+  first. `volksverpetzer.de/.well-known/assetlinks.json` needs **no change**.
+
+## Identifiers
+
+- iOS appID: `LGZ66Q83U6.de.volksverpetzer.app`
+- Android package: `de.volksverpetzer.app`
+- Android signing SHA-256 (Play App Signing, same as live volksverpetzer.de):
+  `29:60:C3:E3:7C:C4:7F:9B:8A:09:BF:77:80:B5:19:2B:25:AC:ED:14:3B:26:BD:DE:F5:2A:E3:D0:98:31:E0:FA`
+
+## Verify after deploy
+
+```bash
+curl -sS https://pruefpunkt.org/.well-known/apple-app-site-association | jq .
+curl -sS https://pruefpunkt.org/.well-known/assetlinks.json | jq .
+curl -sS https://volksverpetzer.de/.well-known/apple-app-site-association | jq .
+```
+
+- Android: `https://developers.google.com/digital-asset-links/tools/generator`
+  or `adb shell pm verify-app-links --re-verify de.volksverpetzer.app`.
+- iOS: reinstall the app (the AASA is cached at install) or test with a fresh
+  build; Apple's CDN (`app-site-association.cdn-apple.com`) may also cache.

--- a/deeplink/well-known/pruefpunkt.org/apple-app-site-association
+++ b/deeplink/well-known/pruefpunkt.org/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "LGZ66Q83U6.de.volksverpetzer.app",
+        "paths": ["NOT /wp-content/uploads/*", "/*/*"]
+      }
+    ]
+  }
+}

--- a/deeplink/well-known/pruefpunkt.org/assetlinks.json
+++ b/deeplink/well-known/pruefpunkt.org/assetlinks.json
@@ -1,0 +1,15 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "de.volksverpetzer.app",
+      "sha256_cert_fingerprints": [
+        "29:60:C3:E3:7C:C4:7F:9B:8A:09:BF:77:80:B5:19:2B:25:AC:ED:14:3B:26:BD:DE:F5:2A:E3:D0:98:31:E0:FA"
+      ]
+    }
+  }
+]

--- a/deeplink/well-known/volksverpetzer.de/apple-app-site-association
+++ b/deeplink/well-known/volksverpetzer.de/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "LGZ66Q83U6.de.volksverpetzer.app",
+        "paths": ["NOT /wp-content/uploads/*", "/*/*"]
+      }
+    ]
+  }
+}

--- a/deeplink/well-known/volksverpetzer.de/assetlinks.json
+++ b/deeplink/well-known/volksverpetzer.de/assetlinks.json
@@ -1,0 +1,15 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "de.volksverpetzer.app",
+      "sha256_cert_fingerprints": [
+        "29:60:C3:E3:7C:C4:7F:9B:8A:09:BF:77:80:B5:19:2B:25:AC:ED:14:3B:26:BD:DE:F5:2A:E3:D0:98:31:E0:FA"
+      ]
+    }
+  }
+]

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -123,6 +123,11 @@ jest.mock("expo-device", () => ({
   isDevice: true,
 }));
 
+jest.mock("expo-web-browser", () => ({
+  __esModule: true,
+  openBrowserAsync: jest.fn(() => Promise.resolve({ type: "opened" })),
+}));
+
 jest.mock("#/hooks/useAppColorScheme", () => ({
   useAppColorScheme: jest.fn(() => "light"),
   useCorporateColor: jest.fn(() => "#1b7194"),

--- a/src/app/+native-intent.tsx
+++ b/src/app/+native-intent.tsx
@@ -28,11 +28,14 @@ export function redirectSystemPath({ path }: { path: string }) {
       : findSecondaryWpFeed(parsedUrl.href, wpUrl, Config.feeds?.wp);
     if (isPrimary || secondary) {
       const urlPath = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
-      // Check if path should be excluded from deep linking
+      // Upload links (/wp-content/uploads/…) must not render in the app — they
+      // are files to download. On Android < 31 the manifest can't exclude them,
+      // so the OS still hands us the URL here; route to the external-link screen,
+      // which opens it in the browser and pops back. (On iOS, and Android 12+,
+      // the site-association / intent-filter exclude usually prevents the app
+      // from opening at all, so this is the fallback path.)
       if (shouldExcludeFromDeepLink(urlPath)) {
-        // Return undefined to prevent routing for excluded paths
-        // The app will not handle this path and it will be opened by OS
-        return;
+        return `/external-link?url=${encodeURIComponent(parsedUrl.href)}`;
       }
       // Secondary-site links must carry originalUrl so the article route
       // fetches from the right WordPress API; primary links use the default.

--- a/src/app/external-link.tsx
+++ b/src/app/external-link.tsx
@@ -1,0 +1,37 @@
+import { router, useLocalSearchParams } from "expo-router";
+import { useEffect } from "react";
+
+import UiSpinner from "#/components/ui/UiSpinner";
+import { openExternalDownload } from "#/helpers/Linking";
+import type { HttpsUrl } from "#/types";
+
+/**
+ * Fallback screen for upload/download links (/wp-content/uploads/…) that the OS
+ * handed to the app instead of the browser — this happens on Android < 31, where
+ * the manifest's `pathAdvancedPattern` exclude is ignored and our app still
+ * claims the URL. Opening the URL from a mounted screen (rather than inside
+ * `+native-intent`'s `redirectSystemPath`) guarantees the native browser module
+ * and navigation are ready. The file opens in a Custom Tab and we pop back so
+ * the app is never left on a blank route.
+ */
+const ExternalLink = () => {
+  const { url } = useLocalSearchParams<{ url?: string }>();
+
+  useEffect(() => {
+    const open = async () => {
+      if (url) {
+        await openExternalDownload(url as HttpsUrl);
+      }
+      if (router.canGoBack()) {
+        router.back();
+      } else {
+        router.replace("/");
+      }
+    };
+    void open();
+  }, [url]);
+
+  return <UiSpinner size="large" containerStyle={{ flex: 1 }} />;
+};
+
+export default ExternalLink;

--- a/src/app/external-link.tsx
+++ b/src/app/external-link.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 
 import UiSpinner from "#/components/ui/UiSpinner";
 import { isInternalUploadUrl, openExternalDownload } from "#/helpers/Linking";
-import type { HttpsUrl } from "#/types";
 
 /**
  * Fallback screen for upload/download links (/wp-content/uploads/…) that the OS
@@ -25,7 +24,7 @@ const ExternalLink = () => {
         // open-redirect where a crafted `/external-link?url=…` deep link could
         // otherwise make the app open an arbitrary external URL.
         if (url && isInternalUploadUrl(url)) {
-          await openExternalDownload(url as HttpsUrl);
+          await openExternalDownload(url);
         }
       } finally {
         if (router.canGoBack()) {

--- a/src/app/external-link.tsx
+++ b/src/app/external-link.tsx
@@ -2,7 +2,7 @@ import { router, useLocalSearchParams } from "expo-router";
 import { useEffect } from "react";
 
 import UiSpinner from "#/components/ui/UiSpinner";
-import { openExternalDownload } from "#/helpers/Linking";
+import { isInternalUploadUrl, openExternalDownload } from "#/helpers/Linking";
 import type { HttpsUrl } from "#/types";
 
 /**
@@ -19,13 +19,20 @@ const ExternalLink = () => {
 
   useEffect(() => {
     const open = async () => {
-      if (url) {
-        await openExternalDownload(url as HttpsUrl);
-      }
-      if (router.canGoBack()) {
-        router.back();
-      } else {
-        router.replace("/");
+      try {
+        // Only open URLs we produced ourselves — an https link to a
+        // /wp-content/uploads/ file on one of our hosts. This blocks an
+        // open-redirect where a crafted `/external-link?url=…` deep link could
+        // otherwise make the app open an arbitrary external URL.
+        if (url && isInternalUploadUrl(url)) {
+          await openExternalDownload(url as HttpsUrl);
+        }
+      } finally {
+        if (router.canGoBack()) {
+          router.back();
+        } else {
+          router.replace("/");
+        }
       }
     };
     void open();

--- a/src/app/handle-share.tsx
+++ b/src/app/handle-share.tsx
@@ -13,7 +13,7 @@ import { shouldExcludeFromDeepLink } from "#/helpers/DeepLinkFilter";
 import { openExternalDownload } from "#/helpers/Linking";
 import { findSecondaryWpFeed } from "#/helpers/utils/feeds";
 import { isSameHost } from "#/helpers/utils/host";
-import type { HttpsUrl } from "#/types";
+import { isHttpsUrl } from "#/helpers/utils/networking";
 
 const URL_SHARE_TYPE: ShareType = "url";
 const TEXT_SHARE_TYPE: ShareType = "text";
@@ -53,7 +53,12 @@ const HandleShare = () => {
         }
 
         if (shouldExcludeFromDeepLink(path)) {
-          openExternalDownload(sharedUrl as HttpsUrl)
+          // openExternalDownload requires an https URL; fall back to the OS
+          // handler for the (unexpected) non-https case rather than casting.
+          const openExternally = isHttpsUrl(sharedUrl)
+            ? openExternalDownload(sharedUrl)
+            : Linking.openURL(sharedUrl);
+          openExternally
             .catch((linkError) => {
               console.warn(
                 "Failed to open excluded URL:",

--- a/src/app/handle-share.tsx
+++ b/src/app/handle-share.tsx
@@ -10,8 +10,10 @@ import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
 import { shouldExcludeFromDeepLink } from "#/helpers/DeepLinkFilter";
+import { openExternalDownload } from "#/helpers/Linking";
 import { findSecondaryWpFeed } from "#/helpers/utils/feeds";
 import { isSameHost } from "#/helpers/utils/host";
+import type { HttpsUrl } from "#/types";
 
 const URL_SHARE_TYPE: ShareType = "url";
 const TEXT_SHARE_TYPE: ShareType = "text";
@@ -51,7 +53,7 @@ const HandleShare = () => {
         }
 
         if (shouldExcludeFromDeepLink(path)) {
-          Linking.openURL(sharedUrl)
+          openExternalDownload(sharedUrl as HttpsUrl)
             .catch((linkError) => {
               console.warn(
                 "Failed to open excluded URL:",

--- a/src/helpers/Linking.ts
+++ b/src/helpers/Linking.ts
@@ -1,5 +1,6 @@
 import * as Linking from "expo-linking";
 import type { Href, ImperativeRouter } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
 
 import Config from "#/constants/Config";
 import { registerEvent } from "#/helpers/network/Analytics";
@@ -37,7 +38,7 @@ const onLinkPress = (
     internalHostnames.includes(normalizedHostname) &&
     shouldExcludeFromDeepLink(path)
   ) {
-    outBoundLinkPress(href, article_link);
+    openExternalDownload(href, article_link);
     return;
   }
 
@@ -68,4 +69,26 @@ const outBoundLinkPress = (href: HttpsUrl, article_link?: string) => {
   Linking.openURL(href);
 };
 
-export { onLinkPress, outBoundLinkPress, parsePath };
+/**
+ * Opens an upload/download URL (e.g. /wp-content/uploads/…) outside the app.
+ *
+ * Uses a Chrome Custom Tab / SFSafariViewController via expo-web-browser rather
+ * than `Linking.openURL`: on Android versions where our app still claims the
+ * upload URL (API < 31, where the manifest's `pathAdvancedPattern` exclude is
+ * ignored), `Linking.openURL` would re-dispatch the URL back into our app and
+ * loop. A Custom Tab never re-triggers the owning app's deep links, so the file
+ * downloads/opens in the browser. Falls back to `openURL` if the browser call
+ * fails.
+ * @param href - The upload/download URL to open.
+ * @param article_link - Optional article URL for analytics context.
+ */
+const openExternalDownload = async (href: HttpsUrl, article_link?: string) => {
+  registerEvent(article_link, "Outbound Link: Click", { url: href });
+  try {
+    await WebBrowser.openBrowserAsync(href);
+  } catch {
+    await Linking.openURL(href);
+  }
+};
+
+export { onLinkPress, openExternalDownload, outBoundLinkPress, parsePath };

--- a/src/helpers/Linking.ts
+++ b/src/helpers/Linking.ts
@@ -78,7 +78,7 @@ const outBoundLinkPress = (href: HttpsUrl, article_link?: string) => {
  * ignored), `Linking.openURL` would re-dispatch the URL back into our app and
  * loop. A Custom Tab never re-triggers the owning app's deep links, so the file
  * downloads/opens in the browser. Falls back to `openURL` if the browser call
- * fails.
+ * fails. Never rejects, so callers can safely fire-and-forget it.
  * @param href - The upload/download URL to open.
  * @param article_link - Optional article URL for analytics context.
  */
@@ -87,8 +87,42 @@ const openExternalDownload = async (href: HttpsUrl, article_link?: string) => {
   try {
     await WebBrowser.openBrowserAsync(href);
   } catch {
-    await Linking.openURL(href);
+    try {
+      await Linking.openURL(href);
+    } catch (error) {
+      console.warn("Failed to open external download:", href, error);
+    }
   }
 };
 
-export { onLinkPress, openExternalDownload, outBoundLinkPress, parsePath };
+/**
+ * True when `href` is an https URL on one of our WordPress hosts pointing at a
+ * `/wp-content/uploads/` file — i.e. exactly the URLs the external-link screen
+ * is meant to open. Used to reject arbitrary URLs passed via the
+ * `/external-link?url=` deep link (open-redirect hardening).
+ * @param href - The candidate URL.
+ */
+const isInternalUploadUrl = (href: string): boolean => {
+  try {
+    const parsed = new URL(href);
+    if (parsed.protocol !== "https:") return false;
+    const internalHostnames = getInternalWpHosts(
+      Config.wpUrl,
+      Config.feeds?.wp,
+    );
+    return (
+      internalHostnames.includes(normalizeHost(parsed.hostname)) &&
+      shouldExcludeFromDeepLink(parsed.pathname)
+    );
+  } catch {
+    return false;
+  }
+};
+
+export {
+  isInternalUploadUrl,
+  onLinkPress,
+  openExternalDownload,
+  outBoundLinkPress,
+  parsePath,
+};

--- a/src/helpers/Linking.ts
+++ b/src/helpers/Linking.ts
@@ -99,10 +99,11 @@ const openExternalDownload = async (href: HttpsUrl, article_link?: string) => {
  * True when `href` is an https URL on one of our WordPress hosts pointing at a
  * `/wp-content/uploads/` file — i.e. exactly the URLs the external-link screen
  * is meant to open. Used to reject arbitrary URLs passed via the
- * `/external-link?url=` deep link (open-redirect hardening).
+ * `/external-link?url=` deep link (open-redirect hardening). A `true` result
+ * also narrows `href` to `HttpsUrl`, since the scheme is checked here.
  * @param href - The candidate URL.
  */
-const isInternalUploadUrl = (href: string): boolean => {
+const isInternalUploadUrl = (href: string): href is HttpsUrl => {
   try {
     const parsed = new URL(href);
     if (parsed.protocol !== "https:") return false;


### PR DESCRIPTION
## Context

Two long-standing deep-link gaps, both on Android **and** iOS:

**a) pruefpunkt.org has no association files.** The app already registers `applinks:pruefpunkt.org` (iOS) and a `pruefpunkt.org` intent filter (Android), but the server returns **404** for both `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json`, so the OS never verifies the domain and Prüfpunkt links never open the app.

**b) `/wp-content/uploads/` links wrongly open the app.** A shared link to a PDF/image under `/wp-content/uploads/` should trigger the OS download/handler, not launch the app onto a blank/not-found screen. The previous mitigation (`+native-intent` returning `undefined`) does **not** hand the URL back to the OS — the OS had already chosen to open the app (both the iOS AASA `"/*/*"` rule and the Android `pathPattern: "/.*/.*"` greedily match upload paths), so it just dead-ended in the app.

## Approach (layered)

Stop the OS from claiming upload URLs where possible, and make the app-side path *actively* open any upload URL externally for the cases the manifest can't cover.

- **iOS** — server-side AASA exclude (`"NOT /wp-content/uploads/*"` before `"/*/*"`). Definitive; the app never opens for uploads.
- **Android manifest** — intent filter switched from `pathPattern: "/.*/.*"` to two `pathAdvancedPattern`s per host: `"/[^/]+/{0,1}"` (1-segment pages like `/impressum-volksverpetzer/`, rendered in-app via the `[category]/index` webview fallback) and `"/[^/]+/[^/]+/{0,1}"` (2-segment articles `/{category}/{slug}`). Both exclude 3+ segment upload paths. The 1-segment case is intentional — it preserves the pre-existing behavior of the old `/.*/.*` pattern, which matched 1-segment-with-trailing-slash. Honored on Android 12+ (API 31); on older versions the attribute is ignored and the filter falls back to claiming all paths → the app-side fallback handles it.
- **App-side fallback** (covers Android 8–11, and iOS until the AASA deploys) — uploads are opened in a Chrome Custom Tab / `SFSafariViewController` via `expo-web-browser`, which never re-dispatches the URL back into our app (no reopen loop, unlike `Linking.openURL`). `+native-intent` redirects uploads to a new `/external-link` screen that opens the file and pops back.

## Commits

1. **Narrow Android App Links to article paths** — `pathAdvancedPattern` in both variant configs (also fixes mimikama's effectively-broken `pathPrefix: "/*/*/"`).
2. **Open wp-content/uploads links externally** — `openExternalDownload` helper, `/external-link` screen, native-intent redirect, share-intent + in-app link handling, jest mock + test updates.
3. **Add deeplink association files** — `deeplink/` source-of-truth folder for pruefpunkt.org (new) + volksverpetzer.de (updated AASA + reference assetlinks) with a deployment README.

## ⚠️ Requires server deployment

The files under `deeplink/well-known/` must be deployed to the websites (infra/WordPress task) — see `deeplink/README.md`. The app changes alone won't make Prüfpunkt links work or fully fix iOS uploads until they're live:
- **pruefpunkt.org**: deploy AASA + assetlinks.json (both 404 today)
- **volksverpetzer.de**: update AASA to add the uploads exclude (assetlinks unchanged)

## Verification

- `pnpm check:ts` ✓ · `pnpm lint` 0 errors ✓ · cspell 0 issues ✓
- `pnpm test` — **803 tests / 104 suites pass**
- Confirmed Expo serializes the key to `android:pathAdvancedPattern="/[^/]+/[^/]+/{0,1}"`.
- Manual device test pending server-file deploy: article link opens app; uploads PDF downloads in browser (Android 12+ direct; Android 8–11 via Custom Tab bounce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
