### PR TITLE
Fix web version: startup crash and missing icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@algolia/client-search": "5.55.2",
-    "@atproto/api": "0.20.27",
+    "@atproto/api": "0.20.28",
     "@babel/runtime": "7.29.7",
     "@expo-google-fonts/source-sans-3": "0.4.1",
     "@expo/config": "57.0.3",
@@ -110,7 +110,7 @@
     "react-native-safe-area-context": "5.7.0",
     "react-native-screens": "4.25.2",
     "react-native-svg": "15.15.4",
-    "react-native-toast-message": "2.3.3",
+    "react-native-toast-message": "2.4.0",
     "react-native-view-shot": "5.1.0",
     "react-native-web": "0.21.2",
     "react-native-webview": "13.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 5.55.2
         version: 5.55.2
       '@atproto/api':
-        specifier: 0.20.27
-        version: 0.20.27
+        specifier: 0.20.28
+        version: 0.20.28
       '@babel/runtime':
         specifier: 7.29.7
         version: 7.29.7
@@ -195,8 +195,8 @@ importers:
         specifier: 15.15.4
         version: 15.15.4(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-toast-message:
-        specifier: 2.3.3
-        version: 2.3.3(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        specifier: 2.4.0
+        version: 2.4.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-view-shot:
         specifier: 5.1.0
         version: 5.1.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -341,12 +341,12 @@ packages:
     resolution: {integrity: sha512-Zc90xvKWUvxcNicvvTO9Pr/hT2TAnkixOIzJm/KMj5Ptm2pKjk71ngTsdkbRtJQvhZ2Kr9N1YdIjLrNHB5P2xw==}
     engines: {node: '>= 14.0.0'}
 
-  '@atproto/api@0.20.27':
-    resolution: {integrity: sha512-RQbsxcGrgsYELf3hyed9ICpjnK65l2S+cn7VUZ1J2S1S3Y9J5WUQD4bOVR+CvSbH+a2nwIk0z3fbmi9Gd+rlfw==}
+  '@atproto/api@0.20.28':
+    resolution: {integrity: sha512-/Rvk8zt9mtRi9tlMD2Qg+NG2lMj3B0HDjmfswR5724pH7GsOEMDDHwleVlmOBSrgACIyVSa5tdCDJ+R+SEhwww==}
     engines: {node: '>=22'}
 
-  '@atproto/common-web@0.5.5':
-    resolution: {integrity: sha512-Cd56SwEW4XQpW9Sz6O6LZAhv2hZ09ENl3rqPtzAidiCTSoeGRU5WjcVaSc8xPUQ3VsOqbKL0bVM6RkXQ6jXMSA==}
+  '@atproto/common-web@0.5.6':
+    resolution: {integrity: sha512-5Y4MIK9dpkJPiKiE6u7iEHitxj+g3aAU2GfGL686JlKE2zDKD4y18BJb+uVek6nXQKb5XOdNVvw+7BHarpn8Fw==}
     engines: {node: '>=22'}
 
   '@atproto/lex-data@0.1.5':
@@ -357,16 +357,16 @@ packages:
     resolution: {integrity: sha512-ENR2cWkVrES+UL6TovbCRdX9BJOyHHJUS8jYx3Lxp3j4vEphjn/u+DW7bWloST2O8ID2OuVlt6+28ftNEEjmQQ==}
     engines: {node: '>=22'}
 
-  '@atproto/lexicon@0.7.6':
-    resolution: {integrity: sha512-2q0hkXtzd9x5wE5n5enl/pjvPmktbKeLZOgdZBIHYSiuUWaacagbqdtUouSoddxSjehorfMNCNoBGMZoSp0ufA==}
+  '@atproto/lexicon@0.7.7':
+    resolution: {integrity: sha512-92VH2oEsJdrIVNy7WY8rGn99ANNVglyUffoN7GJc0mxKi+fXN5iVlJ2cOyTfYABhr2ldSiptZWXEPEdBaIR9/A==}
     engines: {node: '>=22'}
 
-  '@atproto/syntax@0.7.1':
-    resolution: {integrity: sha512-gK66efFZOFHymTc8GH9yOqHUSYzXIVWuQL20qpSQBX5py+QhlFfISHUHg6MO1mjREEdvXQj8Y7sEFVEcNUnp/g==}
+  '@atproto/syntax@0.7.2':
+    resolution: {integrity: sha512-tZ1Tr0R9pK4bI4Zs69t29cjMlCFQvRNBeNkqJC5pGeNuCt64D0eoF7s/AlqeVmYppClmQ0xJquggGgsMDP6j7w==}
     engines: {node: '>=22'}
 
-  '@atproto/xrpc@0.8.5':
-    resolution: {integrity: sha512-f2+nor6ixxOHQaGmc27In+1BsaW7K+sS0nSPtZ9uAWquLglmfzJqGBLNbY1Asm6i7/VBlXFYWRlt7ZqERNIszQ==}
+  '@atproto/xrpc@0.8.6':
+    resolution: {integrity: sha512-yVfKrlwZBBm44Ft9jDvHcTCwQ1ElqSlzXHWhT/KcqE+u24EAhWVFosfABfGbUByB/PmN8eLJ06FsWo5pUQcMNQ==}
     engines: {node: '>=22'}
 
   '@babel/code-frame@7.29.7':
@@ -5772,8 +5772,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-toast-message@2.3.3:
-    resolution: {integrity: sha512-4IIUHwUPvKHu4gjD0Vj2aGQzqPATiblL1ey8tOqsxOWRPGGu52iIbL8M/mCz4uyqecvPdIcMY38AfwRuUADfQQ==}
+  react-native-toast-message@2.4.0:
+    resolution: {integrity: sha512-Ip4sPpf9707Qmn06Jp1aGJrYLx2mwTYBRjXzP7ebPvmjABA6OCT9bEh62E0L6s5zc/KPZ3rix+OnBKW/pOJZ4g==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -6899,22 +6899,22 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.55.2
 
-  '@atproto/api@0.20.27':
+  '@atproto/api@0.20.28':
     dependencies:
-      '@atproto/common-web': 0.5.5
-      '@atproto/lexicon': 0.7.6
-      '@atproto/syntax': 0.7.1
-      '@atproto/xrpc': 0.8.5
+      '@atproto/common-web': 0.5.6
+      '@atproto/lexicon': 0.7.7
+      '@atproto/syntax': 0.7.2
+      '@atproto/xrpc': 0.8.6
       await-lock: 3.0.0
       multiformats: 13.4.2
       tlds: 1.261.0
       zod: 3.25.76
 
-  '@atproto/common-web@0.5.5':
+  '@atproto/common-web@0.5.6':
     dependencies:
       '@atproto/lex-data': 0.1.5
       '@atproto/lex-json': 0.1.4
-      '@atproto/syntax': 0.7.1
+      '@atproto/syntax': 0.7.2
       zod: 3.25.76
 
   '@atproto/lex-data@0.1.5':
@@ -6928,21 +6928,21 @@ snapshots:
       '@atproto/lex-data': 0.1.5
       tslib: 2.8.1
 
-  '@atproto/lexicon@0.7.6':
+  '@atproto/lexicon@0.7.7':
     dependencies:
-      '@atproto/common-web': 0.5.5
-      '@atproto/syntax': 0.7.1
+      '@atproto/common-web': 0.5.6
+      '@atproto/syntax': 0.7.2
       multiformats: 13.4.2
       zod: 3.25.76
 
-  '@atproto/syntax@0.7.1':
+  '@atproto/syntax@0.7.2':
     dependencies:
       iso-datestring-validator: 2.2.2
       tslib: 2.8.1
 
-  '@atproto/xrpc@0.8.5':
+  '@atproto/xrpc@0.8.6':
     dependencies:
-      '@atproto/lexicon': 0.7.6
+      '@atproto/lexicon': 0.7.7
       zod: 3.25.76
 
   '@babel/code-frame@7.29.7':
@@ -13608,7 +13608,7 @@ snapshots:
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
       warn-once: 0.1.1
 
-  react-native-toast-message@2.3.3(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  react-native-toast-message@2.4.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -5,6 +5,7 @@ import {
   SourceSans3_700Bold_Italic,
   useFonts,
 } from "@expo-google-fonts/source-sans-3";
+import OcticonsFont from "@react-native-vector-icons/octicons/fonts/Octicons.ttf";
 import { Stack, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
@@ -91,6 +92,9 @@ const RootLayout = () => {
     SourceSansProItalic: SourceSans3_400Regular_Italic,
     SourceSansProBold: SourceSans3_700Bold,
     SourceSansProBoldItalic: SourceSans3_700Bold_Italic,
+    // The icon font is bundled natively by the vector-icons config plugin,
+    // but on web it has to be registered explicitly
+    ...(Platform.OS === "web" && { Octicons: OcticonsFont }),
   });
 
   const [showChangelog, setShowChangelog] = useState(false);

--- a/src/components/animations/AnimatedSuccess.tsx
+++ b/src/components/animations/AnimatedSuccess.tsx
@@ -1,7 +1,8 @@
+import { Asset } from "expo-asset";
 import { BlurView } from "expo-blur";
 import { useCallback, useEffect, useRef } from "react";
 import type { RefObject } from "react";
-import { Animated, Dimensions, Image, Modal, StyleSheet } from "react-native";
+import { Animated, Dimensions, Modal, StyleSheet } from "react-native";
 import type {
   ImageSourcePropType,
   ImageStyle,
@@ -58,7 +59,15 @@ const AnimatedSuccess = (properties: AnimatedSuccessProperties) => {
   // asset's intrinsic size so the image is positioned correctly for callers
   // that don't pass a style (e.g. the donation flow's default icon)
   const flattenedImageStyle = StyleSheet.flatten(imageStyle);
-  const resolvedAsset = Image.resolveAssetSource(image);
+  // Image.resolveAssetSource doesn't exist on react-native-web; expo-asset
+  // resolves module IDs on all platforms, and object sources carry their
+  // own optional width/height
+  const resolvedAsset =
+    typeof image === "number"
+      ? Asset.fromModule(image)
+      : Array.isArray(image)
+        ? undefined
+        : image;
   const imageHeight =
     typeof flattenedImageStyle?.height === "number"
       ? flattenedImageStyle.height

--- a/src/screens/Onboarding/components/Flatboard.tsx
+++ b/src/screens/Onboarding/components/Flatboard.tsx
@@ -159,6 +159,10 @@ const FlatBoard = (properties: FlatBoardProperties) => {
     setContainerHeight(e.nativeEvent.layout.height);
   };
 
+  // On web the first render happens before the window is measured, and the
+  // carousel throws on width 0; the dimensions update triggers a re-render
+  if (!width) return null;
+
   return (
     <View style={{ flex: 1 }} onLayout={onLayout}>
       <Carousel

--- a/src/screens/Onboarding/components/Flatboard.tsx
+++ b/src/screens/Onboarding/components/Flatboard.tsx
@@ -8,7 +8,7 @@ import type {
   LayoutChangeEvent,
   TextStyle,
 } from "react-native";
-import { View, useWindowDimensions } from "react-native";
+import { Platform, View, useWindowDimensions } from "react-native";
 import Carousel from "react-native-reanimated-carousel";
 import type { ICarouselInstance } from "react-native-reanimated-carousel";
 
@@ -165,23 +165,38 @@ const FlatBoard = (properties: FlatBoardProperties) => {
 
   return (
     <View style={{ flex: 1 }} onLayout={onLayout}>
-      <Carousel
-        ref={carouselRef}
-        width={width}
-        height={containerHeight}
-        data={data}
-        loop={false}
-        onSnapToItem={onSnapToItem}
-        renderItem={({ item }) => (
+      {Platform.OS === "web" ? (
+        // The reanimated carousel doesn't paint its items reliably on web;
+        // the stepper drives navigation via the step state anyway, so web
+        // only loses the swipe gesture
+        <View style={{ flex: 1 }}>
           <MemoSlide
-            {...item}
+            {...data[step]}
             width={width}
             height={containerHeight}
             headingStyle={headingStyle}
             descriptionStyle={descriptionStyle}
           />
-        )}
-      />
+        </View>
+      ) : (
+        <Carousel
+          ref={carouselRef}
+          width={width}
+          height={containerHeight}
+          data={data}
+          loop={false}
+          onSnapToItem={onSnapToItem}
+          renderItem={({ item }) => (
+            <MemoSlide
+              {...item}
+              width={width}
+              height={containerHeight}
+              headingStyle={headingStyle}
+              descriptionStyle={descriptionStyle}
+            />
+          )}
+        />
+      )}
       <Stepper
         step={step}
         data={data}

--- a/src/screens/Settings/components/licenses/data.tsx
+++ b/src/screens/Settings/components/licenses/data.tsx
@@ -5,7 +5,7 @@ export default {
     licenseUrl:
       "https://github.com/algolia/algoliasearch-client-javascript/raw/HEAD/LICENSE",
   },
-  "@atproto/api@0.20.27": {
+  "@atproto/api@0.20.28": {
     licenses: "MIT",
     repository: "https://github.com/bluesky-social/atproto",
     licenseUrl:
@@ -306,7 +306,7 @@ export default {
     licenseUrl:
       "https://github.com/react-native-community/react-native-svg/raw/HEAD/LICENSE",
   },
-  "react-native-toast-message@2.3.3": {
+  "react-native-toast-message@2.4.0": {
     licenses: "MIT",
     repository: "https://github.com/calintamas/react-native-toast-message",
     licenseUrl:


### PR DESCRIPTION
## Summary

The web build was completely broken — this PR makes it load and render correctly.

- **Startup crash**: `Image.resolveAssetSource is not a function` on every load. react-native-web doesn't implement `Image.resolveAssetSource`, and `AnimatedSuccess` (mounted unconditionally via the home feed's `Donate` slot) called it during render. Now resolves module assets via expo-asset's cross-platform `Asset.fromModule`; object sources carry their own optional width/height, matching RN's behavior.
- **Missing icons**: every Octicons glyph rendered as a tofu box because the icon font is only bundled natively (via the vector-icons config plugin) and was never registered on web. The root layout's existing `useFonts` call now loads the Octicons TTF on web.
- **Onboarding broken on web** (two fixes):
  - `Flatboard.tsx` crashed with `` `width` must be specified for horizontal carousels `` when the first render happened before the window was measured (`useWindowDimensions` returning 0); the component now waits for a real width.
  - react-native-reanimated-carousel doesn't paint its items reliably on web — slides stayed invisible even though they were laid out in the DOM, leaving first-run users on a blank page with only the stepper. On web the current slide is now rendered directly (the stepper already drives navigation via state); only the swipe gesture is lost. Native keeps the carousel unchanged.
- Dependency bumps.

## Test plan

- [x] `pnpm lint`, `pnpm check`, `pnpm test` (841 passed)
- [x] Verified in browser: web app loads, home screen renders, icons visible (header heart, search, tab bar, empty state)
- [x] Verified full onboarding flow on web with cleared storage: all four slides render immediately, feed toggles work, "Los geht's" completes onboarding and lands on home
- [ ] Sanity-check a native build to confirm no regressions from the dep bumps (onboarding carousel path is untouched on native, but worth a look)

🤖 Generated with [Claude Code](https://claude.com/claude-code)