### PR TITLE
Fix deep-link 404 on single-segment WordPress pages

### DIFF
--- a/__tests__/app/category/LoadArticle.test.tsx
+++ b/__tests__/app/category/LoadArticle.test.tsx
@@ -27,12 +27,15 @@ jest.mock("#/helpers/utils/feeds", () => ({
 
 jest.mock("#/helpers/Stores/ContentStore", () => ({
   __esModule: true,
-  default: { getStoredArticle: jest.fn(async () => null) },
+  default: { getStoredArticle: jest.fn(() => Promise.resolve(null)) },
 }));
 
 jest.mock("#/helpers/network/WordPressAPI", () => ({
   __esModule: true,
-  default: { getPost: jest.fn(async () => null), create: jest.fn(() => null) },
+  default: {
+    getPost: jest.fn(() => Promise.resolve(null)),
+    create: jest.fn(() => null),
+  },
 }));
 
 const webviewUri = () => {

--- a/__tests__/app/category/LoadArticle.test.tsx
+++ b/__tests__/app/category/LoadArticle.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react-native";
+import { render, waitFor } from "@testing-library/react-native";
 import React from "react";
 
 import LoadArticle from "#/app/[category]/[slug]";
@@ -23,6 +23,16 @@ jest.mock("#/constants/Config", () => ({
 
 jest.mock("#/helpers/utils/feeds", () => ({
   findSecondaryWpFeed: jest.fn(() => undefined),
+}));
+
+jest.mock("#/helpers/Stores/ContentStore", () => ({
+  __esModule: true,
+  default: { getStoredArticle: jest.fn(async () => null) },
+}));
+
+jest.mock("#/helpers/network/WordPressAPI", () => ({
+  __esModule: true,
+  default: { getPost: jest.fn(async () => null), create: jest.fn(() => null) },
 }));
 
 const webviewUri = () => {
@@ -63,5 +73,29 @@ describe("LoadArticle single-segment page (no slug)", () => {
     expect(webviewUri()).toBe(
       "https://volksverpetzer.de/stellenausschreibung-redaktion/",
     );
+  });
+});
+
+describe("LoadArticle article fallback (slug not found)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("builds a trailing-slash /category/slug/ URL when the API has no post", async () => {
+    const { useLocalSearchParams } = jest.requireMock("expo-router");
+    useLocalSearchParams.mockReturnValue({
+      category: "klima",
+      slug: "some-slug",
+    });
+
+    // No cached article and no post from the API -> hasError webview fallback.
+    render(<LoadArticle />);
+
+    await waitFor(() => {
+      const EdgelessWebview = jest.requireMock(
+        "#/screens/Home/components/EdgelessWebview",
+      );
+      expect(EdgelessWebview).toHaveBeenCalled();
+    });
+
+    expect(webviewUri()).toBe("https://volksverpetzer.de/klima/some-slug/");
   });
 });

--- a/__tests__/app/category/LoadArticle.test.tsx
+++ b/__tests__/app/category/LoadArticle.test.tsx
@@ -1,0 +1,67 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+
+import LoadArticle from "#/app/[category]/[slug]";
+
+// The webview is the fallback surface we assert on; capture its `uri` prop.
+jest.mock("#/screens/Home/components/EdgelessWebview", () =>
+  jest.fn(() => null),
+);
+jest.mock("#/screens/Home/components/article/Article", () =>
+  jest.fn(() => null),
+);
+jest.mock("#/components/ui/UiSpinner", () => jest.fn(() => null));
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: jest.fn(() => ({})),
+}));
+
+jest.mock("#/constants/Config", () => ({
+  __esModule: true,
+  default: { wpUrl: "https://volksverpetzer.de", feeds: { wp: [] } },
+}));
+
+jest.mock("#/helpers/utils/feeds", () => ({
+  findSecondaryWpFeed: jest.fn(() => undefined),
+}));
+
+const webviewUri = () => {
+  const EdgelessWebview = jest.requireMock(
+    "#/screens/Home/components/EdgelessWebview",
+  );
+  const [props] = EdgelessWebview.mock.calls.at(-1);
+  return props.uri as string;
+};
+
+describe("LoadArticle single-segment page (no slug)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("builds a trailing-slash URL so WordPress does not 404", () => {
+    const { useLocalSearchParams } = jest.requireMock("expo-router");
+    useLocalSearchParams.mockReturnValue({
+      category: "stellenausschreibung-redaktion",
+    });
+
+    render(<LoadArticle />);
+
+    // Regression: the slashless form (…/stellenausschreibung-redaktion) is a
+    // hard 404 on the live site; the trailing slash is the canonical permalink.
+    expect(webviewUri()).toBe(
+      "https://volksverpetzer.de/stellenausschreibung-redaktion/",
+    );
+  });
+
+  it("prefers the original deep-link URL verbatim when present", () => {
+    const { useLocalSearchParams } = jest.requireMock("expo-router");
+    useLocalSearchParams.mockReturnValue({
+      category: "stellenausschreibung-redaktion",
+      originalUrl: "https://volksverpetzer.de/stellenausschreibung-redaktion/",
+    });
+
+    render(<LoadArticle />);
+
+    expect(webviewUri()).toBe(
+      "https://volksverpetzer.de/stellenausschreibung-redaktion/",
+    );
+  });
+});

--- a/src/app/[category]/[slug].tsx
+++ b/src/app/[category]/[slug].tsx
@@ -111,7 +111,16 @@ const LoadArticle = () => {
 
   if (!slug) {
     const baseUrl = secondaryWp?.handle ?? wpUrl;
-    const url = originalUrl ?? `${baseUrl}/${category || ""}`;
+    // WordPress permalinks are trailing-slash canonical and 404 (no redirect)
+    // on the slashless form, so rebuild with a trailing slash. The incoming
+    // deep link had one, but expo-router strips it when parsing the param.
+    const trimmedBase = baseUrl.replace(/\/+$/, "");
+    const trimmedCategory = (category || "").replaceAll(/^\/+|\/+$/g, "");
+    const url =
+      originalUrl ??
+      (trimmedCategory
+        ? `${trimmedBase}/${trimmedCategory}/`
+        : `${trimmedBase}/`);
     return <EdgelessWebview uri={url as HttpsUrl} />;
   }
 
@@ -146,7 +155,9 @@ const LoadArticle = () => {
         .filter((s): s is string => Boolean(s))
         .map((s) => s.replaceAll(/^\/+|\/+$/g, ""))
         .join("/");
-      return path ? `${trimmedBase}/${path}` : trimmedBase;
+      // Trailing slash to match WordPress's canonical permalink form, which
+      // otherwise 404s on the slashless URL (see the !slug branch above).
+      return path ? `${trimmedBase}/${path}/` : trimmedBase;
     };
 
     const cleanPath = buildFallbackUrl(wpUrl, category, slug);


### PR DESCRIPTION
## Problem

Deep links to top-level WordPress **pages** (e.g. `volksverpetzer.de/stellenausschreibung-redaktion/`) opened the site's own 404 inside the app's webview instead of the page. Reported on Android.

## Root cause

Not the app's `+not-found` screen — the link resolves correctly to `[category]/index` (verified by driving expo-router's real `getStateFromPath`). But expo-router **strips the trailing slash** when parsing it into the `category` route param. The `!slug` webview fallback in `src/app/[category]/[slug].tsx` then rebuilt the URL as `${wpUrl}/${category}` — without the slash.

WordPress here uses trailing-slash canonical permalinks and hard-404s on the slashless form instead of redirecting:

```
HTTP 404  …/stellenausschreibung-redaktion
HTTP 200  …/stellenausschreibung-redaktion/
```

## Fix

- `!slug` single-segment page branch now rebuilds with a trailing slash, and still prefers `originalUrl` verbatim when present.
- The `hasError` article fallback (`buildFallbackUrl`) had the same trailing-slash loss for `/category/slug/` articles that fall back to webview — also fixed.

## Testing

- Confirmed the fixed URL returns HTTP 200 against the live site.
- Added `__tests__/app/category/LoadArticle.test.tsx` (2 regression tests).
- Full suite green (834 passing), `pnpm lint` 0 errors, `pnpm check:ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)