### PR TITLE
Fix web feeds: make requests CORS-simple

### DIFF
--- a/__tests__/helpers/Networking.test.ts
+++ b/__tests__/helpers/Networking.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Platform } from "react-native";
 
 import * as Networking from "#/helpers/utils/networking";
 
@@ -55,6 +56,30 @@ describe("Networking utilities", () => {
         }),
       }),
     );
+  });
+
+  it("createClient omits preflight-triggering default headers on web", async () => {
+    const platform = jest.replaceProperty(Platform, "OS", "web");
+    const client = Networking.createClient("https://example.com" as any);
+    (globalThis.fetch as jest.Mock<any>)
+      .mockImplementationOnce(mockJsonResponse({}))
+      .mockImplementationOnce(mockJsonResponse({}));
+
+    // Custom headers on a GET would force a CORS preflight in browsers
+    await client.request({ url: "/test" });
+    const getInit = (fetch as jest.Mock<any>).mock.calls[0][1] as RequestInit;
+    expect(getInit.headers).not.toHaveProperty("Content-Type");
+    expect(getInit.headers).not.toHaveProperty("User-Agent");
+    expect(getInit.headers).not.toHaveProperty("Cache-Control");
+    expect(getInit.headers).not.toHaveProperty("Pragma");
+    expect(getInit.headers).not.toHaveProperty("Expires");
+
+    // A JSON body still declares its content type
+    await client.request({ url: "/test", method: "POST", data: { a: 1 } });
+    const postInit = (fetch as jest.Mock<any>).mock.calls[1][1] as RequestInit;
+    expect(postInit.headers).toHaveProperty("Content-Type", "application/json");
+
+    platform.restore();
   });
 
   it("createClient merges extraHeaders into every request", async () => {

--- a/config/volksverpetzer.config.ts
+++ b/config/volksverpetzer.config.ts
@@ -99,7 +99,9 @@ const extraConfig: ExtraConfigType = {
   feeds: {
     wp: [
       {
-        handle: "https://www.volksverpetzer.de",
+        // Apex, not www: www 301s to the apex, and cross-origin redirects
+        // without CORS headers fail on web
+        handle: "https://volksverpetzer.de",
         label: "Artikel",
         enabled: true,
       },

--- a/src/helpers/network/WordPressAPI.ts
+++ b/src/helpers/network/WordPressAPI.ts
@@ -1,7 +1,11 @@
 import { decode } from "html-entities";
 
 import Config from "#/constants/Config";
-import { createClient, get as netGet } from "#/helpers/utils/networking";
+import {
+  CACHE_BUSTER_HEADERS,
+  createClient,
+  get as netGet,
+} from "#/helpers/utils/networking";
 import type {
   ArticleProperties,
   HttpsUrl,
@@ -36,11 +40,7 @@ export default class WordPressAPI {
           _: timestamp, // Cache-busting parameter
           _embed: "author",
         },
-        headers: {
-          "Cache-Control": "no-cache, no-store, must-revalidate",
-          Pragma: "no-cache",
-          Expires: "0",
-        },
+        headers: CACHE_BUSTER_HEADERS,
         signal,
       },
     );
@@ -133,11 +133,7 @@ export default class WordPressAPI {
               _: Date.now(),
               _embed: "author",
             },
-            headers: {
-              "Cache-Control": "no-cache, no-store, must-revalidate",
-              Pragma: "no-cache",
-              Expires: "0",
-            },
+            headers: CACHE_BUSTER_HEADERS,
             signal,
           },
         );

--- a/src/helpers/utils/networking.ts
+++ b/src/helpers/utils/networking.ts
@@ -78,16 +78,34 @@ function buildUrl(
  * @param baseURL Base URL for requests
  * @param extraHeaders Additional headers merged into every request
  */
+/**
+ * Cache-defeating request headers for endpoints behind aggressive CDN
+ * caches. Empty on web: these headers aren't CORS-safelisted and would
+ * force a failing preflight; requests carry a timestamp param instead.
+ */
+export const CACHE_BUSTER_HEADERS: FetchHeaders =
+  Platform.OS === "web"
+    ? {}
+    : {
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        Pragma: "no-cache",
+        Expires: "0",
+      };
+
 export function createClient(
   baseURL: HttpsUrl,
   extraHeaders: FetchHeaders = {},
 ): FetchClient {
   const baseHeaders: FetchHeaders = {
-    "Content-Type": "application/json",
-    "User-Agent": `${Constants.expoConfig?.slug}/${Application?.nativeApplicationVersion} (${Platform.OS}; ${Device.osName} ${Device.osVersion}; ${Device.modelName})`,
-    "Cache-Control": "no-cache, no-store, must-revalidate",
-    Pragma: "no-cache",
-    Expires: "0",
+    // On web these defaults must not be sent: User-Agent is a forbidden
+    // header there, and the others aren't CORS-safelisted, so they would
+    // turn every GET into a preflighted request that the WP/proxy
+    // endpoints reject. Browsers handle caching via response headers.
+    ...(Platform.OS !== "web" && {
+      "Content-Type": "application/json",
+      "User-Agent": `${Constants.expoConfig?.slug}/${Application?.nativeApplicationVersion} (${Platform.OS}; ${Device.osName} ${Device.osVersion}; ${Device.modelName})`,
+      ...CACHE_BUSTER_HEADERS,
+    }),
     ...extraHeaders,
   };
 
@@ -119,6 +137,10 @@ export function createClient(
           init.body = data as BodyInit;
         } else {
           init.body = JSON.stringify(data);
+          // The JSON content type is a base header on native only
+          if (!mergedHeaders["Content-Type"]) {
+            mergedHeaders["Content-Type"] = "application/json";
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

The deployed web app at web.volksverpetzer.de rendered fine but showed an empty feed ("Keine Ergebnisse"). Two causes, both CORS:

1. **Every feed request was preflighted.** The networking layer's default headers — `Content-Type: application/json` on GETs, `User-Agent`, `Cache-Control`/`Pragma`/`Expires` — are not CORS-safelisted, so browsers sent an `OPTIONS` preflight before every request, and neither the WP endpoints nor the volksverpetzer-app.de proxies answer preflights (WP's `Access-Control-Allow-Headers` doesn't include `cache-control` either). These defaults are now native-only, making web GETs *simple requests* that work with the plain `Access-Control-Allow-Origin` response headers configured at Bunny. JSON POST bodies still declare their content type (that preflight is legitimate). `WordPressAPI` passed the same cache-buster headers per-request; those now come from a shared `CACHE_BUSTER_HEADERS` constant that is empty on web — the `_` timestamp param keeps doing the cache-busting there.
2. **The article feed pointed at www.** `https://www.volksverpetzer.de` 301s to the apex, and a cross-origin redirect without CORS headers on the 301 fails on web. The feed handle now uses the apex directly — also one less redirect for native users.

Native behavior is unchanged (headers identical to before; the config change only skips a redirect).

## Test plan

- [x] New test: web clients omit the preflight-triggering defaults; JSON POSTs still get `Content-Type`
- [x] `pnpm test` (842 passed), `pnpm check`, ESLint on changed files — all clean
- [x] Verified in the browser (dev server): Prüfpunkt articles load in the home feed from localhost (previously blocked by the preflight). Main VVP articles + proxies stay origin-restricted to web.volksverpetzer.de by design and were verified working via curl with that Origin
- [ ] After merge + deploy: confirm the full feed populates on https://web.volksverpetzer.de

🤖 Generated with [Claude Code](https://claude.com/claude-code)