### PR TITLE
Fix notification toggle reverting other settings

### DIFF
--- a/__tests__/helpers/Notifications.test.ts
+++ b/__tests__/helpers/Notifications.test.ts
@@ -153,6 +153,10 @@ describe("NotificationManager", () => {
 
   describe("registerForPushNotifications", () => {
     afterEach(() => {
+      // Restore spied implementations (getPermissionsAsync, console.warn,
+      // etc.) so they don't leak into later tests — the file only runs
+      // clearAllMocks() globally, which doesn't undo spyOn implementations.
+      jest.restoreAllMocks();
       // Restore Device.isDevice after each test via the setter
       const Device = jest.requireMock("expo-device") as any;
       Device.__setIsDeviceValue(true);
@@ -224,14 +228,13 @@ describe("NotificationManager", () => {
       jest
         .spyOn(Notifications, "requestPermissionsAsync")
         .mockResolvedValue({ status: "denied" } as any);
-      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      jest.spyOn(console, "warn").mockImplementation(() => {});
 
       const result = await NotificationManager.registerForPushNotifications({
         new_post: { value: false, name: "New Posts" },
       });
 
       expect(result.notificationSettings.new_post.value).toBe(false);
-      warnSpy.mockRestore();
     });
 
     it("returns the merged settings, not the stale stored ones, when notifications are unavailable (e.g. web)", async () => {
@@ -272,16 +275,13 @@ describe("NotificationManager", () => {
       jest
         .spyOn(Notifications, "getExpoPushTokenAsync")
         .mockRejectedValue(new Error("token fetch failed"));
-      const errorSpy = jest
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
+      jest.spyOn(console, "error").mockImplementation(() => {});
 
       const result = await NotificationManager.registerForPushNotifications({
         new_post: { value: false, name: "New Posts" },
       });
 
       expect(result.notificationSettings.new_post.value).toBe(false);
-      errorSpy.mockRestore();
     });
 
     it("returns the merged settings, not the stale stored ones, when no token is returned", async () => {

--- a/__tests__/helpers/Notifications.test.ts
+++ b/__tests__/helpers/Notifications.test.ts
@@ -224,13 +224,40 @@ describe("NotificationManager", () => {
       jest
         .spyOn(Notifications, "requestPermissionsAsync")
         .mockResolvedValue({ status: "denied" } as any);
-      jest.spyOn(console, "warn").mockImplementation(() => {});
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
       const result = await NotificationManager.registerForPushNotifications({
         new_post: { value: false, name: "New Posts" },
       });
 
       expect(result.notificationSettings.new_post.value).toBe(false);
+      warnSpy.mockRestore();
+    });
+
+    it("returns the merged settings, not the stale stored ones, when notifications are unavailable (e.g. web)", async () => {
+      const platform = (jest.requireMock("react-native") as any).Platform;
+      platform.OS = "web";
+      try {
+        (
+          SettingsStore.getNotificationSettings as jest.MockedFunction<
+            () => Promise<any>
+          >
+        ).mockResolvedValue({ new_post: { value: true, name: "New Posts" } });
+
+        const result = await NotificationManager.registerForPushNotifications({
+          new_post: { value: false, name: "New Posts" },
+        });
+
+        expect(result.status).toBe("unavailable");
+        expect(result.notificationSettings.new_post.value).toBe(false);
+        expect(SettingsStore.setNotificationSettings).toHaveBeenCalledWith(
+          expect.objectContaining({
+            new_post: { value: false, name: "New Posts" },
+          }),
+        );
+      } finally {
+        platform.OS = "ios";
+      }
     });
 
     it("returns the merged settings, not the stale stored ones, when fetching the token throws", async () => {
@@ -245,13 +272,16 @@ describe("NotificationManager", () => {
       jest
         .spyOn(Notifications, "getExpoPushTokenAsync")
         .mockRejectedValue(new Error("token fetch failed"));
-      jest.spyOn(console, "error").mockImplementation(() => {});
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
       const result = await NotificationManager.registerForPushNotifications({
         new_post: { value: false, name: "New Posts" },
       });
 
       expect(result.notificationSettings.new_post.value).toBe(false);
+      errorSpy.mockRestore();
     });
 
     it("returns the merged settings, not the stale stored ones, when no token is returned", async () => {

--- a/__tests__/helpers/Notifications.test.ts
+++ b/__tests__/helpers/Notifications.test.ts
@@ -151,6 +151,130 @@ describe("NotificationManager", () => {
     });
   });
 
+  describe("registerForPushNotifications", () => {
+    afterEach(() => {
+      // Restore Device.isDevice after each test via the setter
+      const Device = jest.requireMock("expo-device") as any;
+      Device.__setIsDeviceValue(true);
+    });
+
+    it("persists the merged settings before checking permissions or fetching a token", async () => {
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockResolvedValue({ new_post: { value: true, name: "New Posts" } });
+      const getPermissionsSpy = jest
+        .spyOn(Notifications, "getPermissionsAsync")
+        .mockResolvedValue({ status: "granted" } as any);
+      jest
+        .spyOn(Notifications, "getExpoPushTokenAsync")
+        .mockResolvedValue({ data: "ExponentPushToken[test]" } as any);
+      const API = (jest.requireMock("#/helpers/network/ServerAPI") as any)
+        .default;
+      API.registerNotifications.mockResolvedValue({ status: "ok" });
+
+      await NotificationManager.registerForPushNotifications({
+        new_post: { value: false, name: "New Posts" },
+      });
+
+      expect(SettingsStore.setNotificationSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          new_post: { value: false, name: "New Posts" },
+        }),
+      );
+      const setOrder = (SettingsStore.setNotificationSettings as jest.Mock).mock
+        .invocationCallOrder[0];
+      const permissionsOrder = getPermissionsSpy.mock.invocationCallOrder[0];
+      expect(setOrder).toBeLessThan(permissionsOrder);
+    });
+
+    it("persists and returns the merged settings on simulators/emulators without registering a token", async () => {
+      const Device = jest.requireMock("expo-device") as any;
+      Device.__setIsDeviceValue(false);
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockResolvedValue({ new_post: { value: true, name: "New Posts" } });
+
+      const result = await NotificationManager.registerForPushNotifications({
+        new_post: { value: false, name: "New Posts" },
+      });
+
+      expect(result.status).toBe("ok");
+      expect(result.notificationSettings.new_post.value).toBe(false);
+      expect(SettingsStore.setNotificationSettings).toHaveBeenCalledTimes(1);
+      expect(SettingsStore.setNotificationSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          new_post: { value: false, name: "New Posts" },
+        }),
+      );
+    });
+
+    it("returns the merged settings, not the stale stored ones, when permission is denied", async () => {
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockResolvedValue({ new_post: { value: true, name: "New Posts" } });
+      jest
+        .spyOn(Notifications, "getPermissionsAsync")
+        .mockResolvedValue({ status: "denied" } as any);
+      jest
+        .spyOn(Notifications, "requestPermissionsAsync")
+        .mockResolvedValue({ status: "denied" } as any);
+      jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await NotificationManager.registerForPushNotifications({
+        new_post: { value: false, name: "New Posts" },
+      });
+
+      expect(result.notificationSettings.new_post.value).toBe(false);
+    });
+
+    it("returns the merged settings, not the stale stored ones, when fetching the token throws", async () => {
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockResolvedValue({ new_post: { value: true, name: "New Posts" } });
+      jest
+        .spyOn(Notifications, "getPermissionsAsync")
+        .mockResolvedValue({ status: "granted" } as any);
+      jest
+        .spyOn(Notifications, "getExpoPushTokenAsync")
+        .mockRejectedValue(new Error("token fetch failed"));
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await NotificationManager.registerForPushNotifications({
+        new_post: { value: false, name: "New Posts" },
+      });
+
+      expect(result.notificationSettings.new_post.value).toBe(false);
+    });
+
+    it("returns the merged settings, not the stale stored ones, when no token is returned", async () => {
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockResolvedValue({ new_post: { value: true, name: "New Posts" } });
+      jest
+        .spyOn(Notifications, "getPermissionsAsync")
+        .mockResolvedValue({ status: "granted" } as any);
+      jest
+        .spyOn(Notifications, "getExpoPushTokenAsync")
+        .mockResolvedValue({ data: "" } as any);
+
+      const result = await NotificationManager.registerForPushNotifications({
+        new_post: { value: false, name: "New Posts" },
+      });
+
+      expect(result.notificationSettings.new_post.value).toBe(false);
+    });
+  });
+
   describe("checkAndRequestOnLaunch", () => {
     afterEach(() => {
       // Restore Device.isDevice after each test via the setter

--- a/src/helpers/Notifications.ts
+++ b/src/helpers/Notifications.ts
@@ -136,30 +136,27 @@ const NotificationManager = {
     status: string;
     notificationSettings: NotificationSettingType;
   }> {
-    if (Config.isFoss) {
-      const storedSettings = await SettingsStore.getNotificationSettings();
-      return { status: "foss", notificationSettings: storedSettings };
-    }
-    ensureNotificationsConfigured();
-    const Notifications = getNotifications();
-    if (!Notifications) {
-      const storedSettings = await SettingsStore.getNotificationSettings();
-      return { status: "unavailable", notificationSettings: storedSettings };
-    }
-
-    let token: string;
-
     const storedSettings = await SettingsStore.getNotificationSettings();
-
     const notificationSettings = {
       ...SettingsStore.defaultNotificationSettings,
       ...storedSettings,
       ...newSettings,
     };
-
     // Persist locally right away so settings survive even if push
-    // registration below fails or is skipped (no permission, no device).
+    // registration below fails or is unavailable (FOSS build, web, no
+    // permission, no device).
     await SettingsStore.setNotificationSettings(notificationSettings);
+
+    if (Config.isFoss) {
+      return { status: "foss", notificationSettings };
+    }
+    ensureNotificationsConfigured();
+    const Notifications = getNotifications();
+    if (!Notifications) {
+      return { status: "unavailable", notificationSettings };
+    }
+
+    let token: string;
 
     if (Platform.OS === "android") {
       // Create a default channel for general notifications
@@ -212,8 +209,6 @@ const NotificationManager = {
     } else {
       return { status: "ok", notificationSettings };
     }
-
-    /** Merge default, stored, and new settings. */
 
     const body = {
       expo_token: token,

--- a/src/helpers/Notifications.ts
+++ b/src/helpers/Notifications.ts
@@ -199,7 +199,7 @@ const NotificationManager = {
       } catch (error) {
         console.error(error);
         return {
-          status: "error getting token" + error,
+          status: `error getting token: ${error}`,
           notificationSettings,
         };
       }

--- a/src/helpers/Notifications.ts
+++ b/src/helpers/Notifications.ts
@@ -157,6 +157,10 @@ const NotificationManager = {
       ...newSettings,
     };
 
+    // Persist locally right away so settings survive even if push
+    // registration below fails or is skipped (no permission, no device).
+    await SettingsStore.setNotificationSettings(notificationSettings);
+
     if (Platform.OS === "android") {
       // Create a default channel for general notifications
       await Notifications.setNotificationChannelAsync("default", {
@@ -191,7 +195,7 @@ const NotificationManager = {
       }
       if (finalStatus !== "granted") {
         console.warn("Notification permission not granted");
-        return { status: finalStatus, notificationSettings: storedSettings };
+        return { status: finalStatus, notificationSettings };
       }
       try {
         token = await NotificationManager.getToken();
@@ -199,11 +203,11 @@ const NotificationManager = {
         console.error(error);
         return {
           status: "error getting token" + error,
-          notificationSettings: storedSettings,
+          notificationSettings,
         };
       }
       if (!token) {
-        return { status: "No Token", notificationSettings: storedSettings };
+        return { status: "No Token", notificationSettings };
       }
     } else {
       return { status: "ok", notificationSettings };
@@ -217,7 +221,6 @@ const NotificationManager = {
       os: Platform.OS,
       version: Application?.nativeBuildVersion,
     };
-    await SettingsStore.setNotificationSettings(notificationSettings);
     const response = await API.registerNotifications(body);
     return { status: response.status, notificationSettings };
   },


### PR DESCRIPTION
## Summary
- `registerForPushNotifications()` only persisted the merged notification settings to `SettingsStore` after successfully obtaining a push token.
- On simulator/emulator (`Device.isDevice === false`), when notification permission was denied, or when the token fetch failed, it returned early without saving — and in three of those paths it returned the stale on-disk settings instead of the freshly merged ones.
- Since each toggle re-reads storage and merges only the one changed key on top of it, toggling a second setting would revert every previously-disabled setting back to its stored value (reported: disabling "Neuer Artikel" then "Neuer Faktencheck" turned "Neuer Artikel" back on, and vice versa for any combination).

## Fix
- Persist the merged `notificationSettings` to `SettingsStore` immediately after computing it, before any permission/token/network logic runs.
- Return the merged object consistently from every early-return path instead of the stale `storedSettings`.

## Test plan
- [x] `pnpm test -- __tests__/helpers/Notifications.test.ts` (16 passed)
- [ ] Manually toggle "Neuer Artikel", "Neuer Faktencheck", "Neuer Prüfpunkt Artikel" in Einstellungen in various combinations and confirm they don't reset each other