### PR TITLE
Fix Web deprecation warnings for shadow* style props and pointerEvents

### DIFF
--- a/src/components/animations/AnimatedSuccess.tsx
+++ b/src/components/animations/AnimatedSuccess.tsx
@@ -156,11 +156,11 @@ const AnimatedSuccess = (properties: AnimatedSuccessProperties) => {
       {/* Blur the form behind the animation (opacity fade, since the blur
           intensity itself cannot be animated natively) */}
       <Animated.View
-        pointerEvents="none"
         style={{
           bottom: 0,
           left: 0,
           opacity: blurOpacity,
+          pointerEvents: "none",
           position: "absolute",
           right: 0,
           top: 0,

--- a/src/components/bars/NavBar.tsx
+++ b/src/components/bars/NavBar.tsx
@@ -70,13 +70,13 @@ const NavBar = (properties: NavBarProperties) => {
       <LinearGradient
         colors={[`rgba(${r},${g},${b},0)`, `rgba(${r},${g},${b},1)`]}
         locations={[0, 1]}
-        pointerEvents="none"
         style={{
           position: "absolute",
           top: -30,
           left: 0,
           right: 0,
           height: 30,
+          pointerEvents: "none",
         }}
       />
 

--- a/src/components/buttons/BackToTopButton.tsx
+++ b/src/components/buttons/BackToTopButton.tsx
@@ -63,12 +63,9 @@ const styles = StyleSheet.create({
   container: {
     borderRadius: 24,
     bottom: 20,
+    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.25)",
     position: "absolute",
     right: 20,
-    shadowColor: "#000",
-    shadowOffset: { height: 2, width: 0 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
   },
 });
 

--- a/src/components/posts/AnnouncementCard.tsx
+++ b/src/components/posts/AnnouncementCard.tsx
@@ -52,10 +52,10 @@ const AnnouncementCard = ({
         <Image
           source={mascot}
           accessible={false}
+          pointerEvents="none"
           style={{
             alignSelf: "center",
             height: MASCOT_HEIGHT,
-            pointerEvents: "none",
             position: "absolute",
             top: -MASCOT_OVERLAP,
             width: MASCOT_WIDTH,

--- a/src/components/posts/AnnouncementCard.tsx
+++ b/src/components/posts/AnnouncementCard.tsx
@@ -52,10 +52,10 @@ const AnnouncementCard = ({
         <Image
           source={mascot}
           accessible={false}
-          pointerEvents="none"
           style={{
             alignSelf: "center",
             height: MASCOT_HEIGHT,
+            pointerEvents: "none",
             position: "absolute",
             top: -MASCOT_OVERLAP,
             width: MASCOT_WIDTH,

--- a/src/components/posts/ArticlePost.tsx
+++ b/src/components/posts/ArticlePost.tsx
@@ -166,12 +166,11 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
   const elevatedWrapperStyle = useMemo(() => {
     if (!elevated) return;
     const isDark = colorScheme === "dark";
+    const shadowRgb = isDark ? "255, 255, 255" : "0, 0, 0";
+    const shadowOpacity = isDark ? 0.12 : 0.2;
     return {
       borderRadius: 15,
-      shadowColor: isDark ? "#fff" : "#000",
-      shadowOffset: { width: 0, height: 1 },
-      shadowOpacity: isDark ? 0.12 : 0.2,
-      shadowRadius: 1.41,
+      boxShadow: `0px 1px 1.41px rgba(${shadowRgb}, ${shadowOpacity})`,
       elevation: 2,
     };
   }, [elevated, colorScheme]);

--- a/src/components/posts/TiktokPost.tsx
+++ b/src/components/posts/TiktokPost.tsx
@@ -64,7 +64,9 @@ const TiktokPost = (properties: TiktokPostProperties) => {
             accessibilityHint="Thumbnail for the TikTok video"
             importantForAccessibility="yes"
           />
-          <View style={globalStyles.centeredAbsolute} pointerEvents="none">
+          <View
+            style={[globalStyles.centeredAbsolute, { pointerEvents: "none" }]}
+          >
             <PlayIcon
               size={56}
               color={TIKTOK_BRAND_COLOR}

--- a/src/components/posts/YouTubePost.tsx
+++ b/src/components/posts/YouTubePost.tsx
@@ -51,7 +51,9 @@ const YouTubePost = (properties: YouTubePostProperties) => {
             style={{ flex: 1, width: width - 24, backgroundColor: corporate }}
             source={{ uri: preview }}
           />
-          <View style={globalStyles.centeredAbsolute} pointerEvents="none">
+          <View
+            style={[globalStyles.centeredAbsolute, { pointerEvents: "none" }]}
+          >
             <PlayIcon size={56} color={YOUTUBE_BRAND_COLOR} />
           </View>
         </UiPressable>

--- a/src/components/ui/UiCollapsable.tsx
+++ b/src/components/ui/UiCollapsable.tsx
@@ -49,10 +49,10 @@ const UiCollapsable = ({
   return (
     <View style={{ paddingHorizontal: 20, borderRadius, overflow: "hidden" }}>
       <Animated.View
-        pointerEvents="none"
         style={[
           StyleSheet.absoluteFill,
           { backgroundColor: resolvedCardBg, opacity: fadeAnim },
+          { pointerEvents: "none" },
         ]}
       />
       <UiPressable

--- a/src/components/views/Donate.tsx
+++ b/src/components/views/Donate.tsx
@@ -135,8 +135,7 @@ const Donate = ({ article_link, ...properties }: DonateProperties) => {
               ))}
             </ScrollView>
             <LinearGradient
-              pointerEvents="none"
-              style={StyleSheet.absoluteFill}
+              style={[StyleSheet.absoluteFill, { pointerEvents: "none" }]}
               colors={[
                 pickerColor,
                 pickerColor + "aa",


### PR DESCRIPTION
## Summary
- Replace deprecated `shadow*` style props (`shadowColor`, `shadowOffset`, `shadowOpacity`, `shadowRadius`) with the cross-platform `boxShadow` style property in `BackToTopButton` and `ArticlePost` — silences `"shadow*" style props are deprecated. Use "boxShadow"` on Web.
- Move `pointerEvents="none"` from a component prop to `style.pointerEvents` in `AnimatedSuccess`, `NavBar`, `AnnouncementCard`, `TiktokPost`, `YouTubePost`, `UiCollapsable`, and `Donate` — silences `props.pointerEvents is deprecated. Use style.pointerEvents` on Web.
- Both properties are supported on iOS/Android under the New Architecture (RN 0.86), so native rendering is unchanged; only the Web warnings are fixed.

## Test plan
- [x] `pnpm lint:fix` / pre-commit Prettier hook ran clean
- [ ] `pnpm check:ts`
- [ ] `pnpm test`
- [ ] Manually verify BackToTopButton and elevated ArticlePost shadows render on iOS/Android
- [ ] Confirm Web console no longer logs the two deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)