### PR TITLE
Upgrade @testing-library/react-native to 14 (async test API migration)

### DIFF
--- a/__tests__/IframeRenderer.test.tsx
+++ b/__tests__/IframeRenderer.test.tsx
@@ -72,7 +72,7 @@ describe("IframeRenderer dynamic height", () => {
 
     const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <IframeRenderer
         renderProps={renderProps}
         width={360}
@@ -129,7 +129,7 @@ describe("IframeRenderer dynamic height", () => {
 
     const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <IframeRenderer
         renderProps={renderProps}
         width={360}
@@ -185,7 +185,7 @@ describe("IframeRenderer dynamic height", () => {
 
     const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <IframeRenderer
         renderProps={renderProps}
         width={360}
@@ -241,7 +241,7 @@ describe("IframeRenderer dynamic height", () => {
 
     const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <IframeRenderer
         renderProps={renderProps}
         width={360}
@@ -297,7 +297,7 @@ describe("IframeRenderer dynamic height", () => {
 
     const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <IframeRenderer
         renderProps={renderProps}
         width={360}
@@ -353,7 +353,7 @@ describe("IframeRenderer dynamic height", () => {
     expect(height).toBe(360);
   });
 
-  it("should add dark parameter to Datawrapper URLs based on color scheme", () => {
+  it("should add dark parameter to Datawrapper URLs based on color scheme", async () => {
     const onLinkPress = jest.fn();
     const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -367,7 +367,7 @@ describe("IframeRenderer dynamic height", () => {
       },
     });
 
-    render(
+    await render(
       <IframeRenderer
         renderProps={renderProps}
         width={360}
@@ -382,7 +382,7 @@ describe("IframeRenderer dynamic height", () => {
     expect(resultUrl.searchParams.get("dark")).toBe("true");
   });
 
-  it("should add dark=false parameter to Datawrapper URLs in light mode", () => {
+  it("should add dark=false parameter to Datawrapper URLs in light mode", async () => {
     const onLinkPress = jest.fn();
     const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -396,7 +396,7 @@ describe("IframeRenderer dynamic height", () => {
       },
     });
 
-    render(
+    await render(
       <IframeRenderer
         renderProps={renderProps}
         width={360}
@@ -427,7 +427,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
   });
 
   describe("YouTube URL handling", () => {
-    it("should disable autoplay parameter for youtube.com URLs", () => {
+    it("should disable autoplay parameter for youtube.com URLs", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -437,7 +437,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      render(
+      await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -452,7 +452,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
       expect(resultUrl.searchParams.get("start")).toBe("10");
     });
 
-    it("should add Referer header for youtube.com URLs", () => {
+    it("should add Referer header for youtube.com URLs", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -462,7 +462,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      render(
+      await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -476,7 +476,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
       expect(typeof mockLastWebViewProps.source.headers.Referer).toBe("string");
     });
 
-    it("should handle youtube-nocookie.com URLs", () => {
+    it("should handle youtube-nocookie.com URLs", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -486,7 +486,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      render(
+      await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -502,7 +502,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
       expect(mockLastWebViewProps.source.headers).toHaveProperty("Referer");
     });
 
-    it("should handle youtu.be URLs", () => {
+    it("should handle youtu.be URLs", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -512,7 +512,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      render(
+      await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -529,7 +529,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
   });
 
   describe("Non-YouTube/non-Datawrapper URL pass-through", () => {
-    it("should pass through regular URLs without modification", () => {
+    it("should pass through regular URLs without modification", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -540,7 +540,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      render(
+      await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -553,7 +553,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
       expect(mockLastWebViewProps.source.headers).toBeUndefined();
     });
 
-    it("should pass through Vimeo URLs without modification", () => {
+    it("should pass through Vimeo URLs without modification", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -564,7 +564,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      render(
+      await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -577,7 +577,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
       expect(mockLastWebViewProps.source.headers).toBeUndefined();
     });
 
-    it("should pass through Twitter embed URLs without modification", () => {
+    it("should pass through Twitter embed URLs without modification", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -588,7 +588,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      render(
+      await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -603,7 +603,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
   });
 
   describe("Invalid URL handling", () => {
-    it("should render ErrorCard when URL has no hostname", () => {
+    it("should render ErrorCard when URL has no hostname", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -621,7 +621,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      const { getByText } = render(
+      const { getByText } = await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -635,7 +635,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
       parseSpy.mockRestore();
     });
 
-    it("should render ErrorCard when Linking.parse returns undefined hostname", () => {
+    it("should render ErrorCard when Linking.parse returns undefined hostname", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -653,7 +653,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      const { getByText } = render(
+      const { getByText } = await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -669,7 +669,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
   });
 
   describe("URL constructor failure handling", () => {
-    it("should handle valid YouTube URLs correctly", () => {
+    it("should handle valid YouTube URLs correctly", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -680,7 +680,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      render(
+      await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}
@@ -697,7 +697,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
       expect(mockLastWebViewProps.source.headers).toBeDefined();
     });
 
-    it("should handle minimal valid YouTube URLs", () => {
+    it("should handle minimal valid YouTube URLs", async () => {
       const onLinkPress = jest.fn();
       const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -708,7 +708,7 @@ describe("IframeRenderer prepareWebViewSource", () => {
         },
       });
 
-      render(
+      await render(
         <IframeRenderer
           renderProps={renderProps}
           width={360}

--- a/__tests__/app/NotFound.test.tsx
+++ b/__tests__/app/NotFound.test.tsx
@@ -33,13 +33,13 @@ jest.mock("#/constants/Colors", () => ({
 }));
 
 describe("NotFoundScreen", () => {
-  it("renders the 404 heading", () => {
-    const { getByTestId } = render(<NotFoundScreen />);
+  it("renders the 404 heading", async () => {
+    const { getByTestId } = await render(<NotFoundScreen />);
     expect(getByTestId("heading").props.children).toBe("404 Whoops!");
   });
 
-  it("renders the error message", () => {
-    const { getByTestId } = render(<NotFoundScreen />);
+  it("renders the error message", async () => {
+    const { getByTestId } = await render(<NotFoundScreen />);
     expect(getByTestId("empty-text").props.children).toBe(
       "Die angeforderte Seite konnte nicht gefunden werden.",
     );

--- a/__tests__/app/Onboarding.test.tsx
+++ b/__tests__/app/Onboarding.test.tsx
@@ -132,25 +132,25 @@ describe("Onboarding", () => {
   });
 
   describe("notification step visibility", () => {
-    it("includes the notifications step when IS_FOSS is false", () => {
+    it("includes the notifications step when IS_FOSS is false", async () => {
       mockIsFoss = false;
-      render(<Onboarding />);
+      await render(<Onboarding />);
 
       const ids = capturedData.map((s) => s.id);
       expect(ids).toContain(NOTIFICATION_STEP_ID);
     });
 
-    it("excludes the notifications step when IS_FOSS is true", () => {
+    it("excludes the notifications step when IS_FOSS is true", async () => {
       mockIsFoss = true;
-      render(<Onboarding />);
+      await render(<Onboarding />);
 
       const ids = capturedData.map((s) => s.id);
       expect(ids).not.toContain(NOTIFICATION_STEP_ID);
     });
 
-    it("keeps all other steps when IS_FOSS is true", () => {
+    it("keeps all other steps when IS_FOSS is true", async () => {
       mockIsFoss = true;
-      render(<Onboarding />);
+      await render(<Onboarding />);
 
       const ids = capturedData.map((s) => s.id);
       expect(ids).toContain(1); // Welcome
@@ -162,7 +162,7 @@ describe("Onboarding", () => {
   describe("agreeToTerms (onFinish callback)", () => {
     it("calls registerForPushNotifications when IS_FOSS is false", async () => {
       mockIsFoss = false;
-      render(<Onboarding />);
+      await render(<Onboarding />);
 
       await capturedOnFinish!();
 
@@ -174,7 +174,7 @@ describe("Onboarding", () => {
 
     it("skips registerForPushNotifications when IS_FOSS is true", async () => {
       mockIsFoss = true;
-      render(<Onboarding />);
+      await render(<Onboarding />);
 
       await capturedOnFinish!();
 
@@ -184,7 +184,7 @@ describe("Onboarding", () => {
 
     it("still completes onboarding when IS_FOSS is true", async () => {
       mockIsFoss = true;
-      render(<Onboarding />);
+      await render(<Onboarding />);
 
       await capturedOnFinish!();
 

--- a/__tests__/app/Personal.test.tsx
+++ b/__tests__/app/Personal.test.tsx
@@ -48,28 +48,28 @@ jest.mock("@react-native-vector-icons/octicons/static", () => ({
 }));
 
 describe("PersonalTab", () => {
-  it("renders Favoriten and Quellen tab buttons", () => {
-    const { getByRole } = render(<PersonalTab />);
+  it("renders Favoriten and Quellen tab buttons", async () => {
+    const { getByRole } = await render(<PersonalTab />);
     expect(getByRole("tab", { name: "Favoriten" })).toBeTruthy();
     expect(getByRole("tab", { name: "Quellen" })).toBeTruthy();
   });
 
-  it("shows MyFavs by default", () => {
-    const { getByText } = render(<PersonalTab />);
+  it("shows MyFavs by default", async () => {
+    const { getByText } = await render(<PersonalTab />);
     expect(getByText("MyFavs")).toBeTruthy();
   });
 
-  it("switches to MySources when Quellen tab is pressed", () => {
-    const { getByRole, getByText, queryByText } = render(<PersonalTab />);
-    fireEvent.press(getByRole("tab", { name: "Quellen" }));
+  it("switches to MySources when Quellen tab is pressed", async () => {
+    const { getByRole, getByText, queryByText } = await render(<PersonalTab />);
+    await fireEvent.press(getByRole("tab", { name: "Quellen" }));
     expect(getByText("MySources")).toBeTruthy();
     expect(queryByText("MyFavs")).toBeNull();
   });
 
-  it("switches back to MyFavs when Favoriten tab is pressed", () => {
-    const { getByRole, getByText, queryByText } = render(<PersonalTab />);
-    fireEvent.press(getByRole("tab", { name: "Quellen" }));
-    fireEvent.press(getByRole("tab", { name: "Favoriten" }));
+  it("switches back to MyFavs when Favoriten tab is pressed", async () => {
+    const { getByRole, getByText, queryByText } = await render(<PersonalTab />);
+    await fireEvent.press(getByRole("tab", { name: "Quellen" }));
+    await fireEvent.press(getByRole("tab", { name: "Favoriten" }));
     expect(getByText("MyFavs")).toBeTruthy();
     expect(queryByText("MySources")).toBeNull();
   });

--- a/__tests__/app/Search.test.tsx
+++ b/__tests__/app/Search.test.tsx
@@ -106,89 +106,89 @@ describe("SearchScreen", () => {
   beforeEach(() => jest.clearAllMocks());
 
   describe("default state (Artikel tab)", () => {
-    it("shows the Artikel tab tutorial on initial render", () => {
-      const { queryByTestId } = render(<SearchScreen />);
+    it("shows the Artikel tab tutorial on initial render", async () => {
+      const { queryByTestId } = await render(<SearchScreen />);
       expect(queryByTestId("tutorial-artikel")).not.toBeNull();
       expect(queryByTestId("tutorial-ai")).toBeNull();
     });
 
-    it("does not show FaktenBot header on initial render", () => {
-      const { queryByTestId } = render(<SearchScreen />);
+    it("does not show FaktenBot header on initial render", async () => {
+      const { queryByTestId } = await render(<SearchScreen />);
       expect(queryByTestId("faktenbot-active")).toBeNull();
     });
 
-    it("typing alone does not show results", () => {
-      const { getByTestId, queryByTestId } = render(<SearchScreen />);
-      fireEvent.changeText(getByTestId("search-input"), "corona");
+    it("typing alone does not show results", async () => {
+      const { getByTestId, queryByTestId } = await render(<SearchScreen />);
+      await fireEvent.changeText(getByTestId("search-input"), "corona");
       expect(queryByTestId("algolia-results")).toBeNull();
       expect(queryByTestId("tutorial-artikel")).not.toBeNull();
     });
 
-    it("shows Algolia results after submitting a 2+ character search", () => {
-      const { getByTestId, queryByTestId } = render(<SearchScreen />);
-      fireEvent.changeText(getByTestId("search-input"), "co");
-      fireEvent(getByTestId("search-input"), "submitEditing");
+    it("shows Algolia results after submitting a 2+ character search", async () => {
+      const { getByTestId, queryByTestId } = await render(<SearchScreen />);
+      await fireEvent.changeText(getByTestId("search-input"), "co");
+      await fireEvent(getByTestId("search-input"), "submitEditing");
       expect(queryByTestId("algolia-results")).not.toBeNull();
       expect(queryByTestId("tutorial-artikel")).toBeNull();
     });
 
-    it("passes the submitted search string to AlgoliaSearchResults", () => {
-      const { getByTestId } = render(<SearchScreen />);
-      fireEvent.changeText(getByTestId("search-input"), "corona");
-      fireEvent(getByTestId("search-input"), "submitEditing");
+    it("passes the submitted search string to AlgoliaSearchResults", async () => {
+      const { getByTestId } = await render(<SearchScreen />);
+      await fireEvent.changeText(getByTestId("search-input"), "corona");
+      await fireEvent(getByTestId("search-input"), "submitEditing");
       expect(getByTestId("algolia-results").props.children).toBe("corona");
     });
   });
 
   describe("tab switching", () => {
-    it("switches to AI tab when pressing KI-Faktenbot button", () => {
-      const { getByRole, queryByTestId } = render(<SearchScreen />);
-      fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
+    it("switches to AI tab when pressing KI-Faktenbot button", async () => {
+      const { getByRole, queryByTestId } = await render(<SearchScreen />);
+      await fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
       expect(queryByTestId("tutorial-ai")).not.toBeNull();
       expect(queryByTestId("tutorial-artikel")).toBeNull();
     });
 
-    it("activates FaktenBot header when on AI tab", () => {
-      const { getByRole, queryByTestId } = render(<SearchScreen />);
-      fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
+    it("activates FaktenBot header when on AI tab", async () => {
+      const { getByRole, queryByTestId } = await render(<SearchScreen />);
+      await fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
       expect(queryByTestId("faktenbot-active")).not.toBeNull();
     });
 
-    it("switches back to Artikel tab", () => {
-      const { getByRole, queryByTestId } = render(<SearchScreen />);
-      fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
-      fireEvent.press(getByRole("tab", { name: "Artikel" }));
+    it("switches back to Artikel tab", async () => {
+      const { getByRole, queryByTestId } = await render(<SearchScreen />);
+      await fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
+      await fireEvent.press(getByRole("tab", { name: "Artikel" }));
       expect(queryByTestId("tutorial-artikel")).not.toBeNull();
       expect(queryByTestId("tutorial-ai")).toBeNull();
     });
   });
 
   describe("AI tab", () => {
-    it("typing alone does not trigger AI search", () => {
-      const { getByTestId, getByRole, queryByTestId } = render(
+    it("typing alone does not trigger AI search", async () => {
+      const { getByTestId, getByRole, queryByTestId } = await render(
         <SearchScreen />,
       );
-      fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
-      fireEvent.changeText(getByTestId("search-input"), "corona");
+      await fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
+      await fireEvent.changeText(getByTestId("search-input"), "corona");
       expect(queryByTestId("ai-results")).toBeNull();
       expect(queryByTestId("tutorial-ai")).not.toBeNull();
     });
 
-    it("shows AI results after submitting", () => {
-      const { getByTestId, getByRole, queryByTestId } = render(
+    it("shows AI results after submitting", async () => {
+      const { getByTestId, getByRole, queryByTestId } = await render(
         <SearchScreen />,
       );
-      fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
-      fireEvent.changeText(getByTestId("search-input"), "corona");
-      fireEvent(getByTestId("search-input"), "submitEditing");
+      await fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
+      await fireEvent.changeText(getByTestId("search-input"), "corona");
+      await fireEvent(getByTestId("search-input"), "submitEditing");
       expect(queryByTestId("ai-results")).not.toBeNull();
     });
 
-    it("passes the submitted string to AISearch", () => {
-      const { getByTestId, getByRole } = render(<SearchScreen />);
-      fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
-      fireEvent.changeText(getByTestId("search-input"), "corona");
-      fireEvent(getByTestId("search-input"), "submitEditing");
+    it("passes the submitted string to AISearch", async () => {
+      const { getByTestId, getByRole } = await render(<SearchScreen />);
+      await fireEvent.press(getByRole("tab", { name: "KI-Faktenbot" }));
+      await fireEvent.changeText(getByTestId("search-input"), "corona");
+      await fireEvent(getByTestId("search-input"), "submitEditing");
       expect(getByTestId("ai-results").props.children).toBe("corona");
     });
   });

--- a/__tests__/app/Settings.test.tsx
+++ b/__tests__/app/Settings.test.tsx
@@ -157,37 +157,37 @@ describe("SettingsScreen", () => {
   });
 
   describe("notifications collapsable", () => {
-    it("is visible when not FOSS", () => {
+    it("is visible when not FOSS", async () => {
       mockIsFoss = false;
-      const { queryByText } = render(<SettingsScreen />);
+      const { queryByText } = await render(<SettingsScreen />);
       expect(queryByText("Benachrichtigungen")).not.toBeNull();
     });
 
-    it("is hidden when FOSS", () => {
+    it("is hidden when FOSS", async () => {
       mockIsFoss = true;
-      const { queryByText } = render(<SettingsScreen />);
+      const { queryByText } = await render(<SettingsScreen />);
       expect(queryByText("Benachrichtigungen")).toBeNull();
     });
   });
 
   describe("notification reset button", () => {
-    it("is visible when not FOSS", () => {
+    it("is visible when not FOSS", async () => {
       mockIsFoss = false;
-      const { queryByText } = render(<SettingsScreen />);
+      const { queryByText } = await render(<SettingsScreen />);
       expect(queryByText("Benachrichtigungen zurücksetzen")).not.toBeNull();
     });
 
-    it("is hidden when FOSS", () => {
+    it("is hidden when FOSS", async () => {
       mockIsFoss = true;
-      const { queryByText } = render(<SettingsScreen />);
+      const { queryByText } = await render(<SettingsScreen />);
       expect(queryByText("Benachrichtigungen zurücksetzen")).toBeNull();
     });
   });
 
   describe("notification reset button confirmation flow", () => {
-    it("shows a confirm toast when pressed", () => {
-      const { getByText } = render(<SettingsScreen />);
-      fireEvent.press(getByText("Benachrichtigungen zurücksetzen"));
+    it("shows a confirm toast when pressed", async () => {
+      const { getByText } = await render(<SettingsScreen />);
+      await fireEvent.press(getByText("Benachrichtigungen zurücksetzen"));
       expect(jest.mocked(toast.confirm)).toHaveBeenCalledWith(
         "Benachrichtigungen zurücksetzen?",
         expect.any(String),
@@ -195,12 +195,12 @@ describe("SettingsScreen", () => {
       );
     });
 
-    it("calls registerForPushNotifications and shows success toast on confirm", () => {
+    it("calls registerForPushNotifications and shows success toast on confirm", async () => {
       const Notifications = jest.requireMock("#/helpers/Notifications") as {
         default: { registerForPushNotifications: jest.Mock };
       };
-      const { getByText } = render(<SettingsScreen />);
-      fireEvent.press(getByText("Benachrichtigungen zurücksetzen"));
+      const { getByText } = await render(<SettingsScreen />);
+      await fireEvent.press(getByText("Benachrichtigungen zurücksetzen"));
       const onConfirm = jest.mocked(toast.confirm).mock.calls[0][2];
       onConfirm();
       expect(
@@ -211,9 +211,9 @@ describe("SettingsScreen", () => {
   });
 
   describe("achievements reset button confirmation flow", () => {
-    it("shows a confirm toast when pressed", () => {
-      const { getByText } = render(<SettingsScreen />);
-      fireEvent.press(getByText("Alle Erfolge zurücksetzen"));
+    it("shows a confirm toast when pressed", async () => {
+      const { getByText } = await render(<SettingsScreen />);
+      await fireEvent.press(getByText("Alle Erfolge zurücksetzen"));
       expect(jest.mocked(toast.confirm)).toHaveBeenCalledWith(
         "Erfolge zurücksetzen?",
         expect.any(String),
@@ -221,12 +221,12 @@ describe("SettingsScreen", () => {
       );
     });
 
-    it("resets achievements and shows success toast on confirm", () => {
+    it("resets achievements and shows success toast on confirm", async () => {
       const { Achievements } = jest.requireMock("#/helpers/Achievements") as {
         Achievements: { resetEverything: jest.Mock };
       };
-      const { getByText } = render(<SettingsScreen />);
-      fireEvent.press(getByText("Alle Erfolge zurücksetzen"));
+      const { getByText } = await render(<SettingsScreen />);
+      await fireEvent.press(getByText("Alle Erfolge zurücksetzen"));
       const onConfirm = jest.mocked(toast.confirm).mock.calls[0][2];
       onConfirm();
       expect(Achievements.resetEverything).toHaveBeenCalled();
@@ -235,9 +235,9 @@ describe("SettingsScreen", () => {
   });
 
   describe("intro reset button confirmation flow", () => {
-    it("shows a confirm toast when pressed", () => {
-      const { getByText } = render(<SettingsScreen />);
-      fireEvent.press(getByText("Intro zurücksetzen"));
+    it("shows a confirm toast when pressed", async () => {
+      const { getByText } = await render(<SettingsScreen />);
+      await fireEvent.press(getByText("Intro zurücksetzen"));
       expect(jest.mocked(toast.confirm)).toHaveBeenCalledWith(
         "Intro zurücksetzen?",
         "Intro erscheint beim nächsten Start erneut",
@@ -245,15 +245,15 @@ describe("SettingsScreen", () => {
       );
     });
 
-    it("resets onboarding state and shows success toast on confirm", () => {
+    it("resets onboarding state and shows success toast on confirm", async () => {
       const mock = jest.requireMock("#/helpers/Stores/PersonalStore") as {
         default: {
           setOnboardingDone: jest.Mock;
           setLastSeenChangelogVersionCode: jest.Mock;
         };
       };
-      const { getByText } = render(<SettingsScreen />);
-      fireEvent.press(getByText("Intro zurücksetzen"));
+      const { getByText } = await render(<SettingsScreen />);
+      await fireEvent.press(getByText("Intro zurücksetzen"));
       const onConfirm = jest.mocked(toast.confirm).mock.calls[0][2];
       onConfirm();
       expect(mock.default.setOnboardingDone).toHaveBeenCalledWith(false);
@@ -268,15 +268,15 @@ describe("SettingsScreen", () => {
   });
 
   describe("backup (import/export)", () => {
-    it("is visible when enableEngagement is true", () => {
+    it("is visible when enableEngagement is true", async () => {
       mockEnableEngagement = true;
-      const { queryByText } = render(<SettingsScreen />);
+      const { queryByText } = await render(<SettingsScreen />);
       expect(queryByText("BackupView")).not.toBeNull();
     });
 
-    it("is hidden when enableEngagement is false", () => {
+    it("is hidden when enableEngagement is false", async () => {
       mockEnableEngagement = false;
-      const { queryByText } = render(<SettingsScreen />);
+      const { queryByText } = await render(<SettingsScreen />);
       expect(queryByText("BackupView")).toBeNull();
     });
   });
@@ -286,15 +286,15 @@ describe("SettingsScreen", () => {
       mockIsFoss = false;
     });
 
-    it("shows ' - FOSS' suffix when FOSS", () => {
+    it("shows ' - FOSS' suffix when FOSS", async () => {
       mockIsFoss = true;
-      const { queryByText } = render(<SettingsScreen />);
+      const { queryByText } = await render(<SettingsScreen />);
       expect(queryByText(/ - FOSS/)).not.toBeNull();
     });
 
-    it("does not show FOSS suffix when not FOSS", () => {
+    it("does not show FOSS suffix when not FOSS", async () => {
       mockIsFoss = false;
-      const { queryByText } = render(<SettingsScreen />);
+      const { queryByText } = await render(<SettingsScreen />);
       expect(queryByText(/ - FOSS/)).toBeNull();
     });
   });

--- a/__tests__/app/TabsNavigation.test.tsx
+++ b/__tests__/app/TabsNavigation.test.tsx
@@ -55,15 +55,15 @@ describe("TabsNavigation", () => {
     Config.enableEngagement = true;
   });
 
-  it("should hide personal tab when favorites are disabled", () => {
+  it("should hide personal tab when favorites are disabled", async () => {
     Config.enableEngagement = false;
-    render(<TabLayout />);
+    await render(<TabLayout />);
     expect(getPersonalTriggerProps()?.hidden).toBe(true);
   });
 
-  it("should show personal tab when favorites are enabled", () => {
+  it("should show personal tab when favorites are enabled", async () => {
     Config.enableEngagement = true;
-    render(<TabLayout />);
+    await render(<TabLayout />);
     expect(getPersonalTriggerProps()?.hidden).toBe(false);
   });
 });

--- a/__tests__/app/bsky/BskyScreen.test.tsx
+++ b/__tests__/app/bsky/BskyScreen.test.tsx
@@ -52,9 +52,9 @@ const makeMockPost = () => ({
 describe("BskyScreen", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("shows spinner while post is loading", () => {
+  it("shows spinner while post is loading", async () => {
     ContentStore.getStoredBskyPostById.mockReturnValue(new Promise(() => {}));
-    const { getByTestId } = render(<BskyScreen />);
+    const { getByTestId } = await render(<BskyScreen />);
     expect(getByTestId("spinner")).toBeTruthy();
   });
 
@@ -64,7 +64,7 @@ describe("BskyScreen", () => {
     );
     ContentStore.getStoredBskyPostById.mockResolvedValue(makeMockPost());
 
-    render(<BskyScreen />);
+    await render(<BskyScreen />);
 
     await waitFor(() => {
       expect(BlueskyPostDetail).toHaveBeenCalled();
@@ -74,7 +74,7 @@ describe("BskyScreen", () => {
   it("calls router.back() when post is not found", async () => {
     ContentStore.getStoredBskyPostById.mockResolvedValue(null);
 
-    render(<BskyScreen />);
+    await render(<BskyScreen />);
 
     await waitFor(() => {
       expect(mockRouterBack).toHaveBeenCalledTimes(1);

--- a/__tests__/app/category/LoadArticle.test.tsx
+++ b/__tests__/app/category/LoadArticle.test.tsx
@@ -49,13 +49,13 @@ const webviewUri = () => {
 describe("LoadArticle single-segment page (no slug)", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("builds a trailing-slash URL so WordPress does not 404", () => {
+  it("builds a trailing-slash URL so WordPress does not 404", async () => {
     const { useLocalSearchParams } = jest.requireMock("expo-router");
     useLocalSearchParams.mockReturnValue({
       category: "stellenausschreibung-redaktion",
     });
 
-    render(<LoadArticle />);
+    await render(<LoadArticle />);
 
     // Regression: the slashless form (…/stellenausschreibung-redaktion) is a
     // hard 404 on the live site; the trailing slash is the canonical permalink.
@@ -64,14 +64,14 @@ describe("LoadArticle single-segment page (no slug)", () => {
     );
   });
 
-  it("prefers the original deep-link URL verbatim when present", () => {
+  it("prefers the original deep-link URL verbatim when present", async () => {
     const { useLocalSearchParams } = jest.requireMock("expo-router");
     useLocalSearchParams.mockReturnValue({
       category: "stellenausschreibung-redaktion",
       originalUrl: "https://volksverpetzer.de/stellenausschreibung-redaktion/",
     });
 
-    render(<LoadArticle />);
+    await render(<LoadArticle />);
 
     expect(webviewUri()).toBe(
       "https://volksverpetzer.de/stellenausschreibung-redaktion/",
@@ -90,7 +90,7 @@ describe("LoadArticle article fallback (slug not found)", () => {
     });
 
     // No cached article and no post from the API -> hasError webview fallback.
-    render(<LoadArticle />);
+    await render(<LoadArticle />);
 
     await waitFor(() => {
       const EdgelessWebview = jest.requireMock(

--- a/__tests__/app/image.test.tsx
+++ b/__tests__/app/image.test.tsx
@@ -35,46 +35,46 @@ jest.mock("#/constants/Colors", () => ({
 describe("ImageScreen", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("renders without crashing", () => {
-    const { toJSON } = render(<ImageScreen />);
+  it("renders without crashing", async () => {
+    const { toJSON } = await render(<ImageScreen />);
     expect(toJSON()).not.toBeNull();
   });
 
-  it("passes the uri from search params to the Image", () => {
+  it("passes the uri from search params to the Image", async () => {
     const { Image } = jest.requireMock("expo-image");
-    render(<ImageScreen />);
+    await render(<ImageScreen />);
     const [props] = Image.mock.calls[0];
     expect(props.source.uri).toBe("https://example.com/photo.jpg");
   });
 
-  it("renders the NavBar", () => {
+  it("renders the NavBar", async () => {
     const NavBar = jest.requireMock("#/components/bars/NavBar");
-    render(<ImageScreen />);
+    await render(<ImageScreen />);
     expect(NavBar).toHaveBeenCalled();
   });
 
-  it("applies background color from color scheme", () => {
-    const { toJSON } = render(<ImageScreen />);
+  it("applies background color from color scheme", async () => {
+    const { toJSON } = await render(<ImageScreen />);
     const root = toJSON() as any;
     expect(root.props.style).toEqual(
       expect.objectContaining({ backgroundColor: "#ffffff" }),
     );
   });
 
-  it("shows an empty state instead of the Image when uri is missing", () => {
+  it("shows an empty state instead of the Image when uri is missing", async () => {
     const { useLocalSearchParams } = jest.requireMock("expo-router");
     useLocalSearchParams.mockReturnValueOnce({});
     const { Image } = jest.requireMock("expo-image");
-    const { getByText } = render(<ImageScreen />);
+    const { getByText } = await render(<ImageScreen />);
     expect(Image).not.toHaveBeenCalled();
     expect(getByText("Bild konnte nicht geladen werden")).toBeTruthy();
   });
 
-  it("shows an empty state instead of the Image when uri is an array", () => {
+  it("shows an empty state instead of the Image when uri is an array", async () => {
     const { useLocalSearchParams } = jest.requireMock("expo-router");
     useLocalSearchParams.mockReturnValueOnce({ uri: ["a.jpg", "b.jpg"] });
     const { Image } = jest.requireMock("expo-image");
-    const { getByText } = render(<ImageScreen />);
+    const { getByText } = await render(<ImageScreen />);
     expect(Image).not.toHaveBeenCalled();
     expect(getByText("Bild konnte nicht geladen werden")).toBeTruthy();
   });

--- a/__tests__/app/insta/InstaScreen.test.tsx
+++ b/__tests__/app/insta/InstaScreen.test.tsx
@@ -76,9 +76,9 @@ const makeMockInstaPost = () => ({
 describe("InstaScreen", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("shows spinner while post is loading", () => {
+  it("shows spinner while post is loading", async () => {
     ContentStore.getStoredInstaPost.mockReturnValue(new Promise(() => {}));
-    const { getByTestId } = render(<InstaScreen />);
+    const { getByTestId } = await render(<InstaScreen />);
     expect(getByTestId("spinner")).toBeTruthy();
   });
 
@@ -88,7 +88,7 @@ describe("InstaScreen", () => {
     );
     ContentStore.getStoredInstaPost.mockResolvedValue(makeMockInstaPost());
 
-    render(<InstaScreen />);
+    await render(<InstaScreen />);
 
     await waitFor(() => {
       expect(InstaPostDetail).toHaveBeenCalled();
@@ -101,7 +101,7 @@ describe("InstaScreen", () => {
       .requireMock("#/helpers/network/ServerAPI")
       .default.getInstaPost.mockResolvedValue(null);
 
-    render(<InstaScreen />);
+    await render(<InstaScreen />);
 
     await waitFor(() => {
       expect(mockRouterBack).toHaveBeenCalledTimes(1);

--- a/__tests__/components/ActionTab/StatisticsView.test.tsx
+++ b/__tests__/components/ActionTab/StatisticsView.test.tsx
@@ -40,15 +40,15 @@ describe("StatisticsView chevron navigation", () => {
     reanimated.scrollTo.mockImplementation(mockScrollTo);
   });
 
-  it("right chevron scrolls to panel width", () => {
-    const { getByRole } = render(<StatisticsView />);
-    fireEvent.press(getByRole("button", { name: "Nächste Seite" }));
+  it("right chevron scrolls to panel width", async () => {
+    const { getByRole } = await render(<StatisticsView />);
+    await fireEvent.press(getByRole("button", { name: "Nächste Seite" }));
     expect(mockScrollTo).toHaveBeenCalledWith(expect.anything(), 300, 0, true);
   });
 
-  it("left chevron scrolls back to start", () => {
-    const { getByRole } = render(<StatisticsView />);
-    fireEvent.press(getByRole("button", { name: "Vorherige Seite" }));
+  it("left chevron scrolls back to start", async () => {
+    const { getByRole } = await render(<StatisticsView />);
+    await fireEvent.press(getByRole("button", { name: "Vorherige Seite" }));
     expect(mockScrollTo).toHaveBeenCalledWith(expect.anything(), 0, 0, true);
   });
 });

--- a/__tests__/components/ArticleRender/EmRenderer.test.tsx
+++ b/__tests__/components/ArticleRender/EmRenderer.test.tsx
@@ -31,8 +31,8 @@ const getFontFamily = (style: unknown): string | undefined => {
 };
 
 describe("EmRenderer font family", () => {
-  it("uses SourceSansProBoldItalic when parent is SourceSansProBold", () => {
-    const { getByTestId } = render(
+  it("uses SourceSansProBoldItalic when parent is SourceSansProBold", async () => {
+    const { getByTestId } = await render(
       EmRenderer(makeProps("SourceSansProBold")) as React.ReactElement,
     );
     expect(getFontFamily(getByTestId("em-text").props.style)).toBe(
@@ -40,8 +40,8 @@ describe("EmRenderer font family", () => {
     );
   });
 
-  it("uses SourceSansProItalic when parent has a non-bold font", () => {
-    const { getByTestId } = render(
+  it("uses SourceSansProItalic when parent has a non-bold font", async () => {
+    const { getByTestId } = await render(
       EmRenderer(makeProps("SourceSansPro")) as React.ReactElement,
     );
     expect(getFontFamily(getByTestId("em-text").props.style)).toBe(
@@ -49,8 +49,8 @@ describe("EmRenderer font family", () => {
     );
   });
 
-  it("uses SourceSansProItalic when parent has no font family", () => {
-    const { getByTestId } = render(
+  it("uses SourceSansProItalic when parent has no font family", async () => {
+    const { getByTestId } = await render(
       EmRenderer(makeProps()) as React.ReactElement,
     );
     expect(getFontFamily(getByTestId("em-text").props.style)).toBe(

--- a/__tests__/components/FavCounter.test.tsx
+++ b/__tests__/components/FavCounter.test.tsx
@@ -77,7 +77,7 @@ describe("FavCounter", () => {
         Promise.resolve(url === "https://example.com/one" ? 2 : 3),
       );
 
-    const { getByText } = render(
+    const { getByText } = await render(
       <FavCounter shareable={shareable} style={{}} />,
     );
 
@@ -101,7 +101,7 @@ describe("FavCounter", () => {
       permalink: "https://www.instagram.com/p/abc/",
     };
 
-    const { getByRole, getByText, queryByText } = render(
+    const { getByRole, getByText, queryByText } = await render(
       <FavCounter
         shareable={[shareable[0]]}
         style={{}}
@@ -116,7 +116,7 @@ describe("FavCounter", () => {
       expect(getByText("star-outline")).toBeTruthy();
     });
 
-    fireEvent.press(getByRole("button"));
+    await fireEvent.press(getByRole("button"));
 
     await waitFor(() => {
       expect(getByText("3")).toBeTruthy();
@@ -141,7 +141,7 @@ describe("FavCounter", () => {
   it("does not persist a favorite when contentType is missing", async () => {
     jest.mocked(getFavs).mockResolvedValue(2);
 
-    const { getByRole, getByText } = render(
+    const { getByRole, getByText } = await render(
       <FavCounter
         shareable={[shareable[0]]}
         style={{}}
@@ -151,7 +151,7 @@ describe("FavCounter", () => {
 
     await waitFor(() => expect(getByText("star-outline")).toBeTruthy());
 
-    fireEvent.press(getByRole("button"));
+    await fireEvent.press(getByRole("button"));
 
     await waitFor(() =>
       expect(FavoritesStore.addFavorite).not.toHaveBeenCalled(),
@@ -166,7 +166,7 @@ describe("FavCounter", () => {
     jest.mocked(FavoritesStore.isFavorite).mockResolvedValue(true);
     jest.mocked(getFavs).mockResolvedValue(4);
 
-    const { getByRole, getByText } = render(
+    const { getByRole, getByText } = await render(
       <FavCounter
         shareable={[shareable[0]]}
         style={{}}
@@ -180,7 +180,7 @@ describe("FavCounter", () => {
       expect(getByText("star-filled")).toBeTruthy();
     });
 
-    fireEvent.press(getByRole("button"));
+    await fireEvent.press(getByRole("button"));
 
     await waitFor(() => {
       expect(getByText("4")).toBeTruthy();
@@ -194,10 +194,10 @@ describe("FavCounter", () => {
     expect(registerFav).not.toHaveBeenCalled();
   });
 
-  it("renders an empty placeholder and skips engagement when disabled", () => {
+  it("renders an empty placeholder and skips engagement when disabled", async () => {
     mockConfig.enableEngagement = false;
 
-    const { queryByRole, queryByText } = render(
+    const { queryByRole, queryByText } = await render(
       <FavCounter
         shareable={shareable}
         style={{}}

--- a/__tests__/components/Loader.test.tsx
+++ b/__tests__/components/Loader.test.tsx
@@ -42,10 +42,10 @@ describe("Loader", () => {
     jest.restoreAllMocks();
   });
 
-  it("renders loading fallback while request is pending", () => {
+  it("renders loading fallback while request is pending", async () => {
     const deferred = createDeferred<{ value: string }>();
 
-    const { getByText } = render(
+    const { getByText } = await render(
       <Loader
         keyValue="id-1"
         load={() => deferred.promise}
@@ -61,7 +61,7 @@ describe("Loader", () => {
     const deferred = createDeferred<{ value: string }>();
     const onLoaded = jest.fn();
 
-    const { getByText } = render(
+    const { getByText } = await render(
       <Loader
         keyValue="id-2"
         load={() => deferred.promise}
@@ -81,7 +81,7 @@ describe("Loader", () => {
   it("renders default error fallback when loading fails", async () => {
     const deferred = createDeferred<{ value: string }>();
 
-    const { getByText } = render(
+    const { getByText } = await render(
       <Loader
         keyValue="id-3"
         load={() => deferred.promise}
@@ -103,7 +103,7 @@ describe("Loader", () => {
   it("renders custom error UI when renderError is provided", async () => {
     const deferred = createDeferred<{ value: string }>();
 
-    const { getByText, queryByText } = render(
+    const { getByText, queryByText } = await render(
       <Loader
         keyValue="id-4"
         load={() => deferred.promise}

--- a/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
+++ b/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
@@ -44,10 +44,15 @@ jest.mock("#/components/ui/UiSpace", () => ({
   default: jest.fn(() => null),
 }));
 
-jest.mock("#/components/ui/UiText", () => ({
-  __esModule: true,
-  default: jest.fn(({ children }) => children),
-}));
+jest.mock("#/components/ui/UiText", () => {
+  // Wrap children in a real Text: RNTL 14's renderer rejects raw string
+  // children inside a View (e.g. the empty-favorites hint), unlike v13.
+  const { Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: jest.fn(({ children }) => <Text>{children}</Text>),
+  };
+});
 
 jest.mock("#/components/posts/insta/InstaPostCard", () => ({
   __esModule: true,
@@ -152,7 +157,7 @@ describe("MyFavs", () => {
     );
     (API.getInstaPost as jest.Mock).mockResolvedValue(instaApiResponse);
 
-    render(<MyFavs />);
+    await render(<MyFavs />);
 
     await waitFor(() => {
       expect(GenericPost).toHaveBeenCalledTimes(2);
@@ -242,7 +247,7 @@ describe("MyFavs", () => {
       mappedPruefpunktPost,
     );
 
-    render(<MyFavs />);
+    await render(<MyFavs />);
 
     await waitFor(() => {
       expect(GenericPost).toHaveBeenCalledTimes(1);
@@ -274,7 +279,7 @@ describe("MyFavs", () => {
       },
     });
 
-    render(<MyFavs />);
+    await render(<MyFavs />);
 
     await waitFor(() => {
       expect(GenericPost).toHaveBeenCalledTimes(1);
@@ -342,7 +347,7 @@ describe("MyFavs", () => {
     );
     (API.getInstaPost as jest.Mock).mockRejectedValue(new Error("network"));
 
-    render(<MyFavs />);
+    await render(<MyFavs />);
 
     await waitFor(() => {
       expect(GenericPost).toHaveBeenCalledTimes(1);
@@ -414,7 +419,7 @@ describe("MyFavs", () => {
     );
     (FavoritesStore.removeFavorite as jest.Mock).mockResolvedValue(undefined);
 
-    render(<MyFavs />);
+    await render(<MyFavs />);
 
     await waitFor(() => {
       expect(GenericPost).toHaveBeenCalledTimes(1);
@@ -436,7 +441,7 @@ describe("MyFavs", () => {
   it("does not refresh favorites while the screen is unfocused", async () => {
     mockUseIsFocused.mockReturnValue(false);
 
-    render(<MyFavs />);
+    await render(<MyFavs />);
 
     await waitFor(() => {
       expect(FavoritesStore.getAllFavorites).not.toHaveBeenCalled();
@@ -467,24 +472,22 @@ describe("MyFavs", () => {
       .mockReturnValueOnce(firstRequest)
       .mockReturnValueOnce(secondRequest);
 
-    const { rerender } = render(<MyFavs />);
+    const { rerender } = await render(<MyFavs />);
 
     // Trigger a second request by toggling focused off and back on
-    act(() => {
+    await act(() => {
       mockUseIsFocused.mockReturnValue(false);
     });
-    rerender(<MyFavs />);
+    await rerender(<MyFavs />);
 
-    act(() => {
+    await act(() => {
       mockUseIsFocused.mockReturnValue(true);
     });
-    rerender(<MyFavs />);
+    await rerender(<MyFavs />);
 
-    // Resolve the second (newer) request first with one article
-    act(() => {
-      resolveSecond({ "newer-article": { contentType: FAV_TYPE_ARTICLE } });
-    });
-
+    // Wire the article mocks before resolving: RNTL 14's awaited act() flushes
+    // the favorites-processing chain synchronously, so getPost/mapArticleToPost
+    // must already be configured when the newer request resolves.
     const newerArticleApiResponse = {
       id: 2,
       date: "2026-01-02T12:00:00Z",
@@ -517,6 +520,11 @@ describe("MyFavs", () => {
       newerMappedPost,
     );
 
+    // Resolve the second (newer) request first with one article
+    await act(() => {
+      resolveSecond({ "newer-article": { contentType: FAV_TYPE_ARTICLE } });
+    });
+
     await waitFor(() => {
       expect(GenericPost).toHaveBeenCalledTimes(1);
     });
@@ -530,7 +538,7 @@ describe("MyFavs", () => {
 
     // Now resolve the first (older/stale) request — its results must be ignored
     (GenericPost as unknown as jest.Mock).mockClear();
-    act(() => {
+    await act(() => {
       resolveFirst({ "stale-article": { contentType: FAV_TYPE_ARTICLE } });
     });
 

--- a/__tests__/components/Settings/BackupView.test.tsx
+++ b/__tests__/components/Settings/BackupView.test.tsx
@@ -95,8 +95,8 @@ describe("BackupView", () => {
   });
 
   describe("rendering", () => {
-    it("shows export and import rows", () => {
-      const { getByText } = render(<BackupView />);
+    it("shows export and import rows", async () => {
+      const { getByText } = await render(<BackupView />);
       expect(getByText("Sammlung exportieren")).toBeTruthy();
       expect(getByText("Sammlung importieren")).toBeTruthy();
     });
@@ -111,8 +111,8 @@ describe("BackupView", () => {
         "https://example.com": { slug: "example" },
       } as any);
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung exportieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung exportieren"));
 
       await waitFor(() => {
         expect(FavoritesStore.getAllFavorites).toHaveBeenCalledTimes(1);
@@ -133,8 +133,8 @@ describe("BackupView", () => {
         "https://example.com": { slug: "example" },
       } as any);
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung exportieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung exportieren"));
 
       await waitFor(() => {
         expect(toast.success).toHaveBeenCalledWith(
@@ -149,8 +149,8 @@ describe("BackupView", () => {
         .mocked(FavoritesStore.getAllFavorites)
         .mockRejectedValue(new Error("disk full"));
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung exportieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung exportieren"));
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
@@ -170,8 +170,8 @@ describe("BackupView", () => {
       } as any);
       mockFileText.mockResolvedValue(validBackupJson);
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(FavoritesStore.setStoredFavs).toHaveBeenCalledTimes(1);
@@ -189,8 +189,8 @@ describe("BackupView", () => {
         assets: [],
       } as any);
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
@@ -207,8 +207,8 @@ describe("BackupView", () => {
         assets: [],
       } as any);
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(FavoritesStore.setStoredFavs).not.toHaveBeenCalled();
@@ -223,8 +223,8 @@ describe("BackupView", () => {
       } as any);
       mockFileText.mockResolvedValue(JSON.stringify([1, 2, 3]));
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
@@ -244,8 +244,8 @@ describe("BackupView", () => {
         JSON.stringify({ favorites: { abc: { contentType: "unknown" } } }),
       );
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
@@ -263,8 +263,8 @@ describe("BackupView", () => {
       } as any);
       mockFileText.mockResolvedValue(JSON.stringify({ other: "stuff" }));
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
@@ -281,8 +281,8 @@ describe("BackupView", () => {
       } as any);
       mockFileText.mockRejectedValue(new Error("read error"));
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
@@ -301,8 +301,8 @@ describe("BackupView", () => {
         JSON.stringify({ favorites: { abc: { contentType: "article" } } }),
       );
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(FavoritesStore.setStoredFavs).toHaveBeenCalledTimes(1);
@@ -325,8 +325,8 @@ describe("BackupView", () => {
         }),
       );
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(SourcesStore.setStoredSources).toHaveBeenCalledTimes(1);
@@ -347,8 +347,8 @@ describe("BackupView", () => {
         JSON.stringify({ sources: { "https://example.com": { slug: 99 } } }),
       );
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung importieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung importieren"));
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
@@ -369,8 +369,8 @@ describe("BackupView", () => {
         .mockResolvedValue(favorites as any);
       jest.mocked(SourcesStore.getAllSources).mockResolvedValue(sources as any);
 
-      const { getByText } = render(<BackupView />);
-      fireEvent.press(getByText("Sammlung exportieren"));
+      const { getByText } = await render(<BackupView />);
+      await fireEvent.press(getByText("Sammlung exportieren"));
 
       await waitFor(() => {
         expect(mockFileWrite).toHaveBeenCalledWith(

--- a/__tests__/components/ShareCounter.test.tsx
+++ b/__tests__/components/ShareCounter.test.tsx
@@ -45,7 +45,7 @@ describe("ShareCounter", () => {
         Promise.resolve(url === "https://example.com/one" ? 4 : 6),
       );
 
-    const { getByText } = render(
+    const { getByText } = await render(
       <ShareCounter
         shareable={shareable}
         shares={2}
@@ -64,8 +64,8 @@ describe("ShareCounter", () => {
     expect(getShares).toHaveBeenNthCalledWith(2, "https://example.com/two");
   });
 
-  it("skips fetching remote counts when the count is hidden", () => {
-    const { getByText } = render(
+  it("skips fetching remote counts when the count is hidden", async () => {
+    const { getByText } = await render(
       <ShareCounter shareable={shareable} shares={7} style={{}} hideCount />,
     );
 
@@ -76,21 +76,21 @@ describe("ShareCounter", () => {
     expect(getShares).not.toHaveBeenCalled();
   });
 
-  it("calls onPress from press and long press when interactive", () => {
+  it("calls onPress from press and long press when interactive", async () => {
     const onPress = jest.fn();
 
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <ShareCounter shareable={shareable} style={{}} onPress={onPress} />,
     );
 
-    fireEvent.press(getByRole("button"));
-    fireEvent(getByRole("button"), "onLongPress");
+    await fireEvent.press(getByRole("button"));
+    await fireEvent(getByRole("button"), "onLongPress");
 
     expect(onPress).toHaveBeenCalledTimes(2);
   });
 
-  it("renders plain content without a button role when onPress is omitted", () => {
-    const { queryByRole, getByText } = render(
+  it("renders plain content without a button role when onPress is omitted", async () => {
+    const { queryByRole, getByText } = await render(
       <ShareCounter shareable={shareable} style={{}} />,
     );
 
@@ -98,10 +98,10 @@ describe("ShareCounter", () => {
     expect(getByText("share-icon:none:20")).toBeTruthy();
   });
 
-  it("renders an empty placeholder and skips engagement when disabled", () => {
+  it("renders an empty placeholder and skips engagement when disabled", async () => {
     mockConfig.enableEngagement = false;
 
-    const { queryByRole, queryByText } = render(
+    const { queryByRole, queryByText } = await render(
       <ShareCounter shareable={shareable} shares={3} style={{}} />,
     );
 

--- a/__tests__/components/audio/AudioPlayer.test.tsx
+++ b/__tests__/components/audio/AudioPlayer.test.tsx
@@ -57,28 +57,28 @@ describe("AudioPlayer — visibility", () => {
     jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
   });
 
-  it("renders nothing while the audio is not yet loaded", () => {
+  it("renders nothing while the audio is not yet loaded", async () => {
     jest
       .mocked(useAudioPlayerStatus)
       .mockReturnValue({ ...loadedStatus, isLoaded: false } as AudioStatus);
-    const { toJSON } = render(<AudioPlayer audioUrl={TEST_URL} />);
+    const { toJSON } = await render(<AudioPlayer audioUrl={TEST_URL} />);
     expect(toJSON()).toBeNull();
   });
 
-  it("renders nothing when the audio file has a load error (e.g. 404)", () => {
+  it("renders nothing when the audio file has a load error (e.g. 404)", async () => {
     jest.mocked(useAudioPlayerStatus).mockReturnValue({
       ...loadedStatus,
       error: "404 Not Found",
     } as AudioStatus);
-    const { toJSON } = render(<AudioPlayer audioUrl={TEST_URL} />);
+    const { toJSON } = await render(<AudioPlayer audioUrl={TEST_URL} />);
     expect(toJSON()).toBeNull();
   });
 
-  it("renders the player once audio is loaded", () => {
+  it("renders the player once audio is loaded", async () => {
     jest
       .mocked(useAudioPlayerStatus)
       .mockReturnValue(loadedStatus as AudioStatus);
-    const { toJSON } = render(<AudioPlayer audioUrl={TEST_URL} />);
+    const { toJSON } = await render(<AudioPlayer audioUrl={TEST_URL} />);
     expect(toJSON()).not.toBeNull();
   });
 });
@@ -92,44 +92,44 @@ describe("AudioPlayer — playback controls", () => {
       .mockReturnValue(loadedStatus as AudioStatus);
   });
 
-  it("calls setAudioModeAsync with playsInSilentMode on mount", () => {
-    render(<AudioPlayer audioUrl={TEST_URL} />);
+  it("calls setAudioModeAsync with playsInSilentMode on mount", async () => {
+    await render(<AudioPlayer audioUrl={TEST_URL} />);
     expect(setAudioModeAsync).toHaveBeenCalledWith({ playsInSilentMode: true });
   });
 
-  it("calls player.play() when button is pressed while paused", () => {
-    const { getByRole } = render(<AudioPlayer audioUrl={TEST_URL} />);
-    fireEvent.press(getByRole("button"));
+  it("calls player.play() when button is pressed while paused", async () => {
+    const { getByRole } = await render(<AudioPlayer audioUrl={TEST_URL} />);
+    await fireEvent.press(getByRole("button"));
     expect(mockPlayer.play).toHaveBeenCalledTimes(1);
     expect(mockPlayer.pause).not.toHaveBeenCalled();
   });
 
-  it("calls player.pause() when button is pressed while playing", () => {
+  it("calls player.pause() when button is pressed while playing", async () => {
     jest
       .mocked(useAudioPlayerStatus)
       .mockReturnValue({ ...loadedStatus, playing: true } as AudioStatus);
-    const { getByRole } = render(<AudioPlayer audioUrl={TEST_URL} />);
-    fireEvent.press(getByRole("button"));
+    const { getByRole } = await render(<AudioPlayer audioUrl={TEST_URL} />);
+    await fireEvent.press(getByRole("button"));
     expect(mockPlayer.pause).toHaveBeenCalledTimes(1);
     expect(mockPlayer.play).not.toHaveBeenCalled();
   });
 
-  it("calls seekTo(0) when the audio finishes", () => {
+  it("calls seekTo(0) when the audio finishes", async () => {
     jest.mocked(useAudioPlayerStatus).mockReturnValue({
       ...loadedStatus,
       didJustFinish: true,
     } as AudioStatus);
-    render(<AudioPlayer audioUrl={TEST_URL} />);
+    await render(<AudioPlayer audioUrl={TEST_URL} />);
     expect(mockPlayer.seekTo).toHaveBeenCalledWith(0);
   });
 
-  it("does not call seekTo(0) during normal playback", () => {
+  it("does not call seekTo(0) during normal playback", async () => {
     jest.mocked(useAudioPlayerStatus).mockReturnValue({
       ...loadedStatus,
       currentTime: 45,
       didJustFinish: false,
     } as AudioStatus);
-    render(<AudioPlayer audioUrl={TEST_URL} />);
+    await render(<AudioPlayer audioUrl={TEST_URL} />);
     expect(mockPlayer.seekTo).not.toHaveBeenCalled();
   });
 });
@@ -140,19 +140,19 @@ describe("AudioPlayer — accessibility labels", () => {
     jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
   });
 
-  it("labels the button 'Abspielen' when paused", () => {
+  it("labels the button 'Abspielen' when paused", async () => {
     jest
       .mocked(useAudioPlayerStatus)
       .mockReturnValue({ ...loadedStatus, playing: false } as AudioStatus);
-    const { getByRole } = render(<AudioPlayer audioUrl={TEST_URL} />);
+    const { getByRole } = await render(<AudioPlayer audioUrl={TEST_URL} />);
     expect(getByRole("button", { name: "Abspielen" })).toBeTruthy();
   });
 
-  it("labels the button 'Pause' when playing", () => {
+  it("labels the button 'Pause' when playing", async () => {
     jest
       .mocked(useAudioPlayerStatus)
       .mockReturnValue({ ...loadedStatus, playing: true } as AudioStatus);
-    const { getByRole } = render(<AudioPlayer audioUrl={TEST_URL} />);
+    const { getByRole } = await render(<AudioPlayer audioUrl={TEST_URL} />);
     expect(getByRole("button", { name: "Pause" })).toBeTruthy();
   });
 });
@@ -163,13 +163,13 @@ describe("AudioPlayer — clamping", () => {
     jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
   });
 
-  it("clamps remaining time to 0 when currentTime overshoots duration", () => {
+  it("clamps remaining time to 0 when currentTime overshoots duration", async () => {
     jest.mocked(useAudioPlayerStatus).mockReturnValue({
       ...loadedStatus,
       duration: 60,
       currentTime: 61,
     } as AudioStatus);
-    const { getByText } = render(<AudioPlayer audioUrl={TEST_URL} />);
+    const { getByText } = await render(<AudioPlayer audioUrl={TEST_URL} />);
     expect(getByText("0:00")).toBeTruthy();
   });
 });
@@ -188,13 +188,13 @@ describe("AudioPlayer — remaining time display", () => {
     ["0:05", 90, 85],
   ])(
     "shows %s remaining when duration=%s and currentTime=%s",
-    (expected, duration, currentTime) => {
+    async (expected, duration, currentTime) => {
       jest.mocked(useAudioPlayerStatus).mockReturnValue({
         ...loadedStatus,
         duration,
         currentTime,
       } as AudioStatus);
-      const { getByText } = render(<AudioPlayer audioUrl={TEST_URL} />);
+      const { getByText } = await render(<AudioPlayer audioUrl={TEST_URL} />);
       expect(getByText(expected)).toBeTruthy();
     },
   );

--- a/__tests__/components/buttons/ShopButton.test.tsx
+++ b/__tests__/components/buttons/ShopButton.test.tsx
@@ -46,35 +46,37 @@ describe("ShopButton", () => {
     (Config as any).donations.shop = "https://shop.volksverpetzer.de";
   });
 
-  it("renders an accessible button when shop URL is configured", () => {
-    const { getByRole } = render(<ShopButton />);
+  it("renders an accessible button when shop URL is configured", async () => {
+    const { getByRole } = await render(<ShopButton />);
     expect(getByRole("button")).toBeTruthy();
   });
 
-  it("returns null when no shop URL is configured", () => {
+  it("returns null when no shop URL is configured", async () => {
     (Config as any).donations.shop = undefined;
-    const { queryByRole } = render(<ShopButton />);
+    const { queryByRole } = await render(<ShopButton />);
     expect(queryByRole("button")).toBeNull();
   });
 
-  it("opens the shop URL when pressed", () => {
-    const { getByRole } = render(<ShopButton />);
-    fireEvent.press(getByRole("button"));
+  it("opens the shop URL when pressed", async () => {
+    const { getByRole } = await render(<ShopButton />);
+    await fireEvent.press(getByRole("button"));
     expect(Linking.openURL).toHaveBeenCalledWith(
       "https://shop.volksverpetzer.de",
     );
   });
 
-  it("tracks analytics against article_link when provided", () => {
+  it("tracks analytics against article_link when provided", async () => {
     const articleLink = "https://www.volksverpetzer.de/artikel/test" as const;
-    const { getByRole } = render(<ShopButton article_link={articleLink} />);
-    fireEvent.press(getByRole("button"));
+    const { getByRole } = await render(
+      <ShopButton article_link={articleLink} />,
+    );
+    await fireEvent.press(getByRole("button"));
     expect(registerEvent).toHaveBeenCalledWith(articleLink, "Shop");
   });
 
-  it("falls back to wpUrl for analytics when article_link is omitted", () => {
-    const { getByRole } = render(<ShopButton />);
-    fireEvent.press(getByRole("button"));
+  it("falls back to wpUrl for analytics when article_link is omitted", async () => {
+    const { getByRole } = await render(<ShopButton />);
+    await fireEvent.press(getByRole("button"));
     expect(registerEvent).toHaveBeenCalledWith(
       "https://www.volksverpetzer.de",
       "Shop",

--- a/__tests__/components/buttons/SteadyButton.test.tsx
+++ b/__tests__/components/buttons/SteadyButton.test.tsx
@@ -40,29 +40,31 @@ describe("SteadyButton", () => {
     jest.clearAllMocks();
   });
 
-  it("renders an accessible button", () => {
-    const { getByRole } = render(<SteadyButton />);
+  it("renders an accessible button", async () => {
+    const { getByRole } = await render(<SteadyButton />);
     expect(getByRole("button")).toBeTruthy();
   });
 
-  it("opens the Steady URL when pressed", () => {
-    const { getByRole } = render(<SteadyButton />);
-    fireEvent.press(getByRole("button"));
+  it("opens the Steady URL when pressed", async () => {
+    const { getByRole } = await render(<SteadyButton />);
+    await fireEvent.press(getByRole("button"));
     expect(Linking.openURL).toHaveBeenCalledWith(
       "https://steadyhq.com/de/volksverpetzer",
     );
   });
 
-  it("tracks analytics against article_link when provided", () => {
+  it("tracks analytics against article_link when provided", async () => {
     const articleLink = "https://www.volksverpetzer.de/artikel/test" as const;
-    const { getByRole } = render(<SteadyButton article_link={articleLink} />);
-    fireEvent.press(getByRole("button"));
+    const { getByRole } = await render(
+      <SteadyButton article_link={articleLink} />,
+    );
+    await fireEvent.press(getByRole("button"));
     expect(registerEvent).toHaveBeenCalledWith(articleLink, "Steady");
   });
 
-  it("falls back to wpUrl for analytics when article_link is omitted", () => {
-    const { getByRole } = render(<SteadyButton />);
-    fireEvent.press(getByRole("button"));
+  it("falls back to wpUrl for analytics when article_link is omitted", async () => {
+    const { getByRole } = await render(<SteadyButton />);
+    await fireEvent.press(getByRole("button"));
     expect(registerEvent).toHaveBeenCalledWith(
       "https://www.volksverpetzer.de",
       "Steady",

--- a/__tests__/components/licenses/LicenseListItem.test.tsx
+++ b/__tests__/components/licenses/LicenseListItem.test.tsx
@@ -4,11 +4,11 @@ import { render } from "@testing-library/react-native";
 import LicensesListItem from "#/screens/Settings/components/licenses/LicenseListItem";
 
 describe("LicensesListItem", () => {
-  it("renders the title text and has single-line truncation props", () => {
+  it("renders the title text and has single-line truncation props", async () => {
     const longPackageName = "very-long-package-name-".repeat(10);
     const username = "SomeAuthor";
 
-    const { getByText } = render(
+    const { getByText } = await render(
       <LicensesListItem packageName={longPackageName} username={username} />,
     );
 

--- a/__tests__/components/popups/ChangelogModal.test.tsx
+++ b/__tests__/components/popups/ChangelogModal.test.tsx
@@ -47,54 +47,54 @@ describe("ChangelogModal", () => {
   });
 
   describe("when visible", () => {
-    it("renders the heading", () => {
-      const { getByText } = render(
+    it("renders the heading", async () => {
+      const { getByText } = await render(
         <ChangelogModal isVisible onClose={onClose} />,
       );
       expect(getByText("Was ist neu?")).toBeTruthy();
     });
 
-    it("renders the version string", () => {
-      const { getByText } = render(
+    it("renders the version string", async () => {
+      const { getByText } = await render(
         <ChangelogModal isVisible onClose={onClose} />,
       );
       expect(getByText("Version 2.0.0")).toBeTruthy();
     });
 
-    it("renders the changelog notes", () => {
-      const { getByText } = render(
+    it("renders the changelog notes", async () => {
+      const { getByText } = await render(
         <ChangelogModal isVisible onClose={onClose} />,
       );
       expect(getByText("- Neue Funktion A\n- Fehlerbehebung B")).toBeTruthy();
     });
 
-    it("renders the confirm button", () => {
-      const { getByText } = render(
+    it("renders the confirm button", async () => {
+      const { getByText } = await render(
         <ChangelogModal isVisible onClose={onClose} />,
       );
       expect(getByText("Alles klar")).toBeTruthy();
     });
 
-    it("calls onClose when the close icon button is pressed", () => {
-      const { getByLabelText } = render(
+    it("calls onClose when the close icon button is pressed", async () => {
+      const { getByLabelText } = await render(
         <ChangelogModal isVisible onClose={onClose} />,
       );
-      fireEvent.press(getByLabelText("Schließen"));
+      await fireEvent.press(getByLabelText("Schließen"));
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it("calls onClose when the confirm button is pressed", () => {
-      const { getByText } = render(
+    it("calls onClose when the confirm button is pressed", async () => {
+      const { getByText } = await render(
         <ChangelogModal isVisible onClose={onClose} />,
       );
-      fireEvent.press(getByText("Alles klar"));
+      await fireEvent.press(getByText("Alles klar"));
       expect(onClose).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("when not visible", () => {
-    it("renders nothing", () => {
-      const { queryByText } = render(
+    it("renders nothing", async () => {
+      const { queryByText } = await render(
         <ChangelogModal isVisible={false} onClose={onClose} />,
       );
       expect(queryByText("Was ist neu?")).toBeNull();

--- a/__tests__/components/posts/AnnouncementCard.test.tsx
+++ b/__tests__/components/posts/AnnouncementCard.test.tsx
@@ -47,15 +47,15 @@ const announcement: AnnouncementEntry = {
 describe("AnnouncementCard", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("renders the announcement message", () => {
-    const { getByText } = render(
+  it("renders the announcement message", async () => {
+    const { getByText } = await render(
       <AnnouncementCard announcement={announcement} onDismiss={jest.fn()} />,
     );
     expect(getByText(announcement.message)).toBeTruthy();
   });
 
-  it("renders **bold** segments without the markers", () => {
-    const { getByText, queryByText } = render(
+  it("renders **bold** segments without the markers", async () => {
+    const { getByText, queryByText } = await render(
       <AnnouncementCard
         announcement={{ ...announcement, message: "**Neu**: hallo" }}
         onDismiss={jest.fn()}
@@ -65,8 +65,8 @@ describe("AnnouncementCard", () => {
     expect(queryByText("**Neu**: hallo")).toBeNull();
   });
 
-  it("opens links via onLinkPress without rendering the markdown syntax", () => {
-    const { getByText, queryByText } = render(
+  it("opens links via onLinkPress without rendering the markdown syntax", async () => {
+    const { getByText, queryByText } = await render(
       <AnnouncementCard
         announcement={{
           ...announcement,
@@ -76,37 +76,37 @@ describe("AnnouncementCard", () => {
       />,
     );
     expect(queryByText(/\[Prüfpunkt\]/)).toBeNull();
-    fireEvent.press(getByText("Prüfpunkt"));
+    await fireEvent.press(getByText("Prüfpunkt"));
     expect(mockOnLinkPress).toHaveBeenCalledWith(
       "https://pruefpunkt.org",
       expect.anything(),
     );
   });
 
-  it("renders both action buttons", () => {
-    const { getByText } = render(
+  it("renders both action buttons", async () => {
+    const { getByText } = await render(
       <AnnouncementCard announcement={announcement} onDismiss={jest.fn()} />,
     );
     expect(getByText("Alles klar!")).toBeTruthy();
     expect(getByText("Zu den Einstellungen")).toBeTruthy();
   });
 
-  it("dismisses without navigating when 'Alles klar!' is pressed", () => {
+  it("dismisses without navigating when 'Alles klar!' is pressed", async () => {
     const onDismiss = jest.fn();
-    const { getByText } = render(
+    const { getByText } = await render(
       <AnnouncementCard announcement={announcement} onDismiss={onDismiss} />,
     );
-    fireEvent.press(getByText("Alles klar!"));
+    await fireEvent.press(getByText("Alles klar!"));
     expect(onDismiss).toHaveBeenCalledWith(announcement.id);
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-  it("dismisses and navigates when the action button is pressed", () => {
+  it("dismisses and navigates when the action button is pressed", async () => {
     const onDismiss = jest.fn();
-    const { getByText } = render(
+    const { getByText } = await render(
       <AnnouncementCard announcement={announcement} onDismiss={onDismiss} />,
     );
-    fireEvent.press(getByText("Zu den Einstellungen"));
+    await fireEvent.press(getByText("Zu den Einstellungen"));
     expect(onDismiss).toHaveBeenCalledWith(announcement.id);
     expect(mockPush).toHaveBeenCalledWith(announcement.route);
   });

--- a/__tests__/components/posts/ArticlePost.test.tsx
+++ b/__tests__/components/posts/ArticlePost.test.tsx
@@ -83,8 +83,8 @@ describe("ArticlePost — reading time", () => {
     jest.clearAllMocks();
   });
 
-  it("shows reading time in the metadata line when reading_time is set", () => {
-    const { getByText } = render(
+  it("shows reading time in the metadata line when reading_time is set", async () => {
+    const { getByText } = await render(
       <ArticlePost
         article={{ ...baseArticle, reading_time: 12 }}
         inView={false}
@@ -93,8 +93,8 @@ describe("ArticlePost — reading time", () => {
     expect(getByText(/12 Min\./)).toBeTruthy();
   });
 
-  it("does not show reading time when reading_time is undefined", () => {
-    const { queryByText } = render(
+  it("does not show reading time when reading_time is undefined", async () => {
+    const { queryByText } = await render(
       <ArticlePost
         article={{ ...baseArticle, reading_time: undefined }}
         inView={false}
@@ -115,7 +115,7 @@ describe("ArticlePost — inView effects", () => {
     });
     PersonalStore.getScrollPosition.mockResolvedValue(0.5);
 
-    render(<ArticlePost article={baseArticle} inView={true} />);
+    await render(<ArticlePost article={baseArticle} inView={true} />);
 
     await waitFor(() =>
       expect(WordPressAPI.getFeatureImage).toHaveBeenCalled(),
@@ -134,7 +134,7 @@ describe("ArticlePost — inView effects", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {});
 
-    render(<ArticlePost article={baseArticle} inView={true} />);
+    await render(<ArticlePost article={baseArticle} inView={true} />);
 
     await waitFor(() => expect(consoleSpy).toHaveBeenCalled());
     consoleSpy.mockRestore();
@@ -144,31 +144,31 @@ describe("ArticlePost — inView effects", () => {
 describe("ArticlePost — press handlers", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("calls onLinkPress when pressed", () => {
+  it("calls onLinkPress when pressed", async () => {
     const { onLinkPress } = require("#/helpers/Linking");
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <ArticlePost article={baseArticle} inView={false} />,
     );
-    fireEvent.press(getByRole("button"));
+    await fireEvent.press(getByRole("button"));
     expect(onLinkPress).toHaveBeenCalledWith(
       baseArticle.link,
       expect.anything(),
     );
   });
 
-  it("calls onShare on long press", () => {
+  it("calls onShare on long press", async () => {
     const { onShare } = require("#/helpers/Sharing");
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <ArticlePost article={baseArticle} inView={false} />,
     );
-    fireEvent(getByRole("button"), "longPress");
+    await fireEvent(getByRole("button"), "longPress");
     expect(onShare).toHaveBeenCalledWith(baseArticle.link, expect.anything());
   });
 });
 
 describe("ArticlePost — elevated mode", () => {
-  it("wraps content in an elevated View when elevated is true", () => {
-    const { toJSON } = render(
+  it("wraps content in an elevated View when elevated is true", async () => {
+    const { toJSON } = await render(
       <ArticlePost article={baseArticle} inView={false} elevated={true} />,
     );
     expect(toJSON()).toBeTruthy();
@@ -176,11 +176,11 @@ describe("ArticlePost — elevated mode", () => {
 });
 
 describe("ArticlePost — engagement badge", () => {
-  it("does not mount ViewCounter when enableEngagement is false", () => {
+  it("does not mount ViewCounter when enableEngagement is false", async () => {
     // Config mock at the top of the file has enableEngagement: undefined (falsy),
     // so the badge gate `Config.enableEngagement && ...` prevents ViewCounter from rendering.
     const ViewCounter = require("#/components/counter/ViewCounter").default;
-    render(<ArticlePost article={baseArticle} inView={true} />);
+    await render(<ArticlePost article={baseArticle} inView={true} />);
     // ViewCounter is mocked to () => null; if the gate works it is still
     // part of the tree but only when engagement is enabled. With the default
     // mock config (no enableEngagement), the whole badge branch is skipped.
@@ -189,12 +189,12 @@ describe("ArticlePost — engagement badge", () => {
 });
 
 describe("ArticlePost — category badge", () => {
-  it("shows category label when importantCats has a match", () => {
+  it("shows category label when importantCats has a match", async () => {
     jest.mock("#/constants/Config", () => ({
       __esModule: true,
       default: { importantCats: { 5: "Faktisch falsch" } },
     }));
-    const { queryByText } = render(
+    const { queryByText } = await render(
       <ArticlePost
         article={{ ...baseArticle, categories: [5] }}
         inView={false}

--- a/__tests__/components/posts/GenericPost.test.tsx
+++ b/__tests__/components/posts/GenericPost.test.tsx
@@ -32,8 +32,8 @@ const MockComponent = jest.fn(() => null) as React.FC<{ inView: boolean }>;
 describe("GenericPost", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("renders ShareBar when shareable prop is provided", () => {
-    const { getByTestId } = render(
+  it("renders ShareBar when shareable prop is provided", async () => {
+    const { getByTestId } = await render(
       <GenericPost
         component={MockComponent}
         data={{}}
@@ -44,8 +44,8 @@ describe("GenericPost", () => {
     expect(getByTestId("share-bar")).toBeTruthy();
   });
 
-  it("renders no ShareBar when shareable prop is not provided", () => {
-    const { queryByTestId } = render(
+  it("renders no ShareBar when shareable prop is not provided", async () => {
+    const { queryByTestId } = await render(
       <GenericPost component={MockComponent} data={{}} inView />,
     );
     expect(queryByTestId("share-bar")).toBeNull();

--- a/__tests__/components/posts/MastodonPost.test.tsx
+++ b/__tests__/components/posts/MastodonPost.test.tsx
@@ -77,33 +77,33 @@ const basePost = {
 describe("MastodonPost", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("renders the account display name", () => {
-    const { getByText } = render(<MastodonPost {...basePost} />);
+  it("renders the account display name", async () => {
+    const { getByText } = await render(<MastodonPost {...basePost} />);
     expect(getByText(/Test User/)).toBeTruthy();
   });
 
-  it("renders the post content as excerpt by default", () => {
-    const { getByText } = render(<MastodonPost {...basePost} />);
+  it("renders the post content as excerpt by default", async () => {
+    const { getByText } = await render(<MastodonPost {...basePost} />);
     expect(getByText("Hello world")).toBeTruthy();
   });
 
-  it("renders full text when displayText is DISPLAY_TEXT_FULL", () => {
-    const { getByText } = render(
+  it("renders full text when displayText is DISPLAY_TEXT_FULL", async () => {
+    const { getByText } = await render(
       <MastodonPost {...basePost} displayText={DISPLAY_TEXT_FULL} />,
     );
     expect(getByText("Hello world")).toBeTruthy();
   });
 
-  it("hides content when displayText is DISPLAY_TEXT_NONE", () => {
-    const { queryByText } = render(
+  it("hides content when displayText is DISPLAY_TEXT_NONE", async () => {
+    const { queryByText } = await render(
       <MastodonPost {...basePost} displayText={DISPLAY_TEXT_NONE} />,
     );
     expect(queryByText("Hello world")).toBeNull();
   });
 
-  it("shows 'Mehr Lesen' when excerpt is shorter than full text", () => {
+  it("shows 'Mehr Lesen' when excerpt is shorter than full text", async () => {
     const longContent = "<p>" + "word ".repeat(100) + "</p>";
-    const { getByText } = render(
+    const { getByText } = await render(
       <MastodonPost
         {...basePost}
         content={longContent}
@@ -113,8 +113,8 @@ describe("MastodonPost", () => {
     expect(getByText("Mehr Lesen")).toBeTruthy();
   });
 
-  it("shows thread count when answers are present in DISPLAY_TEXT_EXCERPT mode", () => {
-    const { getByText } = render(
+  it("shows thread count when answers are present in DISPLAY_TEXT_EXCERPT mode", async () => {
+    const { getByText } = await render(
       <MastodonPost
         {...basePost}
         answers={[basePost, basePost]}
@@ -124,9 +124,9 @@ describe("MastodonPost", () => {
     expect(getByText(/Thread 1 von 3/)).toBeTruthy();
   });
 
-  it("renders answer content in DISPLAY_TEXT_FULL mode", () => {
+  it("renders answer content in DISPLAY_TEXT_FULL mode", async () => {
     const answer = { ...basePost, content: "<p>Answer text</p>" };
-    const { getByText } = render(
+    const { getByText } = await render(
       <MastodonPost
         {...basePost}
         answers={[answer]}
@@ -136,14 +136,14 @@ describe("MastodonPost", () => {
     expect(getByText("Answer text")).toBeTruthy();
   });
 
-  it("navigates when pressed in excerpt mode", () => {
+  it("navigates when pressed in excerpt mode", async () => {
     const { useRouter } = require("expo-router");
     const push = jest.fn();
     useRouter.mockReturnValue({ push });
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <MastodonPost {...basePost} displayText={DISPLAY_TEXT_EXCERPT} />,
     );
-    fireEvent.press(getByRole("button"));
+    await fireEvent.press(getByRole("button"));
     expect(push).toHaveBeenCalledWith(`/bsky/${basePost.id}`);
   });
 });

--- a/__tests__/components/posts/RedditPost.test.tsx
+++ b/__tests__/components/posts/RedditPost.test.tsx
@@ -46,32 +46,32 @@ const baseProps = {
 describe("RedditPost", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("renders title and author", () => {
-    const { getByText } = render(<RedditPost {...baseProps} />);
+  it("renders title and author", async () => {
+    const { getByText } = await render(<RedditPost {...baseProps} />);
     expect(getByText("Test Reddit Post")).toBeTruthy();
     expect(getByText(/testuser/)).toBeTruthy();
   });
 
-  it("navigates to /image with the URL on press", () => {
-    const { getByRole } = render(<RedditPost {...baseProps} />);
-    fireEvent.press(getByRole("button"));
+  it("navigates to /image with the URL on press", async () => {
+    const { getByRole } = await render(<RedditPost {...baseProps} />);
+    await fireEvent.press(getByRole("button"));
     expect(mockPush).toHaveBeenCalledWith({
       pathname: "/image",
       params: { uri: "https://example.com/image.jpg" },
     });
   });
 
-  it("calls onShare on long press", () => {
+  it("calls onShare on long press", async () => {
     const { onShare } = jest.requireMock("#/helpers/Sharing");
-    const { getByRole } = render(<RedditPost {...baseProps} />);
-    fireEvent(getByRole("button"), "longPress");
+    const { getByRole } = await render(<RedditPost {...baseProps} />);
+    await fireEvent(getByRole("button"), "longPress");
     expect(onShare).toHaveBeenCalledWith("https://example.com/image.jpg", {
       location: "RedditPost",
     });
   });
 
-  it("uses crosspost author when available", () => {
-    const { getByText } = render(
+  it("uses crosspost author when available", async () => {
+    const { getByText } = await render(
       <RedditPost
         {...baseProps}
         crosspost_parent_list={[{ author: "crosspostuser" }]}
@@ -80,24 +80,24 @@ describe("RedditPost", () => {
     expect(getByText(/crosspostuser/)).toBeTruthy();
   });
 
-  it("uses thumbnail when inView is false", () => {
+  it("uses thumbnail when inView is false", async () => {
     const { Image } = require("expo-image");
-    render(<RedditPost {...baseProps} inView={false} />);
+    await render(<RedditPost {...baseProps} inView={false} />);
     const [props] = Image.mock.calls[0];
     expect(props.source.uri).toBe("https://example.com/thumbnail.jpg");
   });
 
-  it("uses full url when inView is true", () => {
+  it("uses full url when inView is true", async () => {
     const { Image } = require("expo-image");
-    render(<RedditPost {...baseProps} inView />);
+    await render(<RedditPost {...baseProps} inView />);
     const [props] = Image.mock.calls[0];
     expect(props.source.uri).toBe("https://example.com/image.jpg");
   });
 
-  it("uses smaller font size for long titles", () => {
+  it("uses smaller font size for long titles", async () => {
     const UiText = jest.requireMock("#/components/ui/UiText");
     const longTitle = "A".repeat(101);
-    render(<RedditPost {...baseProps} title={longTitle} />);
+    await render(<RedditPost {...baseProps} title={longTitle} />);
     const titleCallProps = UiText.mock.calls
       .map(([p]: any) => p)
       .find((p: any) => p.children === longTitle);
@@ -106,9 +106,9 @@ describe("RedditPost", () => {
     );
   });
 
-  it("uses normal font size for short titles", () => {
+  it("uses normal font size for short titles", async () => {
     const UiText = jest.requireMock("#/components/ui/UiText");
-    render(<RedditPost {...baseProps} />);
+    await render(<RedditPost {...baseProps} />);
     const titleCallProps = UiText.mock.calls
       .map(([p]: any) => p)
       .find((p: any) => p.children === "Test Reddit Post");

--- a/__tests__/components/posts/bsky/BlueskyPostDetail.test.tsx
+++ b/__tests__/components/posts/bsky/BlueskyPostDetail.test.tsx
@@ -56,25 +56,25 @@ describe("BlueskyPostDetail", () => {
     jest.clearAllMocks();
   });
 
-  it("renders the post text content", () => {
-    const { getByText } = render(
+  it("renders the post text content", async () => {
+    const { getByText } = await render(
       <BlueskyPostDetail post={makeFeedPost("Hello test post")} />,
     );
     expect(getByText("Hello test post")).toBeTruthy();
   });
 
-  it("renders the external link button with the correct accessibility label", () => {
-    const { getByRole } = render(
+  it("renders the external link button with the correct accessibility label", async () => {
+    const { getByRole } = await render(
       <BlueskyPostDetail post={makeFeedPost("Some text")} />,
     );
     expect(getByRole("button", { name: "In Bluesky öffnen" })).toBeTruthy();
   });
 
-  it("pressing the external link button calls onLinkPress with the Bluesky post URL", () => {
-    const { getByRole } = render(
+  it("pressing the external link button calls onLinkPress with the Bluesky post URL", async () => {
+    const { getByRole } = await render(
       <BlueskyPostDetail post={makeFeedPost("Some text")} />,
     );
-    fireEvent.press(getByRole("button", { name: "In Bluesky öffnen" }));
+    await fireEvent.press(getByRole("button", { name: "In Bluesky öffnen" }));
     expect(onLinkPress).toHaveBeenCalledTimes(1);
     expect(onLinkPress).toHaveBeenCalledWith(
       "https://bsky.app/profile/tester.bsky.social/post/abc123",
@@ -83,14 +83,14 @@ describe("BlueskyPostDetail", () => {
     );
   });
 
-  it("renders a PostText for each reply when replies are provided", () => {
+  it("renders a PostText for each reply when replies are provided", async () => {
     const { PostText } = jest.requireMock(
       "#/components/posts/bsky/PostText",
     ) as { PostText: jest.Mock };
     const reply1 = makeFeedPost("Reply one", "reply1");
     const reply2 = makeFeedPost("Reply two", "reply2");
 
-    render(
+    await render(
       <BlueskyPostDetail
         post={makeFeedPost("Main post")}
         replies={[reply1, reply2]}
@@ -107,22 +107,24 @@ describe("BlueskyPostDetail", () => {
     );
   });
 
-  it("renders no PostText when replies is not provided", () => {
+  it("renders no PostText when replies is not provided", async () => {
     const { PostText } = jest.requireMock(
       "#/components/posts/bsky/PostText",
     ) as { PostText: jest.Mock };
 
-    render(<BlueskyPostDetail post={makeFeedPost("Main post")} />);
+    await render(<BlueskyPostDetail post={makeFeedPost("Main post")} />);
 
     expect(PostText).not.toHaveBeenCalled();
   });
 
-  it("renders no PostText when replies is an empty array", () => {
+  it("renders no PostText when replies is an empty array", async () => {
     const { PostText } = jest.requireMock(
       "#/components/posts/bsky/PostText",
     ) as { PostText: jest.Mock };
 
-    render(<BlueskyPostDetail post={makeFeedPost("Main post")} replies={[]} />);
+    await render(
+      <BlueskyPostDetail post={makeFeedPost("Main post")} replies={[]} />,
+    );
 
     expect(PostText).not.toHaveBeenCalled();
   });

--- a/__tests__/components/posts/bsky/PostText.test.tsx
+++ b/__tests__/components/posts/bsky/PostText.test.tsx
@@ -54,15 +54,15 @@ const makePost = (record: Record<string, unknown>) => ({
 });
 
 describe("PostText", () => {
-  it("returns null when record has no text property", () => {
-    const { toJSON } = render(
+  it("returns null when record has no text property", async () => {
+    const { toJSON } = await render(
       <PostText feedViewPost={makePost({ $type: "app.bsky.feed.post" })} />,
     );
     expect(toJSON()).toBeNull();
   });
 
-  it("renders plain text content", () => {
-    const { getByText } = render(
+  it("renders plain text content", async () => {
+    const { getByText } = await render(
       <PostText
         feedViewPost={makePost({
           $type: "app.bsky.feed.post",

--- a/__tests__/components/ui/UiButton.test.tsx
+++ b/__tests__/components/ui/UiButton.test.tsx
@@ -11,24 +11,24 @@ jest.mock("expo-image", () => ({
 describe("UiButton", () => {
   const source = { uri: "https://example.com/button.png" };
 
-  it("has button accessibility role", () => {
-    const { getByRole } = render(
+  it("has button accessibility role", async () => {
+    const { getByRole } = await render(
       <UiButton source={source} onPress={jest.fn()} />,
     );
     expect(getByRole("button")).toBeTruthy();
   });
 
-  it("calls onPress when pressed", () => {
+  it("calls onPress when pressed", async () => {
     const onPress = jest.fn();
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <UiButton source={source} onPress={onPress} />,
     );
-    fireEvent.press(getByRole("button"));
+    await fireEvent.press(getByRole("button"));
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it("exposes accessibilityLabel", () => {
-    const { getByLabelText } = render(
+  it("exposes accessibilityLabel", async () => {
+    const { getByLabelText } = await render(
       <UiButton
         source={source}
         onPress={jest.fn()}

--- a/__tests__/components/ui/UiCheckbox.test.tsx
+++ b/__tests__/components/ui/UiCheckbox.test.tsx
@@ -10,8 +10,8 @@ jest.mock("#/components/Icons", () => ({
 }));
 
 describe("UiCheckbox", () => {
-  it("renders children", () => {
-    const { getByText } = render(
+  it("renders children", async () => {
+    const { getByText } = await render(
       <UiCheckbox checked={false} onChange={jest.fn()}>
         <Text>Accept terms</Text>
       </UiCheckbox>,
@@ -19,46 +19,46 @@ describe("UiCheckbox", () => {
     expect(getByText("Accept terms")).toBeTruthy();
   });
 
-  it("has checkbox accessibility role", () => {
-    const { getByRole } = render(
+  it("has checkbox accessibility role", async () => {
+    const { getByRole } = await render(
       <UiCheckbox checked={false} onChange={jest.fn()} />,
     );
     expect(getByRole("checkbox")).toBeTruthy();
   });
 
-  it("reflects initial checked state in accessibility", () => {
-    const { getByRole } = render(
+  it("reflects initial checked state in accessibility", async () => {
+    const { getByRole } = await render(
       <UiCheckbox checked={true} onChange={jest.fn()} />,
     );
     expect(getByRole("checkbox", { checked: true })).toBeTruthy();
   });
 
-  it("calls onChange with the toggled value when pressed", () => {
+  it("calls onChange with the toggled value when pressed", async () => {
     const onChange = jest.fn();
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <UiCheckbox checked={false} onChange={onChange} />,
     );
-    fireEvent.press(getByRole("checkbox"));
+    await fireEvent.press(getByRole("checkbox"));
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
-  it("toggles from checked to unchecked", () => {
+  it("toggles from checked to unchecked", async () => {
     const onChange = jest.fn();
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <UiCheckbox checked={true} onChange={onChange} />,
     );
-    fireEvent.press(getByRole("checkbox"));
+    await fireEvent.press(getByRole("checkbox"));
     expect(onChange).toHaveBeenCalledWith(false);
   });
 
-  it("updates accessibility state after parent re-renders with new checked value", () => {
+  it("updates accessibility state after parent re-renders with new checked value", async () => {
     const onChange = jest.fn();
-    const { getByRole, rerender } = render(
+    const { getByRole, rerender } = await render(
       <UiCheckbox checked={false} onChange={onChange} />,
     );
-    fireEvent.press(getByRole("checkbox"));
+    await fireEvent.press(getByRole("checkbox"));
     expect(onChange).toHaveBeenCalledWith(true);
-    rerender(<UiCheckbox checked={true} onChange={onChange} />);
+    await rerender(<UiCheckbox checked={true} onChange={onChange} />);
     expect(getByRole("checkbox", { checked: true })).toBeTruthy();
   });
 });

--- a/__tests__/components/ui/UiCollapsable.test.tsx
+++ b/__tests__/components/ui/UiCollapsable.test.tsx
@@ -23,13 +23,13 @@ describe("UiCollapsable", () => {
   });
 
   describe("title and icon", () => {
-    it("renders the title", () => {
-      const { getByText } = render(<UiCollapsable title="FAQ" />);
+    it("renders the title", async () => {
+      const { getByText } = await render(<UiCollapsable title="FAQ" />);
       expect(getByText("FAQ")).toBeTruthy();
     });
 
-    it("renders an optional icon", () => {
-      const { getByText } = render(
+    it("renders an optional icon", async () => {
+      const { getByText } = await render(
         <UiCollapsable title="FAQ" icon={<Text>icon</Text>} />,
       );
       expect(getByText("icon")).toBeTruthy();
@@ -37,8 +37,8 @@ describe("UiCollapsable", () => {
   });
 
   describe("collapsed state (default)", () => {
-    it("hides children", () => {
-      const { queryByText } = render(
+    it("hides children", async () => {
+      const { queryByText } = await render(
         <UiCollapsable title="FAQ">
           <Text>hidden content</Text>
         </UiCollapsable>,
@@ -46,14 +46,14 @@ describe("UiCollapsable", () => {
       expect(queryByText("hidden content")).toBeNull();
     });
 
-    it("shows chevron pointing down", () => {
-      render(<UiCollapsable title="FAQ" />);
+    it("shows chevron pointing down", async () => {
+      await render(<UiCollapsable title="FAQ" />);
       const lastCall = chevron.mock.calls[chevron.mock.calls.length - 1];
       expect((lastCall[0] as any).direction).toBe("down");
     });
 
-    it("has no background color", () => {
-      const { toJSON } = render(<UiCollapsable title="FAQ" />);
+    it("has no background color", async () => {
+      const { toJSON } = await render(<UiCollapsable title="FAQ" />);
       const root = toJSON() as any;
       const styles = [root.props.style].flat();
       expect(styles.every((s: any) => !s?.backgroundColor)).toBe(true);
@@ -61,8 +61,8 @@ describe("UiCollapsable", () => {
   });
 
   describe("defaultOpen", () => {
-    it("shows children", () => {
-      const { getByText } = render(
+    it("shows children", async () => {
+      const { getByText } = await render(
         <UiCollapsable title="FAQ" defaultOpen>
           <Text>visible content</Text>
         </UiCollapsable>,
@@ -70,14 +70,16 @@ describe("UiCollapsable", () => {
       expect(getByText("visible content")).toBeTruthy();
     });
 
-    it("shows chevron pointing up", () => {
-      render(<UiCollapsable title="FAQ" defaultOpen />);
+    it("shows chevron pointing up", async () => {
+      await render(<UiCollapsable title="FAQ" defaultOpen />);
       const lastCall = chevron.mock.calls[chevron.mock.calls.length - 1];
       expect((lastCall[0] as any).direction).toBe("up");
     });
 
-    it("applies a background color", () => {
-      const { toJSON } = render(<UiCollapsable title="FAQ" defaultOpen />);
+    it("applies a background color", async () => {
+      const { toJSON } = await render(
+        <UiCollapsable title="FAQ" defaultOpen />,
+      );
       const root = toJSON() as any;
       // backgroundColor lives on the Animated.View overlay (first child), not the root View
       const overlay = root.children[0];
@@ -87,44 +89,46 @@ describe("UiCollapsable", () => {
   });
 
   describe("toggling", () => {
-    it("expands on press and shows chevron up", () => {
-      const { getByRole, getByText } = render(
+    it("expands on press and shows chevron up", async () => {
+      const { getByRole, getByText } = await render(
         <UiCollapsable title="FAQ">
           <Text>now visible</Text>
         </UiCollapsable>,
       );
-      fireEvent.press(getByRole("button"));
+      await fireEvent.press(getByRole("button"));
       expect(getByText("now visible")).toBeTruthy();
       const lastCall = chevron.mock.calls[chevron.mock.calls.length - 1];
       expect((lastCall[0] as any).direction).toBe("up");
     });
 
-    it("collapses after a second press", () => {
-      const { getByRole, queryByText } = render(
+    it("collapses after a second press", async () => {
+      const { getByRole, queryByText } = await render(
         <UiCollapsable title="FAQ">
           <Text>content</Text>
         </UiCollapsable>,
       );
-      fireEvent.press(getByRole("button"));
-      fireEvent.press(getByRole("button"));
+      await fireEvent.press(getByRole("button"));
+      await fireEvent.press(getByRole("button"));
       expect(queryByText("content")).toBeNull();
     });
 
-    it("calls onToggle with alternating values", () => {
+    it("calls onToggle with alternating values", async () => {
       const onToggle = jest.fn();
-      const { getByRole } = render(
+      const { getByRole } = await render(
         <UiCollapsable title="FAQ" onToggle={onToggle} />,
       );
-      fireEvent.press(getByRole("button"));
-      fireEvent.press(getByRole("button"));
+      await fireEvent.press(getByRole("button"));
+      await fireEvent.press(getByRole("button"));
       expect(onToggle).toHaveBeenCalledTimes(2);
       expect(onToggle).toHaveBeenNthCalledWith(1, true);
       expect(onToggle).toHaveBeenNthCalledWith(2, false);
     });
 
-    it("does not throw without an onToggle handler", () => {
-      const { getByRole } = render(<UiCollapsable title="FAQ" />);
-      expect(() => fireEvent.press(getByRole("button"))).not.toThrow();
+    it("does not throw without an onToggle handler", async () => {
+      const { getByRole } = await render(<UiCollapsable title="FAQ" />);
+      expect(
+        async () => await fireEvent.press(getByRole("button")),
+      ).not.toThrow();
     });
   });
 });

--- a/__tests__/components/ui/UiDivider.test.tsx
+++ b/__tests__/components/ui/UiDivider.test.tsx
@@ -14,8 +14,8 @@ function flattenStyle(style: unknown): Record<string, unknown> {
 }
 
 describe("UiDivider", () => {
-  it("renders correctly and applies padding/width/style props", () => {
-    const { toJSON } = render(
+  it("renders correctly and applies padding/width/style props", async () => {
+    const { toJSON } = await render(
       <UiDivider
         paddingHorizontal={12}
         thickness={4}
@@ -37,8 +37,8 @@ describe("UiDivider", () => {
     expect(lineStyle.height).toBe(4);
   });
 
-  it("matches snapshot", () => {
-    const { toJSON } = render(
+  it("matches snapshot", async () => {
+    const { toJSON } = await render(
       <UiDivider
         paddingHorizontal={12}
         thickness={4}

--- a/__tests__/components/ui/UiEmptyState.test.tsx
+++ b/__tests__/components/ui/UiEmptyState.test.tsx
@@ -19,49 +19,49 @@ const Icon = ({ color }: { color?: string }) => (
 );
 
 describe("UiEmptyState", () => {
-  it("renders children as text", () => {
-    const { getByText } = render(
+  it("renders children as text", async () => {
+    const { getByText } = await render(
       <UiEmptyState icon={<Icon />}>Keine Einträge</UiEmptyState>,
     );
     expect(getByText("Keine Einträge")).toBeTruthy();
   });
 
-  it("renders the icon", () => {
-    const { getByTestId } = render(
+  it("renders the icon", async () => {
+    const { getByTestId } = await render(
       <UiEmptyState icon={<Icon />}>text</UiEmptyState>,
     );
     expect(getByTestId("icon")).toBeTruthy();
   });
 
-  it("injects the corporate color into the icon when no color is set", () => {
-    const { getByTestId } = render(
+  it("injects the corporate color into the icon when no color is set", async () => {
+    const { getByTestId } = await render(
       <UiEmptyState icon={<Icon />}>text</UiEmptyState>,
     );
     const icon = getByTestId("icon");
     expect(icon.props.style).toMatchObject({ color: "#1b7194" });
   });
 
-  it("preserves an explicit color passed by the caller", () => {
-    const { getByTestId } = render(
+  it("preserves an explicit color passed by the caller", async () => {
+    const { getByTestId } = await render(
       <UiEmptyState icon={<Icon color="red" />}>text</UiEmptyState>,
     );
     const icon = getByTestId("icon");
     expect(icon.props.style).toMatchObject({ color: "red" });
   });
 
-  it("calls onPress when pressed", () => {
+  it("calls onPress when pressed", async () => {
     const onPress = jest.fn();
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <UiEmptyState icon={<Icon />} onPress={onPress}>
         text
       </UiEmptyState>,
     );
-    fireEvent.press(getByRole("button"));
+    await fireEvent.press(getByRole("button"));
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it("does not have button role without onPress", () => {
-    const { queryByRole } = render(
+  it("does not have button role without onPress", async () => {
+    const { queryByRole } = await render(
       <UiEmptyState icon={<Icon />}>text</UiEmptyState>,
     );
     expect(queryByRole("button")).toBeNull();

--- a/__tests__/components/ui/UiLink.test.tsx
+++ b/__tests__/components/ui/UiLink.test.tsx
@@ -50,18 +50,18 @@ const icon = <View testID="icon" />;
 describe("UiLink", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("renders the link text", () => {
-    const { getByText } = render(
+  it("renders the link text", async () => {
+    const { getByText } = await render(
       <UiLink url="https://example.com" text="Impressum" icon={icon} />,
     );
     expect(getByText("Impressum")).toBeTruthy();
   });
 
-  it("opens browser for https URLs", () => {
-    const { getByTestId } = render(
+  it("opens browser for https URLs", async () => {
+    const { getByTestId } = await render(
       <UiLink url="https://example.com" text="Link" icon={icon} />,
     );
-    fireEvent.press(getByTestId("ui-link"));
+    await fireEvent.press(getByTestId("ui-link"));
     expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(
       "https://example.com",
     );
@@ -69,10 +69,10 @@ describe("UiLink", () => {
 
   it("uses MailComposer for mailto URLs when available", async () => {
     jest.mocked(MailComposer.isAvailableAsync).mockResolvedValue(true);
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <UiLink url="mailto:info@example.com" text="Kontakt" icon={icon} />,
     );
-    fireEvent.press(getByTestId("ui-link"));
+    await fireEvent.press(getByTestId("ui-link"));
     await Promise.resolve();
     expect(MailComposer.composeAsync).toHaveBeenCalledWith({
       recipients: ["info@example.com"],
@@ -82,10 +82,10 @@ describe("UiLink", () => {
   it("falls back to Linking.openURL for mailto when MailComposer unavailable", async () => {
     const { openURL } = require("expo-linking");
     jest.mocked(MailComposer.isAvailableAsync).mockResolvedValue(false);
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <UiLink url="mailto:info@example.com" text="Kontakt" icon={icon} />,
     );
-    fireEvent.press(getByTestId("ui-link"));
+    await fireEvent.press(getByTestId("ui-link"));
     await Promise.resolve();
     expect(openURL).toHaveBeenCalledWith("mailto:info@example.com");
   });

--- a/__tests__/components/ui/UiPressable.test.tsx
+++ b/__tests__/components/ui/UiPressable.test.tsx
@@ -25,8 +25,8 @@ describe("UiPressable", () => {
     });
   });
 
-  it("renders children", () => {
-    const { getByText } = render(
+  it("renders children", async () => {
+    const { getByText } = await render(
       <UiPressable>
         <Text>child</Text>
       </UiPressable>,
@@ -34,20 +34,20 @@ describe("UiPressable", () => {
     expect(getByText("child")).toBeTruthy();
   });
 
-  it("calls onPress when pressed", () => {
+  it("calls onPress when pressed", async () => {
     const onPress = jest.fn();
-    const { getByText } = render(
+    const { getByText } = await render(
       <UiPressable onPress={onPress}>
         <Text>press me</Text>
       </UiPressable>,
     );
-    fireEvent.press(getByText("press me"));
+    await fireEvent.press(getByText("press me"));
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves a static style object", () => {
+  it("preserves a static style object", async () => {
     const style = { backgroundColor: "red", padding: 8 };
-    const { toJSON } = render(
+    const { toJSON } = await render(
       <UiPressable style={style}>
         <Text>child</Text>
       </UiPressable>,
@@ -57,9 +57,9 @@ describe("UiPressable", () => {
     expect(combined).toMatchObject(style);
   });
 
-  it("calls a style function with the pressed state", () => {
+  it("calls a style function with the pressed state", async () => {
     const styleFn = jest.fn(() => ({ backgroundColor: "blue" }));
-    render(
+    await render(
       <UiPressable style={styleFn}>
         <Text>child</Text>
       </UiPressable>,
@@ -72,10 +72,10 @@ describe("UiPressable", () => {
 
   it.each(["ios", "web"] as const)(
     "applies opacity feedback on %s (non-Android)",
-    (os) => {
+    async (os) => {
       Object.defineProperty(Platform, "OS", { value: os, configurable: true });
       const styleFn = jest.fn(() => ({}));
-      render(
+      await render(
         <UiPressable style={styleFn}>
           <Text>child</Text>
         </UiPressable>,
@@ -86,9 +86,9 @@ describe("UiPressable", () => {
     },
   );
 
-  it("caller style overrides the default pressed opacity", () => {
+  it("caller style overrides the default pressed opacity", async () => {
     Object.defineProperty(Platform, "OS", { value: "ios", configurable: true });
-    const { toJSON } = render(
+    const { toJSON } = await render(
       <UiPressable style={{ opacity: 1 }}>
         <Text>child</Text>
       </UiPressable>,
@@ -99,12 +99,12 @@ describe("UiPressable", () => {
     expect(combined.opacity).toBe(1);
   });
 
-  it("does not apply opacity on Android (ripple handles feedback)", () => {
+  it("does not apply opacity on Android (ripple handles feedback)", async () => {
     Object.defineProperty(Platform, "OS", {
       value: "android",
       configurable: true,
     });
-    const { toJSON } = render(
+    const { toJSON } = await render(
       <UiPressable style={{ padding: 8 }}>
         <Text>child</Text>
       </UiPressable>,

--- a/__tests__/components/ui/UiSpinner.test.tsx
+++ b/__tests__/components/ui/UiSpinner.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import { render } from "@testing-library/react-native";
 import React from "react";
-import { ActivityIndicator } from "react-native";
 
 // Stable mock for expo-image — persists through jest.resetModules() so the
 // component and test share the same MockImage reference.
@@ -34,30 +33,34 @@ describe("UiSpinner", () => {
       Spinner = loadSpinner(null);
     });
 
-    it("renders an ActivityIndicator", () => {
-      const { UNSAFE_getByType } = render(<Spinner />);
-      expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+    it("renders an ActivityIndicator", async () => {
+      // testID flows through UiSpinner's ActivityIndicatorProps spread onto the
+      // ActivityIndicator; RNTL 14 removed UNSAFE_getByType, so query by testID.
+      const { getByTestId } = await render(
+        <Spinner testID="activity-indicator" />,
+      );
+      expect(getByTestId("activity-indicator")).toBeTruthy();
     });
 
-    it("does not render text when text prop is omitted", () => {
-      const { queryByText } = render(<Spinner />);
+    it("does not render text when text prop is omitted", async () => {
+      const { queryByText } = await render(<Spinner />);
       expect(queryByText(/.+/)).toBeNull();
     });
 
-    it("renders text when text prop is provided", () => {
-      const { getByText } = render(<Spinner text="Lade Artikel..." />);
+    it("renders text when text prop is provided", async () => {
+      const { getByText } = await render(<Spinner text="Lade Artikel..." />);
       expect(getByText("Lade Artikel...")).toBeTruthy();
     });
 
-    it("applies textAlign:center to the text", () => {
-      const { getByText } = render(<Spinner text="Lade Artikel..." />);
+    it("applies textAlign:center to the text", async () => {
+      const { getByText } = await render(<Spinner text="Lade Artikel..." />);
       expect(getByText("Lade Artikel...").props.style).toMatchObject({
         textAlign: "center",
       });
     });
 
-    it("applies gap:12 to the container", () => {
-      const { toJSON } = render(<Spinner />);
+    it("applies gap:12 to the container", async () => {
+      const { toJSON } = await render(<Spinner />);
       const flatStyle = ((toJSON() as any).props.style as any[]).flat();
       expect(flatStyle).toContainEqual(expect.objectContaining({ gap: 12 }));
     });
@@ -69,18 +72,21 @@ describe("UiSpinner", () => {
       Spinner = loadSpinner({ uri: "logo_animated.gif" });
     });
 
-    it("does not render an ActivityIndicator", () => {
-      const { UNSAFE_queryAllByType } = render(<Spinner />);
-      expect(UNSAFE_queryAllByType(ActivityIndicator)).toHaveLength(0);
+    it("does not render an ActivityIndicator", async () => {
+      const { queryByTestId } = await render(
+        <Spinner testID="activity-indicator" />,
+      );
+      expect(queryByTestId("activity-indicator")).toBeNull();
     });
 
-    it("renders an expo-image Image", () => {
-      const { UNSAFE_getByType } = render(<Spinner />);
-      expect(UNSAFE_getByType(MockImage)).toBeTruthy();
+    it("renders an expo-image Image", async () => {
+      MockImage.mockClear();
+      await render(<Spinner />);
+      expect(MockImage).toHaveBeenCalled();
     });
 
-    it("still renders text when text prop is provided", () => {
-      const { getByText } = render(<Spinner text="Wird geladen..." />);
+    it("still renders text when text prop is provided", async () => {
+      const { getByText } = await render(<Spinner text="Wird geladen..." />);
       expect(getByText("Wird geladen...")).toBeTruthy();
     });
   });

--- a/__tests__/components/ui/UiTabIconLabel.test.tsx
+++ b/__tests__/components/ui/UiTabIconLabel.test.tsx
@@ -10,8 +10,8 @@ import UiTabIconLabel from "#/components/ui/UiTabIconLabel";
 const makeIcon = () => jest.fn((_color: string) => null);
 
 describe("UiTabIconLabel", () => {
-  it("renders the label text", () => {
-    const { getByText } = render(
+  it("renders the label text", async () => {
+    const { getByText } = await render(
       <UiTabIconLabel
         icon={makeIcon()}
         label="Favoriten"
@@ -22,9 +22,9 @@ describe("UiTabIconLabel", () => {
     expect(getByText("Favoriten")).toBeTruthy();
   });
 
-  it("calls onPress when the tab is pressed", () => {
+  it("calls onPress when the tab is pressed", async () => {
     const onPress = jest.fn();
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <UiTabIconLabel
         icon={makeIcon()}
         label="Favoriten"
@@ -32,13 +32,13 @@ describe("UiTabIconLabel", () => {
         onPress={onPress}
       />,
     );
-    fireEvent.press(getByRole("tab"));
+    await fireEvent.press(getByRole("tab"));
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
   describe("accessibility", () => {
-    it("exposes the label as accessibilityLabel", () => {
-      const { getByLabelText } = render(
+    it("exposes the label as accessibilityLabel", async () => {
+      const { getByLabelText } = await render(
         <UiTabIconLabel
           icon={makeIcon()}
           label="Favoriten"
@@ -49,8 +49,8 @@ describe("UiTabIconLabel", () => {
       expect(getByLabelText("Favoriten")).toBeTruthy();
     });
 
-    it("marks the tab as selected when active", () => {
-      const { getByRole } = render(
+    it("marks the tab as selected when active", async () => {
+      const { getByRole } = await render(
         <UiTabIconLabel
           icon={makeIcon()}
           label="Favoriten"
@@ -61,8 +61,8 @@ describe("UiTabIconLabel", () => {
       expect(getByRole("tab", { selected: true })).toBeTruthy();
     });
 
-    it("marks the tab as not selected when inactive", () => {
-      const { getByRole } = render(
+    it("marks the tab as not selected when inactive", async () => {
+      const { getByRole } = await render(
         <UiTabIconLabel
           icon={makeIcon()}
           label="Favoriten"
@@ -75,9 +75,9 @@ describe("UiTabIconLabel", () => {
   });
 
   describe("icon color", () => {
-    it("passes iconOnPrimary color to icon when active", () => {
+    it("passes iconOnPrimary color to icon when active", async () => {
       const icon = makeIcon();
-      render(
+      await render(
         <UiTabIconLabel
           icon={icon}
           label="Favoriten"
@@ -88,9 +88,9 @@ describe("UiTabIconLabel", () => {
       expect(icon).toHaveBeenCalledWith("#3893C0");
     });
 
-    it("passes iconMuted color to icon when inactive", () => {
+    it("passes iconMuted color to icon when inactive", async () => {
       const icon = makeIcon();
-      render(
+      await render(
         <UiTabIconLabel
           icon={icon}
           label="Favoriten"
@@ -103,8 +103,8 @@ describe("UiTabIconLabel", () => {
   });
 
   describe("background color", () => {
-    it("uses primary background when active", () => {
-      const { toJSON } = render(
+    it("uses primary background when active", async () => {
+      const { toJSON } = await render(
         <UiTabIconLabel
           icon={makeIcon()}
           label="Favoriten"
@@ -117,8 +117,8 @@ describe("UiTabIconLabel", () => {
       expect(combined.backgroundColor).toBe("#1b7194");
     });
 
-    it("uses muted background when inactive", () => {
-      const { toJSON } = render(
+    it("uses muted background when inactive", async () => {
+      const { toJSON } = await render(
         <UiTabIconLabel
           icon={makeIcon()}
           label="Favoriten"
@@ -133,8 +133,8 @@ describe("UiTabIconLabel", () => {
   });
 
   describe("label rendering", () => {
-    it("renders a static Animated.Text when no animation props are given", () => {
-      const { getByText } = render(
+    it("renders a static Animated.Text when no animation props are given", async () => {
+      const { getByText } = await render(
         <UiTabIconLabel
           icon={makeIcon()}
           label="Quellen"
@@ -145,7 +145,7 @@ describe("UiTabIconLabel", () => {
       expect(getByText("Quellen")).toBeTruthy();
     });
 
-    it("renders an animated label container when animatedLabelHeight is provided", () => {
+    it("renders an animated label container when animatedLabelHeight is provided", async () => {
       const animatedHeight = new Animated.Value(20).interpolate({
         inputRange: [0, 1],
         outputRange: [20, 0],
@@ -154,7 +154,7 @@ describe("UiTabIconLabel", () => {
         inputRange: [0, 1],
         outputRange: [1, 0],
       });
-      const { getByText } = render(
+      const { getByText } = await render(
         <UiTabIconLabel
           icon={makeIcon()}
           label="Quellen"

--- a/__tests__/components/ui/UiTabView.test.tsx
+++ b/__tests__/components/ui/UiTabView.test.tsx
@@ -5,8 +5,8 @@ import { Animated } from "react-native";
 import UiTabView from "#/components/ui/UiTabView";
 
 describe("UiTabView", () => {
-  it("renders children", () => {
-    const { getByText } = render(
+  it("renders children", async () => {
+    const { getByText } = await render(
       <UiTabView width={200}>
         <Animated.Text>Tab A</Animated.Text>
         <Animated.Text>Tab B</Animated.Text>
@@ -16,8 +16,8 @@ describe("UiTabView", () => {
     expect(getByText("Tab B")).toBeTruthy();
   });
 
-  it("renders a plain View without a height style when animatedHeight is not provided", () => {
-    const { toJSON } = render(
+  it("renders a plain View without a height style when animatedHeight is not provided", async () => {
+    const { toJSON } = await render(
       <UiTabView width={200}>
         <Animated.Text>content</Animated.Text>
       </UiTabView>,
@@ -30,12 +30,12 @@ describe("UiTabView", () => {
     expect(style.height).toBeUndefined();
   });
 
-  it("applies animatedHeight as the height style when provided", () => {
+  it("applies animatedHeight as the height style when provided", async () => {
     const animatedHeight = new Animated.Value(0).interpolate({
       inputRange: [0, 1],
       outputRange: [60, 40],
     });
-    const { toJSON } = render(
+    const { toJSON } = await render(
       <UiTabView width={200} animatedHeight={animatedHeight}>
         <Animated.Text>content</Animated.Text>
       </UiTabView>,
@@ -50,8 +50,8 @@ describe("UiTabView", () => {
     expect(style.width).toBe(200);
   });
 
-  it("applies pill shape styles", () => {
-    const { toJSON } = render(
+  it("applies pill shape styles", async () => {
+    const { toJSON } = await render(
       <UiTabView width={160}>
         <Animated.Text>content</Animated.Text>
       </UiTabView>,

--- a/__tests__/components/ui/UiTextInput.test.tsx
+++ b/__tests__/components/ui/UiTextInput.test.tsx
@@ -26,23 +26,23 @@ describe("TextInput", () => {
     jest.mocked(useAppColorScheme).mockReturnValue("light");
   });
 
-  it("renders with light theme colors", () => {
-    const { getByTestId } = render(<UiTextInput testID="input" />);
+  it("renders with light theme colors", async () => {
+    const { getByTestId } = await render(<UiTextInput testID="input" />);
     const style = flatStyle(getByTestId("input").props.style);
     expect(style.backgroundColor).toBe("#BADDE8");
     expect(style.color).toBe("#111");
   });
 
-  it("renders with dark theme colors", () => {
+  it("renders with dark theme colors", async () => {
     jest.mocked(useAppColorScheme).mockReturnValue("dark");
-    const { getByTestId } = render(<UiTextInput testID="input" />);
+    const { getByTestId } = await render(<UiTextInput testID="input" />);
     const style = flatStyle(getByTestId("input").props.style);
     expect(style.backgroundColor).toBe("#777");
     expect(style.color).toBe("#F7F7F7");
   });
 
-  it("merges additional style props", () => {
-    const { getByTestId } = render(
+  it("merges additional style props", async () => {
+    const { getByTestId } = await render(
       <UiTextInput testID="input" style={{ borderWidth: 1 }} />,
     );
     const style = flatStyle(getByTestId("input").props.style);
@@ -50,8 +50,8 @@ describe("TextInput", () => {
     expect(style.backgroundColor).toBe("#BADDE8");
   });
 
-  it("passes through other props", () => {
-    const { getByTestId } = render(
+  it("passes through other props", async () => {
+    const { getByTestId } = await render(
       <UiTextInput testID="input" placeholder="Search..." editable={false} />,
     );
     const input = getByTestId("input");

--- a/__tests__/components/views/EmptyComponent.test.tsx
+++ b/__tests__/components/views/EmptyComponent.test.tsx
@@ -43,30 +43,30 @@ jest.mock("#/components/Icons", () => {
 const Icon = () => <Text testID="custom-icon">icon</Text>;
 
 describe("EmptyComponent", () => {
-  it("renders the text", () => {
-    const { getByText } = render(
+  it("renders the text", async () => {
+    const { getByText } = await render(
       <EmptyComponent text="Nichts gefunden" icon={<Icon />} />,
     );
     expect(getByText("Nichts gefunden")).toBeTruthy();
   });
 
-  it("renders the icon", () => {
-    const { getByTestId } = render(
+  it("renders the icon", async () => {
+    const { getByTestId } = await render(
       <EmptyComponent text="Nichts gefunden" icon={<Icon />} />,
     );
     expect(getByTestId("custom-icon")).toBeTruthy();
   });
 
-  it("always renders the donate card", () => {
-    const { getByTestId, getByTestId: g } = render(
+  it("always renders the donate card", async () => {
+    const { getByTestId, getByTestId: g } = await render(
       <EmptyComponent text="text" icon={<Icon />} />,
     );
     expect(getByTestId("card")).toBeTruthy();
     expect(g("heart-icon")).toBeTruthy();
   });
 
-  it("renders children between the empty state and the donate card", () => {
-    const { getByTestId } = render(
+  it("renders children between the empty state and the donate card", async () => {
+    const { getByTestId } = await render(
       <EmptyComponent text="text" icon={<Icon />}>
         <Text testID="slot-content">between</Text>
       </EmptyComponent>,
@@ -75,17 +75,17 @@ describe("EmptyComponent", () => {
   });
 
   it("renders without children", () => {
-    expect(() =>
-      render(<EmptyComponent text="text" icon={<Icon />} />),
+    expect(
+      async () => await render(<EmptyComponent text="text" icon={<Icon />} />),
     ).not.toThrow();
   });
 
-  it("forwards onPress to the empty state", () => {
+  it("forwards onPress to the empty state", async () => {
     const onPress = jest.fn();
-    const { getByRole } = render(
+    const { getByRole } = await render(
       <EmptyComponent text="text" icon={<Icon />} onPress={onPress} />,
     );
-    fireEvent.press(getByRole("button"));
+    await fireEvent.press(getByRole("button"));
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/helpers/SettingsProvider.test.tsx
+++ b/__tests__/helpers/SettingsProvider.test.tsx
@@ -54,13 +54,13 @@ describe("SettingsProvider", () => {
     mockSettingsStore.setAdvancedSettings.mockResolvedValue(undefined as never);
   });
 
-  it("renders null while settings are loading", () => {
+  it("renders null while settings are loading", async () => {
     mockSettingsStore.getContentSettings.mockReturnValue(new Promise(() => {}));
     mockSettingsStore.getAdvancedSettings.mockReturnValue(
       new Promise(() => {}),
     );
 
-    const { toJSON } = render(
+    const { toJSON } = await render(
       <SettingsProvider>
         <Text testID="child">visible</Text>
       </SettingsProvider>,
@@ -77,7 +77,7 @@ describe("SettingsProvider", () => {
       {} as AdvancedSettingType,
     );
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <SettingsProvider>
         <Text testID="child">visible</Text>
       </SettingsProvider>,
@@ -95,7 +95,7 @@ describe("SettingsProvider", () => {
       alwaysDarkMode: { value: true, name: "Immer Dark Mode" },
     } as unknown as AdvancedSettingType);
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <SettingsProvider>
         <ConsumerComponent />
       </SettingsProvider>,
@@ -133,14 +133,16 @@ describe("SettingsProvider", () => {
       );
     };
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <SettingsProvider>
         <SetterComponent />
       </SettingsProvider>,
     );
 
     await waitFor(() => getByTestId("toggle"));
-    act(() => getByTestId("toggle").props.onPress());
+    await act(() => {
+      getByTestId("toggle").props.onPress();
+    });
 
     await waitFor(() =>
       expect(mockSettingsStore.setContentSettings).toHaveBeenCalledWith(
@@ -157,7 +159,7 @@ describe("SettingsProvider", () => {
       new Error("storage failure"),
     );
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <SettingsProvider>
         <Text testID="child">visible</Text>
       </SettingsProvider>,

--- a/__tests__/hooks/useAISearch.abort.test.tsx
+++ b/__tests__/hooks/useAISearch.abort.test.tsx
@@ -67,9 +67,11 @@ describe("useAISearch AbortController behavior", () => {
         return d2.promise;
       });
 
-    const { rerender, getByTestId } = render(<HookHarness search="first" />);
+    const { rerender, getByTestId } = await render(
+      <HookHarness search="first" />,
+    );
 
-    rerender(<HookHarness search="second" />);
+    await rerender(<HookHarness search="second" />);
 
     await waitFor(() => expect(vectorSearch).toHaveBeenCalledTimes(2));
     const firstSignal = vectorSearch.mock.calls[0][1] as AbortSignal;

--- a/__tests__/hooks/useAISearch.noResults.test.tsx
+++ b/__tests__/hooks/useAISearch.noResults.test.tsx
@@ -42,15 +42,15 @@ const Harness = ({ search }: { search: string }) => {
 describe("useAISearch — noResults", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("noResults is false while loading", () => {
+  it("noResults is false while loading", async () => {
     vectorSearch.mockReturnValue(new Promise(() => {}));
-    const { queryByTestId } = render(<Harness search="test" />);
+    const { queryByTestId } = await render(<Harness search="test" />);
     expect(queryByTestId("no-results")).toBeNull();
   });
 
   it("noResults becomes true when vectorSearch returns an empty array", async () => {
     vectorSearch.mockResolvedValue([] as AISearchResponse[]);
-    const { queryByTestId } = render(<Harness search="leer" />);
+    const { queryByTestId } = await render(<Harness search="leer" />);
     await waitFor(() => expect(queryByTestId("no-results")).not.toBeNull());
   });
 
@@ -58,7 +58,7 @@ describe("useAISearch — noResults", () => {
     vectorSearch.mockResolvedValue([
       { title: "Hit", text: "body", url: "https://example.com/1" },
     ]);
-    const { queryByTestId } = render(<Harness search="treffer" />);
+    const { queryByTestId } = await render(<Harness search="treffer" />);
     await waitFor(() => expect(queryByTestId("count").props.children).toBe(1));
     expect(queryByTestId("no-results")).toBeNull();
   });
@@ -68,11 +68,11 @@ describe("useAISearch — noResults", () => {
       .mockResolvedValueOnce([] as AISearchResponse[])
       .mockReturnValueOnce(new Promise(() => {}));
 
-    const { queryByTestId, rerender } = render(<Harness search="leer" />);
+    const { queryByTestId, rerender } = await render(<Harness search="leer" />);
     await waitFor(() => expect(queryByTestId("no-results")).not.toBeNull());
 
-    act(() => {
-      rerender(<Harness search="neu" />);
+    await act(async () => {
+      await rerender(<Harness search="neu" />);
     });
 
     expect(queryByTestId("no-results")).toBeNull();

--- a/__tests__/hooks/useNotificationObserver.test.ts
+++ b/__tests__/hooks/useNotificationObserver.test.ts
@@ -44,8 +44,8 @@ describe("useNotificationObserver", () => {
       mockIsFoss = false;
     });
 
-    it("subscribes to notification responses on mount", () => {
-      renderHook(() => useNotificationObserver());
+    it("subscribes to notification responses on mount", async () => {
+      await renderHook(() => useNotificationObserver());
 
       expect(
         Notifications.getLastNotificationResponseAsync,
@@ -55,14 +55,14 @@ describe("useNotificationObserver", () => {
       ).toHaveBeenCalledTimes(1);
     });
 
-    it("removes the listener on unmount", () => {
+    it("removes the listener on unmount", async () => {
       const mockRemove = jest.fn();
       (
         Notifications.addNotificationResponseReceivedListener as jest.Mock
       ).mockReturnValue({ remove: mockRemove });
 
-      const { unmount } = renderHook(() => useNotificationObserver());
-      unmount();
+      const { unmount } = await renderHook(() => useNotificationObserver());
+      await unmount();
 
       expect(mockRemove).toHaveBeenCalledTimes(1);
     });
@@ -77,8 +77,8 @@ describe("useNotificationObserver", () => {
       mockIsFoss = false;
     });
 
-    it("does not subscribe to notifications", () => {
-      renderHook(() => useNotificationObserver());
+    it("does not subscribe to notifications", async () => {
+      await renderHook(() => useNotificationObserver());
 
       expect(
         Notifications.getLastNotificationResponseAsync,

--- a/__tests__/screens/Home/Feed.abort.test.tsx
+++ b/__tests__/screens/Home/Feed.abort.test.tsx
@@ -77,7 +77,7 @@ describe("Feed AbortController behavior", () => {
       .mockImplementationOnce(() => d2.promise);
 
     const fetcher = jest.fn(() => Promise.resolve([]));
-    const { rerender, unmount } = render(
+    const { rerender, unmount } = await render(
       <Feed fetchers={[{ fetcher, props: {} }]} />,
     );
 
@@ -86,7 +86,7 @@ describe("Feed AbortController behavior", () => {
       fetchAndProcessPosts.mock.calls[0][1] as { signal: AbortSignal }
     ).signal;
 
-    rerender(
+    await rerender(
       <Feed
         fetchers={[
           { fetcher, props: {} },
@@ -104,7 +104,7 @@ describe("Feed AbortController behavior", () => {
     expect(firstSignal.aborted).toBe(true);
     expect(secondSignal.aborted).toBe(false);
 
-    unmount();
+    await unmount();
 
     await act(async () => {
       d1.resolve([]);

--- a/__tests__/screens/Home/Feed.announcements.test.tsx
+++ b/__tests__/screens/Home/Feed.announcements.test.tsx
@@ -102,7 +102,7 @@ describe("Feed announcements", () => {
   });
 
   it("does not show an announcement when showAnnouncements is not set", async () => {
-    const { getByTestId, queryByTestId } = render(
+    const { getByTestId, queryByTestId } = await render(
       <Feed fetchers={[{ fetcher: jest.fn().mockResolvedValue(posts) }]} />,
     );
     await waitFor(() => expect(getByTestId("post-item")).toBeTruthy());
@@ -110,7 +110,7 @@ describe("Feed announcements", () => {
   });
 
   it("shows the first non-dismissed announcement when showAnnouncements is set", async () => {
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText } = await render(
       <Feed
         showAnnouncements
         fetchers={[{ fetcher: jest.fn().mockResolvedValue(posts) }]}
@@ -122,7 +122,7 @@ describe("Feed announcements", () => {
 
   it("does not show an announcement already recorded as dismissed", async () => {
     mockGetDismissed.mockResolvedValue(["test-announcement"]);
-    const { getByTestId, queryByTestId } = render(
+    const { getByTestId, queryByTestId } = await render(
       <Feed
         showAnnouncements
         fetchers={[{ fetcher: jest.fn().mockResolvedValue(posts) }]}
@@ -133,7 +133,7 @@ describe("Feed announcements", () => {
   });
 
   it("hides the announcement and persists dismissal when dismissed", async () => {
-    const { getByTestId, queryByTestId } = render(
+    const { getByTestId, queryByTestId } = await render(
       <Feed
         showAnnouncements
         fetchers={[{ fetcher: jest.fn().mockResolvedValue(posts) }]}
@@ -141,7 +141,7 @@ describe("Feed announcements", () => {
     );
     await waitFor(() => expect(getByTestId("announcement-card")).toBeTruthy());
 
-    fireEvent.press(getByTestId("announcement-card"));
+    await fireEvent.press(getByTestId("announcement-card"));
 
     await waitFor(() => expect(queryByTestId("announcement-card")).toBeNull());
     expect(mockDismiss).toHaveBeenCalledWith("test-announcement");
@@ -149,7 +149,7 @@ describe("Feed announcements", () => {
 
   it("still shows the empty state alongside the announcement when the feed is empty", async () => {
     mockFetch.mockResolvedValue([]);
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <Feed
         showAnnouncements
         fetchers={[{ fetcher: jest.fn().mockResolvedValue([]) }]}

--- a/__tests__/screens/Home/Feed.render.test.tsx
+++ b/__tests__/screens/Home/Feed.render.test.tsx
@@ -58,7 +58,7 @@ describe("Feed rendering", () => {
   beforeEach(() => jest.clearAllMocks());
 
   it("shows empty state when fetchers array is empty", async () => {
-    const { getByTestId } = render(<Feed fetchers={[]} />);
+    const { getByTestId } = await render(<Feed fetchers={[]} />);
     await waitFor(() => expect(getByTestId("empty-state")).toBeTruthy());
   });
 
@@ -78,7 +78,7 @@ describe("Feed rendering", () => {
     mockFetch.mockResolvedValueOnce(posts);
 
     const fetcher = jest.fn().mockResolvedValue(posts);
-    const { getByTestId } = render(<Feed fetchers={[{ fetcher }]} />);
+    const { getByTestId } = await render(<Feed fetchers={[{ fetcher }]} />);
 
     await waitFor(() => expect(getByTestId("post-item")).toBeTruthy());
   });
@@ -109,7 +109,7 @@ describe("Feed rendering", () => {
     mockFetch.mockResolvedValueOnce(posts);
 
     const fetcher = jest.fn().mockResolvedValue(posts);
-    const { getAllByTestId } = render(<Feed fetchers={[{ fetcher }]} />);
+    const { getAllByTestId } = await render(<Feed fetchers={[{ fetcher }]} />);
 
     await waitFor(() => expect(getAllByTestId("post-item")).toHaveLength(2));
   });

--- a/__tests__/screens/Home/Recommended.abort.test.tsx
+++ b/__tests__/screens/Home/Recommended.abort.test.tsx
@@ -64,7 +64,7 @@ describe("Recommended", () => {
       ],
     });
 
-    render(<Recommended article_link="https://example.com/article" />);
+    await render(<Recommended article_link="https://example.com/article" />);
 
     await waitFor(() => expect(recommendations).toHaveBeenCalledTimes(1));
   });
@@ -77,7 +77,7 @@ describe("Recommended", () => {
       .mockImplementation(() => {});
     recommendations.mockRejectedValue(new Error("network failure"));
 
-    render(<Recommended article_link="https://example.com/article" />);
+    await render(<Recommended article_link="https://example.com/article" />);
 
     await waitFor(() =>
       expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -99,14 +99,14 @@ describe("Recommended AbortController behavior", () => {
 
     recommendations.mockReturnValue(d.promise);
 
-    const { unmount } = render(
+    const { unmount } = await render(
       <Recommended article_link="https://example.com/article" />,
     );
 
     await waitFor(() => expect(recommendations).toHaveBeenCalledTimes(1));
     const signal = recommendations.mock.calls[0][1] as AbortSignal;
 
-    unmount();
+    await unmount();
     expect(signal.aborted).toBe(true);
 
     await act(async () => {

--- a/__tests__/screens/Home/components/article/ArticleSourceList.test.tsx
+++ b/__tests__/screens/Home/components/article/ArticleSourceList.test.tsx
@@ -55,10 +55,10 @@ const defaultProps = {
   slug: "test-artikel",
 };
 
-const openCollapsable = (
-  getAllByRole: ReturnType<typeof render>["getAllByRole"],
+const openCollapsable = async (
+  getAllByRole: Awaited<ReturnType<typeof render>>["getAllByRole"],
 ) => {
-  fireEvent.press(getAllByRole("button")[0]);
+  await fireEvent.press(getAllByRole("button")[0]);
 };
 
 describe("ArticleSourceList", () => {
@@ -69,39 +69,51 @@ describe("ArticleSourceList", () => {
   });
 
   describe("initial render", () => {
-    it("renders the Quellen title", () => {
-      const { getByText } = render(<ArticleSourceList {...defaultProps} />);
+    it("renders the Quellen title", async () => {
+      const { getByText } = await render(
+        <ArticleSourceList {...defaultProps} />,
+      );
       expect(getByText("Quellen")).toBeTruthy();
     });
 
-    it("does not call getLinks while collapsed", () => {
-      render(<ArticleSourceList {...defaultProps} />);
+    it("does not call getLinks while collapsed", async () => {
+      await render(<ArticleSourceList {...defaultProps} />);
       expect(mockGetLinks).not.toHaveBeenCalled();
     });
   });
 
   describe("engagement disabled", () => {
-    it("shows Keine Daten after opening when engagement is off", () => {
+    it("shows Keine Daten after opening when engagement is off", async () => {
       mockConfig.enableEngagement = false;
-      const { getAllByRole, getByText } = render(
+      const { getAllByRole, getByText } = await render(
         <ArticleSourceList {...defaultProps} />,
       );
-      act(() => openCollapsable(getAllByRole));
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       expect(getByText("Keine Daten")).toBeTruthy();
     });
 
-    it("does not call getLinks when engagement is disabled", () => {
+    it("does not call getLinks when engagement is disabled", async () => {
       mockConfig.enableEngagement = false;
-      const { getAllByRole } = render(<ArticleSourceList {...defaultProps} />);
-      act(() => openCollapsable(getAllByRole));
+      const { getAllByRole } = await render(
+        <ArticleSourceList {...defaultProps} />,
+      );
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       expect(mockGetLinks).not.toHaveBeenCalled();
     });
   });
 
   describe("fetching links", () => {
     it("calls getLinks with article_link when opened", async () => {
-      const { getAllByRole } = render(<ArticleSourceList {...defaultProps} />);
-      act(() => openCollapsable(getAllByRole));
+      const { getAllByRole } = await render(
+        <ArticleSourceList {...defaultProps} />,
+      );
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       await waitFor(() =>
         expect(mockGetLinks).toHaveBeenCalledWith(ARTICLE_LINK),
       );
@@ -116,33 +128,41 @@ describe("ArticleSourceList", () => {
           resolveLinks = resolve;
         }),
       );
-      const { getAllByRole, queryByText } = render(
+      const { getAllByRole, queryByText } = await render(
         <ArticleSourceList {...defaultProps} />,
       );
-      act(() => openCollapsable(getAllByRole));
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
 
       // While the request is in flight it must not prematurely claim "no data".
       expect(queryByText("Keine Daten")).toBeNull();
 
-      act(() => resolveLinks([]));
+      await act(() => {
+        resolveLinks([]);
+      });
       await waitFor(() => expect(queryByText("Keine Daten")).toBeTruthy());
     });
 
     it("shows Keine Daten when getLinks returns empty array", async () => {
       mockGetLinks.mockResolvedValue([]);
-      const { getAllByRole, getByText } = render(
+      const { getAllByRole, getByText } = await render(
         <ArticleSourceList {...defaultProps} />,
       );
-      act(() => openCollapsable(getAllByRole));
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       await waitFor(() => expect(getByText("Keine Daten")).toBeTruthy());
     });
 
     it("shows link rows when getLinks returns results", async () => {
       mockGetLinks.mockResolvedValue([{ url: SOURCE_URL, visitors: 42 }]);
-      const { getAllByRole, getByText } = render(
+      const { getAllByRole, getByText } = await render(
         <ArticleSourceList {...defaultProps} />,
       );
-      act(() => openCollapsable(getAllByRole));
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       await waitFor(() => expect(getByText("42 Clicks")).toBeTruthy());
     });
 
@@ -151,20 +171,24 @@ describe("ArticleSourceList", () => {
         { url: SOURCE_URL, visitors: 0 },
         { url: "https://example.com/other" as HttpsUrl, visitors: 5 },
       ]);
-      const { getAllByRole, queryByText, getByText } = render(
+      const { getAllByRole, queryByText, getByText } = await render(
         <ArticleSourceList {...defaultProps} />,
       );
-      act(() => openCollapsable(getAllByRole));
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       await waitFor(() => expect(getByText("5 Clicks")).toBeTruthy());
       expect(queryByText("0 Clicks")).toBeNull();
     });
 
     it("shows Keine Daten when all links have zero visitors", async () => {
       mockGetLinks.mockResolvedValue([{ url: SOURCE_URL, visitors: 0 }]);
-      const { getAllByRole, getByText } = render(
+      const { getAllByRole, getByText } = await render(
         <ArticleSourceList {...defaultProps} />,
       );
-      act(() => openCollapsable(getAllByRole));
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       await waitFor(() => expect(getByText("Keine Daten")).toBeTruthy());
     });
   });
@@ -174,10 +198,12 @@ describe("ArticleSourceList", () => {
       const urlWithQuery =
         "https://example.com/page?utm_source=vvp" as HttpsUrl;
       mockGetLinks.mockResolvedValue([{ url: urlWithQuery, visitors: 3 }]);
-      const { getAllByRole, getByText } = render(
+      const { getAllByRole, getByText } = await render(
         <ArticleSourceList {...defaultProps} />,
       );
-      act(() => openCollapsable(getAllByRole));
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       await waitFor(() =>
         expect(getByText("https://example.com/page")).toBeTruthy(),
       );
@@ -186,10 +212,12 @@ describe("ArticleSourceList", () => {
     it("strips hash fragments from the displayed URL", async () => {
       const urlWithHash = "https://example.com/page#section" as HttpsUrl;
       mockGetLinks.mockResolvedValue([{ url: urlWithHash, visitors: 3 }]);
-      const { getAllByRole, getByText } = render(
+      const { getAllByRole, getByText } = await render(
         <ArticleSourceList {...defaultProps} />,
       );
-      act(() => openCollapsable(getAllByRole));
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       await waitFor(() =>
         expect(getByText("https://example.com/page")).toBeTruthy(),
       );
@@ -201,12 +229,16 @@ describe("ArticleSourceList", () => {
 
     it("calls outBoundLinkPress with the source url and article_link", async () => {
       mockGetLinks.mockResolvedValue(links);
-      const { getAllByRole } = render(<ArticleSourceList {...defaultProps} />);
-      act(() => openCollapsable(getAllByRole));
+      const { getAllByRole } = await render(
+        <ArticleSourceList {...defaultProps} />,
+      );
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       await waitFor(() =>
         expect(getAllByRole("button").length).toBeGreaterThan(1),
       );
-      fireEvent.press(getAllByRole("button")[1]);
+      await fireEvent.press(getAllByRole("button")[1]);
       await waitFor(() =>
         expect(mockOutBoundLinkPress).toHaveBeenCalledWith(
           SOURCE_URL,
@@ -217,12 +249,16 @@ describe("ArticleSourceList", () => {
 
     it("calls SourcesStore.onAddSource when engagement is enabled", async () => {
       mockGetLinks.mockResolvedValue(links);
-      const { getAllByRole } = render(<ArticleSourceList {...defaultProps} />);
-      act(() => openCollapsable(getAllByRole));
+      const { getAllByRole } = await render(
+        <ArticleSourceList {...defaultProps} />,
+      );
+      await act(async () => {
+        await openCollapsable(getAllByRole);
+      });
       await waitFor(() =>
         expect(getAllByRole("button").length).toBeGreaterThan(1),
       );
-      fireEvent.press(getAllByRole("button")[1]);
+      await fireEvent.press(getAllByRole("button")[1]);
       await waitFor(() =>
         expect(mockOnAddSource).toHaveBeenCalledWith(
           SOURCE_URL,

--- a/__tests__/screens/Home/components/article/ArticleStats.test.tsx
+++ b/__tests__/screens/Home/components/article/ArticleStats.test.tsx
@@ -33,31 +33,31 @@ describe("ArticleStats — reading time", () => {
     mockConfig.enableEngagement = true;
   });
 
-  it("renders reading time with clock icon label when reading_time is set", () => {
-    const { getByText } = render(
+  it("renders reading time with clock icon label when reading_time is set", async () => {
+    const { getByText } = await render(
       <ArticleStats article_link={article_link} reading_time={12} />,
     );
     expect(getByText("12 Min.")).toBeTruthy();
   });
 
-  it("does not render reading time when reading_time is undefined", () => {
-    const { queryByText } = render(
+  it("does not render reading time when reading_time is undefined", async () => {
+    const { queryByText } = await render(
       <ArticleStats article_link={article_link} reading_time={undefined} />,
     );
     expect(queryByText(/Min\./)).toBeNull();
   });
 
-  it("renders reading time even when engagement is disabled", () => {
+  it("renders reading time even when engagement is disabled", async () => {
     mockConfig.enableEngagement = false;
-    const { getByText } = render(
+    const { getByText } = await render(
       <ArticleStats article_link={article_link} reading_time={5} />,
     );
     expect(getByText("5 Min.")).toBeTruthy();
   });
 
-  it("returns nothing when engagement is disabled and reading_time is absent", () => {
+  it("returns nothing when engagement is disabled and reading_time is absent", async () => {
     mockConfig.enableEngagement = false;
-    const { toJSON } = render(
+    const { toJSON } = await render(
       <ArticleStats article_link={article_link} reading_time={undefined} />,
     );
     expect(toJSON()).toBeNull();

--- a/__tests__/screens/Home/components/article/Header.test.tsx
+++ b/__tests__/screens/Home/components/article/Header.test.tsx
@@ -95,8 +95,8 @@ describe("Header — reading time forwarded to ArticleStats", () => {
     ).default;
   });
 
-  it("passes reading_time to ArticleStats when set", () => {
-    render(
+  it("passes reading_time to ArticleStats when set", async () => {
+    await render(
       <Header
         {...defaultProps}
         article={{ ...baseArticle, reading_time: 8 }}
@@ -107,8 +107,8 @@ describe("Header — reading time forwarded to ArticleStats", () => {
     });
   });
 
-  it("passes undefined reading_time to ArticleStats when absent", () => {
-    render(
+  it("passes undefined reading_time to ArticleStats when absent", async () => {
+    await render(
       <Header
         {...defaultProps}
         article={{ ...baseArticle, reading_time: undefined }}
@@ -125,8 +125,8 @@ describe("Header — author byline", () => {
     jest.clearAllMocks();
   });
 
-  it("renders the author display name when authors are provided", () => {
-    const { getAllByText } = render(
+  it("renders the author display name when authors are provided", async () => {
+    const { getAllByText } = await render(
       <Header
         {...defaultProps}
         article={{ ...baseArticle, authors: [testAuthor] }}
@@ -136,8 +136,8 @@ describe("Header — author byline", () => {
     expect(getAllByText("Jane Doe").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("hides the author byline when authors is undefined", () => {
-    const { queryByText } = render(
+  it("hides the author byline when authors is undefined", async () => {
+    const { queryByText } = await render(
       <Header
         {...defaultProps}
         article={{ ...baseArticle, authors: undefined }}
@@ -146,15 +146,15 @@ describe("Header — author byline", () => {
     expect(queryByText(/\bvon\b/)).toBeNull();
   });
 
-  it("hides the author byline when authors is an empty array", () => {
-    const { queryByText } = render(
+  it("hides the author byline when authors is an empty array", async () => {
+    const { queryByText } = await render(
       <Header {...defaultProps} article={{ ...baseArticle, authors: [] }} />,
     );
     expect(queryByText(/\bvon\b/)).toBeNull();
   });
 
-  it("always renders the article date regardless of authors", () => {
-    const { getAllByText } = render(
+  it("always renders the article date regardless of authors", async () => {
+    const { getAllByText } = await render(
       <Header
         {...defaultProps}
         article={{ ...baseArticle, authors: undefined }}
@@ -172,22 +172,22 @@ describe("Header — AudioPlayer integration", () => {
     mockConfig.audioCdnUrl = undefined;
   });
 
-  it("does not render AudioPlayer when audioCdnUrl is not configured", () => {
-    render(<Header {...defaultProps} />);
+  it("does not render AudioPlayer when audioCdnUrl is not configured", async () => {
+    await render(<Header {...defaultProps} />);
     expect(MockAudioPlayer).not.toHaveBeenCalled();
   });
 
-  it("renders AudioPlayer with the correct URL when audioCdnUrl is set", () => {
+  it("renders AudioPlayer with the correct URL when audioCdnUrl is set", async () => {
     mockConfig.audioCdnUrl = "https://vvpaudio.b-cdn.net/audio";
-    render(<Header {...defaultProps} />);
+    await render(<Header {...defaultProps} />);
     expect(MockAudioPlayer.mock.calls[0][0]).toMatchObject({
       audioUrl: "https://vvpaudio.b-cdn.net/audio/test-article.mp3",
     });
   });
 
-  it("strips a trailing slash from audioCdnUrl before building the URL", () => {
+  it("strips a trailing slash from audioCdnUrl before building the URL", async () => {
     mockConfig.audioCdnUrl = "https://vvpaudio.b-cdn.net/audio/";
-    render(<Header {...defaultProps} />);
+    await render(<Header {...defaultProps} />);
     expect(MockAudioPlayer.mock.calls[0][0]).toMatchObject({
       audioUrl: "https://vvpaudio.b-cdn.net/audio/test-article.mp3",
     });

--- a/__tests__/screens/Home/components/article/renderer/BlockRenderer.test.tsx
+++ b/__tests__/screens/Home/components/article/renderer/BlockRenderer.test.tsx
@@ -32,8 +32,8 @@ const baseRenderProps = {
   renderIndex: 0,
 };
 
-const wrap = (ui: React.ReactElement, advancedReporting = false) =>
-  render(
+const wrap = async (ui: React.ReactElement, advancedReporting = false) =>
+  await render(
     <SettingsContext.Provider
       value={{
         advancedSettings: {
@@ -49,23 +49,23 @@ const wrap = (ui: React.ReactElement, advancedReporting = false) =>
   );
 
 describe("BlockRenderer", () => {
-  it("renders nothing when TDefaultRenderer is absent from renderProps", () => {
-    const { toJSON } = wrap(
+  it("renders nothing when TDefaultRenderer is absent from renderProps", async () => {
+    const { toJSON } = await wrap(
       <BlockRenderer renderProps={{ renderIndex: 0 } as any} url={url} />,
     );
     expect(toJSON()).toBeNull();
   });
 
-  it("renders the TDefaultRenderer content without a ReportingWrapper by default", () => {
-    const { getByTestId, queryByTestId } = wrap(
+  it("renders the TDefaultRenderer content without a ReportingWrapper by default", async () => {
+    const { getByTestId, queryByTestId } = await wrap(
       <BlockRenderer renderProps={baseRenderProps} url={url} />,
     );
     expect(getByTestId("default-renderer")).toBeTruthy();
     expect(queryByTestId("reporting-wrapper")).toBeNull();
   });
 
-  it("wraps content in ReportingWrapper when advancedReporting is enabled", () => {
-    const { getByTestId } = wrap(
+  it("wraps content in ReportingWrapper when advancedReporting is enabled", async () => {
+    const { getByTestId } = await wrap(
       <BlockRenderer renderProps={baseRenderProps} url={url} />,
       true,
     );
@@ -73,8 +73,8 @@ describe("BlockRenderer", () => {
     expect(getByTestId("default-renderer")).toBeTruthy();
   });
 
-  it("passes renderIndex to ReportingWrapper", () => {
-    const { getByTestId } = wrap(
+  it("passes renderIndex to ReportingWrapper", async () => {
+    const { getByTestId } = await wrap(
       <BlockRenderer
         renderProps={{ ...baseRenderProps, renderIndex: 3 }}
         url={url}

--- a/__tests__/screens/Home/components/article/renderer/ImageRenderer.test.tsx
+++ b/__tests__/screens/Home/components/article/renderer/ImageRenderer.test.tsx
@@ -49,30 +49,32 @@ const baseRenderProps = {
 describe("ImageRenderer", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("renders without crashing", () => {
-    const { toJSON } = render(<ImageRenderer {...baseRenderProps} />);
+  it("renders without crashing", async () => {
+    const { toJSON } = await render(<ImageRenderer {...baseRenderProps} />);
     expect(toJSON()).not.toBeNull();
   });
 
-  it("navigates to /image with the uri on press", () => {
-    const { getByTestId } = render(<ImageRenderer {...baseRenderProps} />);
-    fireEvent.press(getByTestId("image-pressable"));
+  it("navigates to /image with the uri on press", async () => {
+    const { getByTestId } = await render(
+      <ImageRenderer {...baseRenderProps} />,
+    );
+    await fireEvent.press(getByTestId("image-pressable"));
     expect(mockPush).toHaveBeenCalledWith({
       pathname: "/image",
       params: { uri: "https://example.com/article-image.jpg" },
     });
   });
 
-  it("renders the image with the uri from renderer props", () => {
+  it("renders the image with the uri from renderer props", async () => {
     const { Image } = jest.requireMock("expo-image");
-    render(<ImageRenderer {...baseRenderProps} />);
+    await render(<ImageRenderer {...baseRenderProps} />);
     const [props] = Image.mock.calls[0];
     expect(props.source.uri).toBe("https://example.com/article-image.jpg");
   });
 
-  it("updates aspect ratio after image loads", () => {
+  it("updates aspect ratio after image loads", async () => {
     const { Image } = jest.requireMock("expo-image");
-    render(<ImageRenderer {...baseRenderProps} />);
+    await render(<ImageRenderer {...baseRenderProps} />);
     const [firstProps] = Image.mock.calls[0];
     expect(firstProps.onLoad).toBeDefined();
     act(() => {

--- a/__tests__/screens/Onboarding/components/Stepper.test.tsx
+++ b/__tests__/screens/Onboarding/components/Stepper.test.tsx
@@ -44,57 +44,57 @@ describe("StandardStepper", () => {
   });
 
   describe("back button", () => {
-    it("hides the back button on the first step", () => {
-      const { queryByText } = render(
+    it("hides the back button on the first step", async () => {
+      const { queryByText } = await render(
         <StandardStepper step={0} data={makeData(3)} {...defaultHandlers} />,
       );
       expect(queryByText("Zurück")).toBeNull();
     });
 
-    it("shows the back button on steps after the first", () => {
-      const { getByText } = render(
+    it("shows the back button on steps after the first", async () => {
+      const { getByText } = await render(
         <StandardStepper step={1} data={makeData(3)} {...defaultHandlers} />,
       );
       expect(getByText("Zurück")).toBeTruthy();
     });
 
-    it("calls previousStep when the back button is pressed", () => {
-      const { getByText } = render(
+    it("calls previousStep when the back button is pressed", async () => {
+      const { getByText } = await render(
         <StandardStepper step={2} data={makeData(4)} {...defaultHandlers} />,
       );
-      fireEvent.press(getByText("Zurück"));
+      await fireEvent.press(getByText("Zurück"));
       expect(defaultHandlers.previousStep).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("next button", () => {
-    it("shows Weiter on steps before the last", () => {
-      const { getByText } = render(
+    it("shows Weiter on steps before the last", async () => {
+      const { getByText } = await render(
         <StandardStepper step={0} data={makeData(3)} {...defaultHandlers} />,
       );
       expect(getByText("Weiter")).toBeTruthy();
     });
 
-    it("calls nextStep when Weiter is pressed", () => {
-      const { getByText } = render(
+    it("calls nextStep when Weiter is pressed", async () => {
+      const { getByText } = await render(
         <StandardStepper step={1} data={makeData(3)} {...defaultHandlers} />,
       );
-      fireEvent.press(getByText("Weiter"));
+      await fireEvent.press(getByText("Weiter"));
       expect(defaultHandlers.nextStep).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("finish button", () => {
-    it("shows the finish button on the last step instead of Weiter", () => {
-      const { getByText, queryByText } = render(
+    it("shows the finish button on the last step instead of Weiter", async () => {
+      const { getByText, queryByText } = await render(
         <StandardStepper step={2} data={makeData(3)} {...defaultHandlers} />,
       );
       expect(getByText("Get Started")).toBeTruthy();
       expect(queryByText("Weiter")).toBeNull();
     });
 
-    it("uses buttonTitle prop when provided", () => {
-      const { getByText } = render(
+    it("uses buttonTitle prop when provided", async () => {
+      const { getByText } = await render(
         <StandardStepper
           step={2}
           data={makeData(3)}
@@ -105,11 +105,11 @@ describe("StandardStepper", () => {
       expect(getByText("Jetzt starten")).toBeTruthy();
     });
 
-    it("calls onFinish when the finish button is pressed", () => {
-      const { getByText } = render(
+    it("calls onFinish when the finish button is pressed", async () => {
+      const { getByText } = await render(
         <StandardStepper step={2} data={makeData(3)} {...defaultHandlers} />,
       );
-      fireEvent.press(getByText("Get Started"));
+      await fireEvent.press(getByText("Get Started"));
       expect(defaultHandlers.onFinish).toHaveBeenCalledTimes(1);
     });
   });

--- a/__tests__/screens/PersonalTab/MySources.test.tsx
+++ b/__tests__/screens/PersonalTab/MySources.test.tsx
@@ -5,6 +5,7 @@ import {
   within,
 } from "@testing-library/react-native";
 import { useFocusEffect } from "expo-router";
+import { useEffect } from "react";
 
 import SourcesStore from "#/helpers/Stores/SourcesStore";
 import MySources from "#/screens/PersonalTab/components/MySources";
@@ -72,15 +73,19 @@ const sources = {
 describe("MySources", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Mirror the real useFocusEffect: run the (stable, []-memoized) callback
+    // once on mount rather than on every render. Re-running on each render would
+    // re-fetch the full list and resurrect entries removed via handleDelete —
+    // which RNTL 14's extra async flushing now surfaces as a flaky failure.
     jest.mocked(useFocusEffect).mockImplementation((cb) => {
-      cb();
+      useEffect(() => cb(), [cb]);
     });
     jest.mocked(SourcesStore.getAllSources).mockResolvedValue(sources as any);
     jest.mocked(SourcesStore.removeSource).mockResolvedValue(undefined);
   });
 
   it("groups sources by slug, showing one heading per article", async () => {
-    const { queryAllByText } = render(<MySources />);
+    const { queryAllByText } = await render(<MySources />);
     await waitFor(() => {
       expect(queryAllByText("Article A")).toHaveLength(1);
       expect(queryAllByText("Article B")).toHaveLength(1);
@@ -88,7 +93,7 @@ describe("MySources", () => {
   });
 
   it("renders all URLs belonging to a slug group", async () => {
-    const { getByText } = render(<MySources />);
+    const { getByText } = await render(<MySources />);
     await waitFor(() => {
       expect(getByText("https://example.com/source-a1")).toBeTruthy();
       expect(getByText("https://example.com/source-a2")).toBeTruthy();
@@ -97,7 +102,7 @@ describe("MySources", () => {
   });
 
   it("removes only the tapped entry and keeps the rest visible", async () => {
-    const { getByTestId, queryByText } = render(<MySources />);
+    const { getByTestId, queryByText } = await render(<MySources />);
 
     await waitFor(() => {
       expect(
@@ -106,7 +111,7 @@ describe("MySources", () => {
     });
 
     const row = getByTestId("source-row-https://example.com/source-a2");
-    fireEvent.press(within(row).getByLabelText("Löschen"));
+    await fireEvent.press(within(row).getByLabelText("Löschen"));
 
     await waitFor(() => {
       expect(SourcesStore.removeSource).toHaveBeenCalledTimes(1);

--- a/__tests__/screens/ReportTab/ReportStatusListItem.test.tsx
+++ b/__tests__/screens/ReportTab/ReportStatusListItem.test.tsx
@@ -38,7 +38,7 @@ describe("ReportStatusListItem", () => {
       status: "pending",
     });
 
-    const { getByText } = render(<ReportStatusListItem id="abc-123" />);
+    const { getByText } = await render(<ReportStatusListItem id="abc-123" />);
 
     await waitFor(() => expect(getReportStatus).toHaveBeenCalled());
     expect(getByText("abc-123")).toBeTruthy();
@@ -47,7 +47,7 @@ describe("ReportStatusListItem", () => {
   it("passes the signal to getReportStatus", async () => {
     (getReportStatus as jest.Mock<any>).mockResolvedValue({ status: "posted" });
 
-    render(<ReportStatusListItem id="rep-1" />);
+    await render(<ReportStatusListItem id="rep-1" />);
 
     await waitFor(() => expect(getReportStatus).toHaveBeenCalledTimes(1));
 
@@ -64,14 +64,14 @@ describe("ReportStatusListItem", () => {
     });
     getReportStatus.mockReturnValue(pending);
 
-    const { unmount } = render(<ReportStatusListItem id="rep-2" />);
+    const { unmount } = await render(<ReportStatusListItem id="rep-2" />);
 
     await waitFor(() => expect(getReportStatus).toHaveBeenCalledTimes(1));
 
     const signal = (getReportStatus.mock.calls[0] as [string, AbortSignal])[1];
     expect(signal.aborted).toBe(false);
 
-    unmount();
+    await unmount();
     expect(signal.aborted).toBe(true);
 
     await act(() => {
@@ -89,10 +89,10 @@ describe("ReportStatusListItem", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {});
 
-    const { unmount } = render(<ReportStatusListItem id="rep-3" />);
+    const { unmount } = await render(<ReportStatusListItem id="rep-3" />);
     await waitFor(() => expect(getReportStatus).toHaveBeenCalled());
 
-    unmount();
+    await unmount();
 
     await act(() => {
       resolve({ status: "posted" });
@@ -110,7 +110,7 @@ describe("ReportStatusListItem", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {});
 
-    render(<ReportStatusListItem id="rep-4" />);
+    await render(<ReportStatusListItem id="rep-4" />);
 
     await waitFor(() => expect(getReportStatus).toHaveBeenCalled());
     consoleError.mockRestore();

--- a/__tests__/screens/Search/SearchHeader.test.tsx
+++ b/__tests__/screens/Search/SearchHeader.test.tsx
@@ -58,33 +58,41 @@ describe("SearchHeader", () => {
   beforeEach(() => jest.clearAllMocks());
 
   describe("headline text", () => {
-    it("shows 'Artikel-Suche' when showFaktenBot is false", () => {
-      const { getByText } = render(
+    it("shows 'Artikel-Suche' when showFaktenBot is false", async () => {
+      const { getByText } = await render(
         <SearchHeader {...baseProps} showFaktenBot={false} />,
       );
       expect(getByText("Artikel-Suche")).toBeTruthy();
     });
 
-    it("shows 'Fact Check' when showFaktenBot is true", () => {
-      const { getByText } = render(
+    it("shows 'Fact Check' when showFaktenBot is true", async () => {
+      const { getByText } = await render(
         <SearchHeader {...baseProps} showFaktenBot={true} />,
       );
       expect(getByText("Fact Check")).toBeTruthy();
     });
 
-    it("defaults to 'Fact Check' when showFaktenBot is omitted", () => {
-      const { getByText } = render(<SearchHeader {...baseProps} />);
+    it("defaults to 'Fact Check' when showFaktenBot is omitted", async () => {
+      const { getByText } = await render(<SearchHeader {...baseProps} />);
       expect(getByText("Fact Check")).toBeTruthy();
     });
   });
 
   describe("header background color", () => {
-    it("uses Colors[colorScheme].background (not surface) for the header", () => {
-      const { toJSON } = render(
+    it("uses Colors[colorScheme].background (not surface) for the header", async () => {
+      const { toJSON } = await render(
         <SearchHeader {...baseProps} showFaktenBot={false} />,
       );
-      const views = toJSON() as any[];
-      const headerView = views[0];
+      // RNTL 14's toJSON() returns the root node as an object; multiple roots
+      // are wrapped in a container node with an empty-string type whose
+      // children are the actual top-level elements. Unwrap to the header View.
+      const json = toJSON() as any;
+      const roots = Array.isArray(json)
+        ? json
+        : json?.type === ""
+          ? json.children
+          : [json];
+      const headerView = roots[0];
       const flatStyle = (headerView.props.style as any[]).flat();
       expect(flatStyle).toContainEqual(
         expect.objectContaining({ backgroundColor: "#FFF" }),
@@ -96,35 +104,35 @@ describe("SearchHeader", () => {
   });
 
   describe("search validation", () => {
-    it("shows an info toast when fewer than 2 characters are submitted", () => {
-      const { getByLabelText } = render(
+    it("shows an info toast when fewer than 2 characters are submitted", async () => {
+      const { getByLabelText } = await render(
         <SearchHeader {...baseProps} search="a" />,
       );
-      fireEvent(getByLabelText("Text input field"), "submitEditing");
+      await fireEvent(getByLabelText("Text input field"), "submitEditing");
       expect(toast.info).toHaveBeenCalledWith(
         "Bitte mindestens 2 Zeichen eingeben",
       );
     });
 
-    it("does not show a toast when 2 or more characters are submitted", () => {
-      const { getByLabelText } = render(
+    it("does not show a toast when 2 or more characters are submitted", async () => {
+      const { getByLabelText } = await render(
         <SearchHeader {...baseProps} search="ab" />,
       );
-      fireEvent(getByLabelText("Text input field"), "submitEditing");
+      await fireEvent(getByLabelText("Text input field"), "submitEditing");
       expect(toast.info).not.toHaveBeenCalled();
     });
   });
 
   describe("FaktenBot visibility", () => {
-    it("renders FaktenBot when showFaktenBot is true", () => {
-      const { getByTestId } = render(
+    it("renders FaktenBot when showFaktenBot is true", async () => {
+      const { getByTestId } = await render(
         <SearchHeader {...baseProps} showFaktenBot={true} />,
       );
       expect(getByTestId("faktenbot")).toBeTruthy();
     });
 
-    it("does not render FaktenBot when showFaktenBot is false", () => {
-      const { queryByTestId } = render(
+    it("does not render FaktenBot when showFaktenBot is false", async () => {
+      const { queryByTestId } = await render(
         <SearchHeader {...baseProps} showFaktenBot={false} />,
       );
       expect(queryByTestId("faktenbot")).toBeNull();

--- a/__tests__/screens/Search/components/SearchResultItem.test.tsx
+++ b/__tests__/screens/Search/components/SearchResultItem.test.tsx
@@ -55,17 +55,17 @@ jest.mock("#/helpers/utils/color", () => ({
 describe("SearchResultItem", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("renders inside a plain View when onPress is not provided", () => {
-    const { getByTestId, queryByTestId } = render(
+  it("renders inside a plain View when onPress is not provided", async () => {
+    const { getByTestId, queryByTestId } = await render(
       <SearchResultItem title="Test Title" text="<p>Test</p>" />,
     );
     expect(getByTestId("ui-card")).toBeTruthy();
     expect(queryByTestId("pressable")).toBeNull();
   });
 
-  it("renders inside a UiPressable when onPress is provided", () => {
+  it("renders inside a UiPressable when onPress is provided", async () => {
     const onPress = jest.fn();
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <SearchResultItem
         title="Test Title"
         text="<p>Test</p>"
@@ -75,28 +75,28 @@ describe("SearchResultItem", () => {
     expect(getByTestId("pressable")).toBeTruthy();
   });
 
-  it("calls onPress when the pressable is tapped", () => {
+  it("calls onPress when the pressable is tapped", async () => {
     const onPress = jest.fn();
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       <SearchResultItem
         title="Test Title"
         text="<p>Test</p>"
         onPress={onPress}
       />,
     );
-    fireEvent.press(getByTestId("pressable"));
+    await fireEvent.press(getByTestId("pressable"));
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it("renders the title as a Heading", () => {
-    const { getByTestId } = render(
+  it("renders the title as a Heading", async () => {
+    const { getByTestId } = await render(
       <SearchResultItem title="My Title" text="<p>content</p>" />,
     );
     expect(getByTestId("heading").props.children).toBe("My Title");
   });
 
-  it("renders no Heading when title is empty", () => {
-    const { queryByTestId } = render(
+  it("renders no Heading when title is empty", async () => {
+    const { queryByTestId } = await render(
       <SearchResultItem title="" text="<p>content</p>" />,
     );
     expect(queryByTestId("heading")).toBeNull();

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@cspell/eslint-plugin": "10.0.1",
     "@jest/globals": "29.7.0",
     "@react-native/jest-preset": "0.85.3",
-    "@testing-library/react-native": "13.3.3",
+    "@testing-library/react-native": "14.0.1",
     "@trivago/prettier-plugin-sort-imports": "6.0.2",
     "@types/jest": "29.5.14",
     "@types/lodash": "4.17.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         version: 57.0.2(expo@57.0.1)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-router:
         specifier: 57.0.2
-        version: 57.0.2(f4a7027c329aaf945cc6df2684a243dd)
+        version: 57.0.2(90d142eec975dc69a9de99a4550b2ef7)
       expo-sharing:
         specifier: 57.0.1
         version: 57.0.1(expo@57.0.1)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -223,8 +223,8 @@ importers:
         specifier: 0.85.3
         version: 0.85.3(@babel/core@7.29.7)(react@19.2.3)
       '@testing-library/react-native':
-        specifier: 13.3.3
-        version: 13.3.3(jest@29.7.0(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 14.0.1
+        version: 14.0.1(jest@29.7.0(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))
       '@trivago/prettier-plugin-sort-imports':
         specifier: 6.0.2
         version: 6.0.2(prettier@3.9.4)
@@ -2007,14 +2007,14 @@ packages:
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
-  '@testing-library/react-native@13.3.3':
-    resolution: {integrity: sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==}
-    engines: {node: '>=18'}
+  '@testing-library/react-native@14.0.1':
+    resolution: {integrity: sha512-2r2e2y8SkUNRWKRXlUGqDYunB+AkbdXUPn49Bs5rpv9oxRb0K3USBVugbPbAKJjfj4w5Ba91NJ8LcQCZyopUZA==}
+    engines: {node: ^22.13.0 || >=24}
     peerDependencies:
       jest: '>=29.0.0'
-      react: '>=18.2.0'
-      react-native: '>=0.71'
-      react-test-renderer: 19.2.3
+      react: '>=19.0.0'
+      react-native: '>=0.78'
+      test-renderer: ^1.0.0
     peerDependenciesMeta:
       jest:
         optional: true
@@ -2140,6 +2140,11 @@ packages:
   '@types/react-native@0.73.0':
     resolution: {integrity: sha512-6ZRPQrYM72qYKGWidEttRe6M5DZBEV5F+MHMHqd4TTYx0tfkcdrUFGdef6CCxY0jXU7wldvd/zA/b0A/kTeJmA==}
     deprecated: This is a stub types definition. react-native provides its own type definitions, so you do not need this installed.
+
+  '@types/react-reconciler@0.33.0':
+    resolution: {integrity: sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==}
+    peerDependencies:
+      '@types/react': '*'
 
   '@types/react-test-renderer@19.1.0':
     resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
@@ -5721,6 +5726,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -6259,6 +6270,11 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  test-renderer@1.2.0:
+    resolution: {integrity: sha512-JYiEGbgBGtmHAWX8Kf99gGRL1HtjcRVHLrmJNTZL4vFs9XrnWcuL45Iszw/pO4094+JR7havSrN+ds6YTOpSQA==}
+    peerDependencies:
+      react: ^19.0.0
 
   text-segmentation@1.0.3:
     resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
@@ -7740,7 +7756,7 @@ snapshots:
       ws: 8.21.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.2(f4a7027c329aaf945cc6df2684a243dd)
+      expo-router: 57.0.2(90d142eec975dc69a9de99a4550b2ef7)
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -8017,7 +8033,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 57.0.2(@expo/log-box@57.0.0)(expo@57.0.1)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
-      expo-router: 57.0.2(f4a7027c329aaf945cc6df2684a243dd)
+      expo-router: 57.0.2(90d142eec975dc69a9de99a4550b2ef7)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -8967,15 +8983,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@testing-library/react-native@14.0.1(jest@29.7.0(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))':
     dependencies:
       jest-matcher-utils: 30.4.1
       picocolors: 1.1.1
       pretty-format: 30.4.1
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
-      react-test-renderer: 19.2.3(react@19.2.3)
       redent: 3.0.0
+      test-renderer: 1.2.0(@types/react@19.2.17)(react@19.2.3)
     optionalDependencies:
       jest: 29.7.0(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@6.0.3))
 
@@ -9112,6 +9128,10 @@ snapshots:
       - react
       - supports-color
       - utf-8-validate
+
+  '@types/react-reconciler@0.33.0(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
 
   '@types/react-test-renderer@19.1.0':
     dependencies:
@@ -10930,7 +10950,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-router@57.0.2(f4a7027c329aaf945cc6df2684a243dd):
+  expo-router@57.0.2(90d142eec975dc69a9de99a4550b2ef7):
     dependencies:
       '@expo/log-box': 57.0.0(@expo/dom-webview@57.0.0)(expo@57.0.1)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       '@expo/metro-runtime': 57.0.2(@expo/log-box@57.0.0)(expo@57.0.1)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -10968,7 +10988,7 @@ snapshots:
       standard-navigation: 0.0.5
       vaul: 1.1.2(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
-      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/react-native': 14.0.1(jest@29.7.0(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))
       react-dom: 19.2.3(react@19.2.3)
       react-native-gesture-handler: 2.32.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-reanimated: 4.5.0(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -13477,6 +13497,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  react-reconciler@0.33.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      scheduler: 0.27.0
+
   react-refresh@0.14.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.3):
@@ -14073,6 +14098,14 @@ snapshots:
       '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
+
+  test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3):
+    dependencies:
+      '@types/react-reconciler': 0.33.0(@types/react@19.2.17)
+      react: 19.2.3
+      react-reconciler: 0.33.0(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
 
   text-segmentation@1.0.3:
     dependencies:


### PR DESCRIPTION
Supersedes #370 (the Dependabot bump), which failed CI because RNTL 14 is a breaking change the test suite wasn't migrated for.

## Why

RNTL 14 makes `render`, `rerender`, `unmount`, `fireEvent(.*)`, and `renderHook` **async**, and **removes** the `UNSAFE_*ByType` queries. The existing synchronous suite no longer type-checks (`render(...).getByX` is now a `Promise`) or runs.

## What

- Bump `@testing-library/react-native` `13.3.3` → `14.0.1`.
- `await` all `render`/`rerender`/`unmount`/`fireEvent`/`renderHook` calls and mark the enclosing test callbacks `async`. This was applied mechanically via a one-off TypeScript-AST codemod (wrap target calls in `await`, mark the immediately-enclosing function `async`), then the edge cases below were fixed by hand.
- `await` the `act()` wrappers that drive async state updates; keep sync-callback `act()` where nothing needs awaiting.
- **UiSpinner**: `UNSAFE_getByType`/`UNSAFE_queryAllByType` were removed — replaced with `testID` queries (testID flows through the `ActivityIndicatorProps` spread) and a mock-call assertion for the Image branch.
- **SearchHeader**: adapt to the new `toJSON()` shape — it returns the root node as an object, wrapping multiple roots in a container node with an empty-string `type`.
- **MyFavs**: the `UiText` mock returned raw string children; v14's renderer rejects strings directly under a `<View>`, so it now wraps them in `<Text>`. Also reordered the stale-request test's mock wiring before the awaited `act()` (which now flushes synchronously).
- **MySources**: the `useFocusEffect` mock ran its callback on every render, re-fetching the full list and resurrecting rows removed via `handleDelete`; v14's stricter async flushing surfaced this. The mock now runs once on mount, matching the real hook with a stable `useCallback`.

## Verification

- `pnpm test` → **835 passed**, 3 skipped, 108 suites.
- `pnpm check:ts`, `pnpm lint`, `pnpm check` (spell) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)