### PR TITLE
Add web export + Bunny deploy workflow

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,66 @@
+name: Deploy Web to Bunny
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-web
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v7
+
+      - name: 🏗 Setup environment
+        uses: ./.github/actions/setup-node-pnpm-expo
+        with:
+          setup-node: "true"
+
+      - name: 📦 Export web bundle
+        run: npx expo export --platform web
+        shell: bash
+
+      - name: ⬆️ Upload to Bunny storage
+        env:
+          STORAGE_ZONE: ${{ secrets.BUNNY_STORAGE_ZONE_NAME }}
+          STORAGE_KEY: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
+          # Region-specific hostname, e.g. storage.bunnycdn.com (DE) or
+          # ny.storage.bunnycdn.com — see the storage zone's FTP & API access page
+          STORAGE_HOST: ${{ secrets.BUNNY_STORAGE_HOST }}
+        run: |
+          if [ -z "$STORAGE_ZONE" ] || [ -z "$STORAGE_KEY" ]; then
+            echo "::error::BUNNY_STORAGE_ZONE_NAME and BUNNY_STORAGE_PASSWORD secrets must be set"
+            exit 1
+          fi
+          HOST="${STORAGE_HOST:-storage.bunnycdn.com}"
+          cd dist
+          FILES=$(find . -type f | sed 's|^\./||')
+          COUNT=$(echo "$FILES" | wc -l | tr -d ' ')
+          echo "Uploading $COUNT files to $HOST/$STORAGE_ZONE"
+          echo "$FILES" | xargs -P 8 -I {} sh -c '
+            curl --fail --silent --show-error --retry 3 --retry-all-errors \
+              -H "AccessKey: $STORAGE_KEY" \
+              -H "Content-Type: application/octet-stream" \
+              --upload-file "{}" \
+              "https://'"$HOST"'/'"$STORAGE_ZONE"'/{}" > /dev/null \
+              && echo "  ✓ {}" || { echo "  ✗ {}"; exit 1; }
+          '
+        shell: bash
+
+      - name: 🧹 Purge pull zone cache
+        env:
+          PULLZONE_ID: ${{ secrets.BUNNY_PULLZONE_ID }}
+          API_KEY: ${{ secrets.BUNNY_API_KEY }}
+        run: |
+          if [ -z "$PULLZONE_ID" ] || [ -z "$API_KEY" ]; then
+            echo "BUNNY_PULLZONE_ID / BUNNY_API_KEY not set — skipping cache purge"
+            exit 0
+          fi
+          curl --fail --silent --show-error --request POST \
+            -H "AccessKey: $API_KEY" \
+            "https://api.bunny.net/pullzone/$PULLZONE_ID/purgeCache"
+          echo "Pull zone cache purged"
+        shell: bash

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -35,19 +35,21 @@ jobs:
             echo "::error::BUNNY_STORAGE_ZONE_NAME and BUNNY_STORAGE_PASSWORD secrets must be set"
             exit 1
           fi
-          HOST="${STORAGE_HOST:-storage.bunnycdn.com}"
+          export HOST="${STORAGE_HOST:-storage.bunnycdn.com}"
           cd dist
-          FILES=$(find . -type f | sed 's|^\./||')
-          COUNT=$(echo "$FILES" | wc -l | tr -d ' ')
+          COUNT=$(find . -type f | wc -l | tr -d ' ')
           echo "Uploading $COUNT files to $HOST/$STORAGE_ZONE"
-          echo "$FILES" | xargs -P 8 -I {} sh -c '
+          # Filenames are passed as positional parameters, never interpolated
+          # into the script text, so they cannot be executed as shell code
+          find . -type f -print0 | xargs -0 -P 8 -n 1 sh -c '
+            f="${1#./}"
             curl --fail --silent --show-error --retry 3 --retry-all-errors \
               -H "AccessKey: $STORAGE_KEY" \
               -H "Content-Type: application/octet-stream" \
-              --upload-file "{}" \
-              "https://'"$HOST"'/'"$STORAGE_ZONE"'/{}" > /dev/null \
-              && echo "  ✓ {}" || { echo "  ✗ {}"; exit 1; }
-          '
+              --upload-file "$1" \
+              "https://$HOST/$STORAGE_ZONE/$f" > /dev/null \
+              && echo "  ✓ $f" || { echo "  ✗ $f"; exit 1; }
+          ' sh
         shell: bash
 
       - name: 🧹 Purge index.html from the CDN cache
@@ -60,6 +62,8 @@ jobs:
             echo "BUNNY_WEB_URL / BUNNY_API_KEY not set — skipping cache purge"
             exit 0
           fi
+          # Tolerate a trailing slash in the configured base URL
+          WEB_URL="${WEB_URL%/}"
           # Only these URLs are purged — the JS bundles are content-hashed and
           # never need purging, and no other zone or site is touched
           for path in "/" "/index.html" "/metadata.json"; do

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -52,9 +52,9 @@ jobs:
           ' sh
         shell: bash
 
-      - name: 🧹 Purge index.html from the CDN cache
+      - name: 🧹 Purge web entry URLs from the CDN cache
         env:
-          # Public base URL of the deployed web app, e.g. https://app.volksverpetzer.de
+          # Public base URL of the deployed web app, e.g. https://web.volksverpetzer.de
           WEB_URL: ${{ secrets.BUNNY_WEB_URL }}
           API_KEY: ${{ secrets.BUNNY_API_KEY }}
         run: |

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -50,17 +50,22 @@ jobs:
           '
         shell: bash
 
-      - name: 🧹 Purge pull zone cache
+      - name: 🧹 Purge index.html from the CDN cache
         env:
-          PULLZONE_ID: ${{ secrets.BUNNY_PULLZONE_ID }}
+          # Public base URL of the deployed web app, e.g. https://app.volksverpetzer.de
+          WEB_URL: ${{ secrets.BUNNY_WEB_URL }}
           API_KEY: ${{ secrets.BUNNY_API_KEY }}
         run: |
-          if [ -z "$PULLZONE_ID" ] || [ -z "$API_KEY" ]; then
-            echo "BUNNY_PULLZONE_ID / BUNNY_API_KEY not set — skipping cache purge"
+          if [ -z "$WEB_URL" ] || [ -z "$API_KEY" ]; then
+            echo "BUNNY_WEB_URL / BUNNY_API_KEY not set — skipping cache purge"
             exit 0
           fi
-          curl --fail --silent --show-error --request POST \
-            -H "AccessKey: $API_KEY" \
-            "https://api.bunny.net/pullzone/$PULLZONE_ID/purgeCache"
-          echo "Pull zone cache purged"
+          # Only these URLs are purged — the JS bundles are content-hashed and
+          # never need purging, and no other zone or site is touched
+          for path in "/" "/index.html" "/metadata.json"; do
+            curl --fail --silent --show-error --request POST \
+              -H "AccessKey: $API_KEY" \
+              "https://api.bunny.net/purge?url=$(printf %s "$WEB_URL$path" | sed 's|/|%2F|g; s|:|%3A|g')"
+            echo "purged $WEB_URL$path"
+          done
         shell: bash


### PR DESCRIPTION
## Summary

Adds a manually triggered GitHub Actions workflow (`deploy-web.yml`) that publishes the web version of the app to Bunny:

1. `npx expo export --platform web` — produces the static SPA bundle in `dist/` (verified locally: 48 files, ~10 MB, single hashed entry JS)
2. Uploads every file to a Bunny **storage zone** via the storage HTTP API — plain `curl` with retries, 8 parallel uploads, filenames passed as positional parameters (no shell interpolation), no third-party deploy action
3. Purges **only the web app's entry URLs** (`/`, `/index.html`, `/metadata.json`) from the CDN cache via Bunny's single-URL purge API — the JS bundles are content-hashed and never need purging. Deliberately not a zone-wide purge, so the workflow cannot touch the volksverpetzer.de site's cache even if misconfigured.

Reuses the existing `setup-node-pnpm-expo` composite action.

## Live URL decision

The web app will be served at **https://web.volksverpetzer.de**.

## Required repo secrets

| Secret | Value |
|---|---|
| `BUNNY_STORAGE_ZONE_NAME` | Storage zone name (required) |
| `BUNNY_STORAGE_PASSWORD` | Storage zone password/AccessKey (required) |
| `BUNNY_STORAGE_HOST` | Region endpoint, defaults to `storage.bunnycdn.com` (optional) |
| `BUNNY_WEB_URL` | `https://web.volksverpetzer.de` (for the scoped cache purge) |
| `BUNNY_API_KEY` | Account API key, used only for the purge; skipped if unset (optional) |

## Infra checklist (outside this repo)

- [ ] Bunny: create storage zone + pull zone, CNAME `web.volksverpetzer.de` → pull zone, enable SSL
- [ ] Bunny: set `index.html` as the custom 404 file **on the storage zone** (SPA fallback — deep links like `/faktencheck/<slug>` 404 on direct load otherwise)
- [ ] Bunny pull zone caching: default edge **and** browser cache expiration = 0 (HTML stays fresh, including the SPA-fallback copies of `index.html` cached under deep-link URLs); two Edge Rules setting cache time and browser cache time to 1 year for `https://web.volksverpetzer.de/_expo/*` and `https://web.volksverpetzer.de/assets/*` (content-hashed, immutable). No Perma-Cache, no query-string vary. With this, the workflow's purge step is belt-and-braces rather than load-bearing.
- [ ] Server (volksverpetzer-app.de): add `Access-Control-Allow-Origin: https://web.volksverpetzer.de` on the proxy/feed/reporting endpoints
- [ ] WordPress (volksverpetzer.de): REST API already sends per-origin CORS headers; verify cached `/wp-json` responses keep them (the existing `*/wp-json/*` cache bypass rule covers this)
- [ ] Datenschutzerklärung: mention the web app hosting if needed (own domain + Bunny EU CDN, no new processors)

## Test plan

- [x] `npx expo export --platform web` runs clean locally on this branch
- [x] Workflow YAML validated; `pnpm check` clean; upload invocation smoke-tested against the real `dist/`
- [ ] Set the Bunny secrets and run the workflow once, then verify https://web.volksverpetzer.de

🤖 Generated with [Claude Code](https://claude.com/claude-code)
