### PR TITLE
Auto-request notification permission on onboarding and gate switches on it

### DIFF
--- a/__tests__/app/Onboarding.test.tsx
+++ b/__tests__/app/Onboarding.test.tsx
@@ -220,6 +220,29 @@ describe("Onboarding", () => {
         Notifications.requestPermissionAndApplyDefaults,
       ).toHaveBeenCalledTimes(1);
     });
+
+    it("retries the request on a later visit after a failure", async () => {
+      mockIsFoss = false;
+      jest
+        .mocked(Notifications.requestPermissionAndApplyDefaults)
+        .mockRejectedValueOnce(new Error("native module failure"));
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      await render(<Onboarding />);
+
+      await act(async () => {
+        capturedOnStepChange!({ id: NOTIFICATION_STEP_ID }, 2);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        capturedOnStepChange!({ id: 1 }, 0);
+        capturedOnStepChange!({ id: NOTIFICATION_STEP_ID }, 2);
+        await Promise.resolve();
+      });
+
+      expect(
+        Notifications.requestPermissionAndApplyDefaults,
+      ).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("notification switches disabled state", () => {

--- a/__tests__/app/Onboarding.test.tsx
+++ b/__tests__/app/Onboarding.test.tsx
@@ -51,6 +51,9 @@ jest.mock("#/helpers/Notifications", () => ({
     requestPermissionAndApplyDefaults: jest.fn(() =>
       Promise.resolve({ status: "granted", notificationSettings: {} }),
     ),
+    getPermissions: jest.fn(() =>
+      Promise.resolve({ status: "granted", granted: true }),
+    ),
   },
 }));
 
@@ -301,6 +304,21 @@ describe("Onboarding", () => {
       expect(Notifications.registerForPushNotifications).toHaveBeenCalledTimes(
         1,
       );
+      expect(PersonalStore.setOnboardingDone).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips registerForPushNotifications when permission is not granted", async () => {
+      mockIsFoss = false;
+      (Notifications.getPermissions as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ status: "denied", granted: false }),
+      );
+      await render(<Onboarding />);
+
+      await capturedOnFinish!();
+
+      // Registering would call requestPermissionsAsync again and show a
+      // second OS dialog right after the user denied on the step.
+      expect(Notifications.registerForPushNotifications).not.toHaveBeenCalled();
       expect(PersonalStore.setOnboardingDone).toHaveBeenCalledTimes(1);
     });
 

--- a/__tests__/app/Onboarding.test.tsx
+++ b/__tests__/app/Onboarding.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { render } from "@testing-library/react-native";
+import { act, render } from "@testing-library/react-native";
 import React from "react";
 
 import Onboarding from "#/app/onboarding";
@@ -29,15 +29,17 @@ jest.mock("#/constants/Config", () => ({
   dataProtectionUrl: "https://example.com/datenschutz",
 }));
 
-// Capture data and onFinish from FlatBoard without rendering the full UI
+// Capture data, onFinish and onStepChange from FlatBoard without rendering the full UI
 let capturedData: { id: number; title: string }[] = [];
 let capturedOnFinish: (() => Promise<void>) | null = null;
+let capturedOnStepChange: ((item: any, step: number) => void) | null = null;
 
 jest.mock("#/screens/Onboarding/components/Flatboard", () => ({
   __esModule: true,
-  default: jest.fn(({ data, onFinish }: any) => {
+  default: jest.fn(({ data, onFinish, onStepChange }: any) => {
     capturedData = data;
     capturedOnFinish = onFinish;
+    capturedOnStepChange = onStepChange;
     return null;
   }),
 }));
@@ -46,6 +48,9 @@ jest.mock("#/helpers/Notifications", () => ({
   __esModule: true,
   default: {
     registerForPushNotifications: jest.fn(() => Promise.resolve({})),
+    requestPermissionAndApplyDefaults: jest.fn(() =>
+      Promise.resolve({ status: "granted", notificationSettings: {} }),
+    ),
   },
 }));
 
@@ -72,6 +77,10 @@ jest.mock("expo-haptics", () => ({
 
 jest.mock("expo-web-browser", () => ({
   openBrowserAsync: jest.fn(),
+}));
+
+jest.mock("expo-linking", () => ({
+  openSettings: jest.fn(),
 }));
 
 jest.mock("#/helpers/Stores/SettingsStore", () => ({
@@ -125,6 +134,7 @@ describe("Onboarding", () => {
     jest.clearAllMocks();
     capturedData = [];
     capturedOnFinish = null;
+    capturedOnStepChange = null;
     jest.spyOn(React, "useContext").mockReturnValue({
       contentSettings: {},
       setContentSettings: jest.fn(),
@@ -156,6 +166,128 @@ describe("Onboarding", () => {
       expect(ids).toContain(1); // Welcome
       expect(ids).toContain(3); // Content settings
       expect(ids).toContain(8); // Privacy
+    });
+  });
+
+  describe("onStepChange (notification permission request)", () => {
+    it("requests notification permission once the notification step is reached", async () => {
+      mockIsFoss = false;
+      await render(<Onboarding />);
+
+      await act(async () => {
+        capturedOnStepChange!(
+          { id: NOTIFICATION_STEP_ID },
+          capturedData.findIndex((s) => s.id === NOTIFICATION_STEP_ID),
+        );
+        await Promise.resolve();
+      });
+
+      expect(
+        Notifications.requestPermissionAndApplyDefaults,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not request permission for other steps", async () => {
+      mockIsFoss = false;
+      await render(<Onboarding />);
+
+      await act(async () => {
+        capturedOnStepChange!({ id: 1 }, 0);
+        capturedOnStepChange!({ id: 8 }, 2);
+        await Promise.resolve();
+      });
+
+      expect(
+        Notifications.requestPermissionAndApplyDefaults,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("only requests permission once even if the step is revisited", async () => {
+      mockIsFoss = false;
+      await render(<Onboarding />);
+
+      await act(async () => {
+        capturedOnStepChange!({ id: NOTIFICATION_STEP_ID }, 2);
+        capturedOnStepChange!({ id: 1 }, 0);
+        capturedOnStepChange!({ id: NOTIFICATION_STEP_ID }, 2);
+        await Promise.resolve();
+      });
+
+      expect(
+        Notifications.requestPermissionAndApplyDefaults,
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("notification switches disabled state", () => {
+    // FlatBoard is mocked to just capture `data` without rendering any step's
+    // Component, so we render the notification step's Component ourselves to
+    // see what it passes down to SettingsList.
+    const renderNotificationStepAndGetListProps = async () => {
+      const notificationStep = (capturedData as any[]).find(
+        (s) => s.id === NOTIFICATION_STEP_ID,
+      );
+      const NotificationStepComponent = notificationStep.Component;
+      await render(<NotificationStepComponent />);
+      const SettingsList = jest.requireMock(
+        "#/components/views/SettingsList",
+      ) as jest.Mock;
+      return SettingsList.mock.calls.at(-1)?.[0] as
+        { disabled: boolean; onDisabledPress: () => void } | undefined;
+    };
+
+    it("disables the switches and offers Settings when permission is denied", async () => {
+      mockIsFoss = false;
+      jest
+        .mocked(Notifications.requestPermissionAndApplyDefaults)
+        .mockResolvedValue({
+          status: "denied",
+          notificationSettings: {
+            new_post: { value: false, name: "Neue Artikel" },
+          },
+        } as any);
+      await render(<Onboarding />);
+
+      await act(async () => {
+        capturedOnStepChange!(
+          { id: NOTIFICATION_STEP_ID },
+          capturedData.findIndex((s) => s.id === NOTIFICATION_STEP_ID),
+        );
+        await Promise.resolve();
+      });
+
+      const listProps = await renderNotificationStepAndGetListProps();
+      expect(listProps?.disabled).toBe(true);
+
+      const Linking = jest.requireMock("expo-linking") as {
+        openSettings: jest.Mock;
+      };
+      listProps?.onDisabledPress();
+      expect(Linking.openSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the switches enabled when permission is granted", async () => {
+      mockIsFoss = false;
+      jest
+        .mocked(Notifications.requestPermissionAndApplyDefaults)
+        .mockResolvedValue({
+          status: "ok",
+          notificationSettings: {
+            new_post: { value: true, name: "Neue Artikel" },
+          },
+        } as any);
+      await render(<Onboarding />);
+
+      await act(async () => {
+        capturedOnStepChange!(
+          { id: NOTIFICATION_STEP_ID },
+          capturedData.findIndex((s) => s.id === NOTIFICATION_STEP_ID),
+        );
+        await Promise.resolve();
+      });
+
+      const listProps = await renderNotificationStepAndGetListProps();
+      expect(listProps?.disabled).toBe(false);
     });
   });
 

--- a/__tests__/app/Settings.test.tsx
+++ b/__tests__/app/Settings.test.tsx
@@ -6,8 +6,9 @@ import {
   it,
   jest,
 } from "@jest/globals";
-import { fireEvent, render } from "@testing-library/react-native";
-import React from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { useFocusEffect } from "expo-router";
+import React, { useEffect } from "react";
 
 import SettingsScreen from "#/app/(tabs)/settings";
 import { toast } from "#/helpers/toast";
@@ -32,7 +33,12 @@ jest.mock("#/constants/Config", () => ({
 
 jest.mock("expo-router", () => ({
   useRouter: jest.fn(() => ({ push: jest.fn() })),
+  useFocusEffect: jest.fn(),
   router: { push: jest.fn() },
+}));
+
+jest.mock("expo-linking", () => ({
+  openSettings: jest.fn(),
 }));
 
 jest.mock("expo-application", () => ({
@@ -44,6 +50,7 @@ jest.mock("#/helpers/Notifications", () => ({
   __esModule: true,
   default: {
     getToken: jest.fn(() => Promise.resolve("")),
+    getPermissions: jest.fn(() => Promise.resolve({ status: "granted" })),
     registerForPushNotifications: jest.fn(() =>
       Promise.resolve({ notificationSettings: {} }),
     ),
@@ -154,6 +161,11 @@ describe("SettingsScreen", () => {
       advancedSettings: {},
       setAdvancedSettings: jest.fn(),
     });
+    // Mirror the real useFocusEffect: run the (stable, []-memoized) callback
+    // once on mount, same pattern used in MySources.test.tsx.
+    jest.mocked(useFocusEffect).mockImplementation((cb) => {
+      useEffect(() => cb(), [cb]);
+    });
   });
 
   describe("notifications collapsable", () => {
@@ -167,6 +179,82 @@ describe("SettingsScreen", () => {
       mockIsFoss = true;
       const { queryByText } = await render(<SettingsScreen />);
       expect(queryByText("Benachrichtigungen")).toBeNull();
+    });
+  });
+
+  describe("notification permission state", () => {
+    const getNotificationListProps = () => {
+      const SettingsList = jest.requireMock(
+        "#/components/views/SettingsList",
+      ) as jest.Mock;
+      // Every re-render re-invokes the mock for all three SettingsList
+      // usages (feed/notifications/advanced), so take the most recent
+      // notifications call rather than the first (pre-permission-check) one.
+      return SettingsList.mock.calls.findLast(
+        (call: any[]) => "onDisabledPress" in call[0],
+      )?.[0] as { disabled: boolean; onDisabledPress: () => void } | undefined;
+    };
+
+    it("disables the notification switches when permission is denied", async () => {
+      const Notifications = jest.requireMock("#/helpers/Notifications") as {
+        default: { getPermissions: jest.Mock<any> };
+      };
+      Notifications.default.getPermissions.mockResolvedValue({
+        status: "denied",
+      });
+
+      await render(<SettingsScreen />);
+
+      await waitFor(() => {
+        expect(getNotificationListProps()?.disabled).toBe(true);
+      });
+    });
+
+    it("keeps the notification switches enabled when permission is granted", async () => {
+      const Notifications = jest.requireMock("#/helpers/Notifications") as {
+        default: { getPermissions: jest.Mock<any> };
+      };
+      Notifications.default.getPermissions.mockResolvedValue({
+        status: "granted",
+      });
+
+      await render(<SettingsScreen />);
+      await waitFor(() => {
+        expect(Notifications.default.getPermissions).toHaveBeenCalledTimes(1);
+      });
+
+      expect(getNotificationListProps()?.disabled).toBe(false);
+    });
+
+    it("opens system Settings when the disabled message is pressed", async () => {
+      const Notifications = jest.requireMock("#/helpers/Notifications") as {
+        default: { getPermissions: jest.Mock<any> };
+      };
+      Notifications.default.getPermissions.mockResolvedValue({
+        status: "denied",
+      });
+      const Linking = jest.requireMock("expo-linking") as {
+        openSettings: jest.Mock;
+      };
+
+      await render(<SettingsScreen />);
+      await waitFor(() => {
+        expect(getNotificationListProps()?.disabled).toBe(true);
+      });
+      getNotificationListProps()?.onDisabledPress();
+
+      expect(Linking.openSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not check permissions in FOSS mode", async () => {
+      mockIsFoss = true;
+      const Notifications = jest.requireMock("#/helpers/Notifications") as {
+        default: { getPermissions: jest.Mock<any> };
+      };
+
+      await render(<SettingsScreen />);
+
+      expect(Notifications.default.getPermissions).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/components/views/SettingsList.test.tsx
+++ b/__tests__/components/views/SettingsList.test.tsx
@@ -9,6 +9,15 @@ jest.mock("#/components/ui/UiText", () => {
   return jest.fn(({ children }: any) => <Text>{children}</Text>);
 });
 
+jest.mock("#/components/ui/UiPressable", () => {
+  const { Pressable } = require("react-native");
+  return jest.fn(({ children, onPress, ...props }: any) => (
+    <Pressable onPress={onPress} {...props}>
+      {children}
+    </Pressable>
+  ));
+});
+
 jest.mock("#/hooks/useAppColorScheme", () => ({
   useAppColorScheme: jest.fn(() => "light"),
 }));
@@ -118,5 +127,70 @@ describe("SettingsList", () => {
     });
 
     consoleErrorSpy.mockRestore();
+  });
+
+  describe("disabled (permission denied)", () => {
+    it("disables every switch and shows off, regardless of the stored value", async () => {
+      const saveSettings = jest.fn(() => {});
+      const { getAllByTestId } = await render(
+        <SettingsList
+          saveSettings={saveSettings}
+          settings={settings}
+          disabled
+        />,
+      );
+
+      for (const switchElement of getAllByTestId("settingSwitch")) {
+        expect(switchElement.props.disabled).toBe(true);
+        expect(switchElement.props.value).toBe(false);
+      }
+    });
+
+    it("shows the disabled message and opens Settings when pressed", async () => {
+      const saveSettings = jest.fn(() => {});
+      const onDisabledPress = jest.fn();
+      const { getByText } = await render(
+        <SettingsList
+          saveSettings={saveSettings}
+          settings={settings}
+          disabled
+          disabledMessage="Benachrichtigungen sind deaktiviert."
+          onDisabledPress={onDisabledPress}
+        />,
+      );
+
+      const message = getByText("Benachrichtigungen sind deaktiviert.");
+      expect(message).toBeTruthy();
+      await fireEvent.press(message);
+      expect(onDisabledPress).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not render a message row when disabledMessage is not provided", async () => {
+      const saveSettings = jest.fn(() => {});
+      const { queryAllByRole } = await render(
+        <SettingsList
+          saveSettings={saveSettings}
+          settings={settings}
+          disabled
+        />,
+      );
+
+      expect(queryAllByRole("button")).toHaveLength(0);
+    });
+
+    it("does not disable switches when disabled is false", async () => {
+      const saveSettings = jest.fn(() => {});
+      const { getAllByTestId } = await render(
+        <SettingsList
+          saveSettings={saveSettings}
+          settings={settings}
+          disabled={false}
+        />,
+      );
+
+      for (const switchElement of getAllByTestId("settingSwitch")) {
+        expect(switchElement.props.disabled).toBe(false);
+      }
+    });
   });
 });

--- a/__tests__/helpers/Notifications.test.ts
+++ b/__tests__/helpers/Notifications.test.ts
@@ -354,19 +354,28 @@ describe("NotificationManager", () => {
       jest
         .spyOn(Notifications, "getPermissionsAsync")
         .mockResolvedValue({ status: "undetermined" } as any);
-      jest
+      const requestSpy = jest
         .spyOn(Notifications, "requestPermissionsAsync")
         .mockResolvedValue({ status: "denied" } as any);
       jest.spyOn(console, "warn").mockImplementation(() => {});
+      const API = (jest.requireMock("#/helpers/network/ServerAPI") as any)
+        .default;
 
       const result =
         await NotificationManager.requestPermissionAndApplyDefaults();
 
       expect(result.notificationSettings.new_post.value).toBe(false);
       expect(result.notificationSettings.new_fact_check.value).toBe(false);
+      // The denied path must not fall through to registerForPushNotifications,
+      // which would trigger a second permission request and a server call.
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+      expect(API.registerNotifications).not.toHaveBeenCalled();
+      expect(SettingsStore.setNotificationSettings).toHaveBeenCalledWith(
+        result.notificationSettings,
+      );
     });
 
-    it("does not re-prompt when permission is already granted", async () => {
+    it("does not re-prompt and keeps stored switch values when permission is already granted", async () => {
       (
         SettingsStore.getNotificationSettings as jest.MockedFunction<
           () => Promise<any>
@@ -387,7 +396,10 @@ describe("NotificationManager", () => {
         await NotificationManager.requestPermissionAndApplyDefaults();
 
       expect(requestSpy).not.toHaveBeenCalled();
-      expect(result.notificationSettings.new_post.value).toBe(true);
+      // No prompt was shown, so the user's stored choice (off) must survive
+      // instead of being overwritten by the all-on grant defaults — e.g.
+      // when onboarding is re-entered after the user customized settings.
+      expect(result.notificationSettings.new_post.value).toBe(false);
     });
 
     it("returns unavailable on simulators without requesting permission", async () => {

--- a/__tests__/helpers/Notifications.test.ts
+++ b/__tests__/helpers/Notifications.test.ts
@@ -305,6 +305,109 @@ describe("NotificationManager", () => {
     });
   });
 
+  describe("requestPermissionAndApplyDefaults", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      const Device = jest.requireMock("expo-device") as any;
+      Device.__setIsDeviceValue(true);
+    });
+
+    it("requests permission and turns every switch on when granted", async () => {
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockResolvedValue({
+        new_post: { value: false, name: "New Posts" },
+        new_fact_check: { value: false, name: "New Fact Check" },
+      });
+      jest
+        .spyOn(Notifications, "getPermissionsAsync")
+        .mockResolvedValue({ status: "undetermined" } as any);
+      const requestSpy = jest
+        .spyOn(Notifications, "requestPermissionsAsync")
+        .mockResolvedValue({ status: "granted" } as any);
+      jest
+        .spyOn(Notifications, "getExpoPushTokenAsync")
+        .mockResolvedValue({ data: "ExponentPushToken[test]" } as any);
+      const API = (jest.requireMock("#/helpers/network/ServerAPI") as any)
+        .default;
+      API.registerNotifications.mockResolvedValue({ status: "ok" });
+
+      const result =
+        await NotificationManager.requestPermissionAndApplyDefaults();
+
+      expect(requestSpy).toHaveBeenCalled();
+      expect(result.notificationSettings.new_post.value).toBe(true);
+      expect(result.notificationSettings.new_fact_check.value).toBe(true);
+    });
+
+    it("requests permission and turns every switch off when denied", async () => {
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockResolvedValue({
+        new_post: { value: true, name: "New Posts" },
+        new_fact_check: { value: true, name: "New Fact Check" },
+      });
+      jest
+        .spyOn(Notifications, "getPermissionsAsync")
+        .mockResolvedValue({ status: "undetermined" } as any);
+      jest
+        .spyOn(Notifications, "requestPermissionsAsync")
+        .mockResolvedValue({ status: "denied" } as any);
+      jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result =
+        await NotificationManager.requestPermissionAndApplyDefaults();
+
+      expect(result.notificationSettings.new_post.value).toBe(false);
+      expect(result.notificationSettings.new_fact_check.value).toBe(false);
+    });
+
+    it("does not re-prompt when permission is already granted", async () => {
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockResolvedValue({ new_post: { value: false, name: "New Posts" } });
+      jest
+        .spyOn(Notifications, "getPermissionsAsync")
+        .mockResolvedValue({ status: "granted" } as any);
+      const requestSpy = jest.spyOn(Notifications, "requestPermissionsAsync");
+      jest
+        .spyOn(Notifications, "getExpoPushTokenAsync")
+        .mockResolvedValue({ data: "ExponentPushToken[test]" } as any);
+      const API = (jest.requireMock("#/helpers/network/ServerAPI") as any)
+        .default;
+      API.registerNotifications.mockResolvedValue({ status: "ok" });
+
+      const result =
+        await NotificationManager.requestPermissionAndApplyDefaults();
+
+      expect(requestSpy).not.toHaveBeenCalled();
+      expect(result.notificationSettings.new_post.value).toBe(true);
+    });
+
+    it("returns unavailable on simulators without requesting permission", async () => {
+      const Device = jest.requireMock("expo-device") as any;
+      Device.__setIsDeviceValue(false);
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockResolvedValue({ new_post: { value: true, name: "New Posts" } });
+      const requestSpy = jest.spyOn(Notifications, "requestPermissionsAsync");
+
+      const result =
+        await NotificationManager.requestPermissionAndApplyDefaults();
+
+      expect(requestSpy).not.toHaveBeenCalled();
+      expect(result.status).toBe("unavailable");
+    });
+  });
+
   describe("checkAndRequestOnLaunch", () => {
     afterEach(() => {
       // Restore Device.isDevice after each test via the setter
@@ -506,6 +609,27 @@ describe("NotificationManager", () => {
         await NotificationManager.checkAndRequestOnLaunch();
 
         expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("requestPermissionAndApplyDefaults", () => {
+      it("returns stored settings with status 'foss' without requesting permission", async () => {
+        const mockSettings = {
+          new_post: { value: true, name: "Neue Artikel" },
+        };
+        (
+          SettingsStore.getNotificationSettings as jest.MockedFunction<
+            () => Promise<any>
+          >
+        ).mockResolvedValue(mockSettings);
+        const permissionsSpy = jest.spyOn(Notifications, "getPermissionsAsync");
+
+        const result =
+          await NotificationManager.requestPermissionAndApplyDefaults();
+
+        expect(permissionsSpy).not.toHaveBeenCalled();
+        expect(result.status).toBe("foss");
+        expect(result.notificationSettings).toEqual(mockSettings);
       });
     });
 

--- a/__tests__/helpers/Notifications.test.ts
+++ b/__tests__/helpers/Notifications.test.ts
@@ -610,7 +610,10 @@ describe("NotificationManager", () => {
 
         expect(permissionsSpy).not.toHaveBeenCalled();
         expect(result.status).toBe("foss");
-        expect(result.notificationSettings).toEqual(mockSettings);
+        expect(result.notificationSettings).toEqual({
+          ...SettingsStore.defaultNotificationSettings,
+          ...mockSettings,
+        });
       });
     });
 
@@ -641,7 +644,10 @@ describe("NotificationManager", () => {
 
         expect(permissionsSpy).not.toHaveBeenCalled();
         expect(result.status).toBe("foss");
-        expect(result.notificationSettings).toEqual(mockSettings);
+        expect(result.notificationSettings).toEqual({
+          ...SettingsStore.defaultNotificationSettings,
+          ...mockSettings,
+        });
       });
     });
 

--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -107,11 +107,15 @@ const SettingsScreen = () => {
     useCallback(() => {
       if (Config.isFoss || Platform.OS === "web") return;
       let isActive = true;
-      Notifications.getPermissions().then((permissions) => {
-        if (isActive) {
-          setNotificationPermissionDenied(permissions.status === "denied");
-        }
-      });
+      Notifications.getPermissions()
+        .then((permissions) => {
+          if (isActive) {
+            setNotificationPermissionDenied(permissions.status === "denied");
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to check notification permission:", error);
+        });
       return () => {
         isActive = false;
       };

--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -1,7 +1,8 @@
 import * as Application from "expo-application";
-import { useRouter } from "expo-router";
-import { useContext, useEffect, useRef, useState } from "react";
-import { Animated, StyleSheet, View } from "react-native";
+import * as Linking from "expo-linking";
+import { useFocusEffect, useRouter } from "expo-router";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { Animated, Platform, StyleSheet, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 
 import {
@@ -45,6 +46,8 @@ const SettingsScreen = () => {
     useState<NotificationSettingType>(
       SettingsStore.defaultNotificationSettings,
     );
+  const [notificationPermissionDenied, setNotificationPermissionDenied] =
+    useState(false);
   const {
     contentSettings,
     setContentSettings,
@@ -97,6 +100,24 @@ const SettingsScreen = () => {
     getToken();
   }, []);
 
+  // Re-check the OS permission whenever this tab regains focus (e.g. the
+  // user just came back from toggling it in the system Settings app), so the
+  // switches reflect reality rather than a request made once at mount.
+  useFocusEffect(
+    useCallback(() => {
+      if (Config.isFoss || Platform.OS === "web") return;
+      let isActive = true;
+      Notifications.getPermissions().then((permissions) => {
+        if (isActive) {
+          setNotificationPermissionDenied(permissions.status === "denied");
+        }
+      });
+      return () => {
+        isActive = false;
+      };
+    }, []),
+  );
+
   return (
     <>
       <AnimatedHeader
@@ -147,6 +168,9 @@ const SettingsScreen = () => {
               <SettingsList
                 saveSettings={saveNotificationSetting}
                 settings={notificationSettings}
+                disabled={notificationPermissionDenied}
+                disabledMessage="Benachrichtigungen sind in den Systemeinstellungen deaktiviert. Tippe hier, um sie zu aktivieren."
+                onDisabledPress={() => Linking.openSettings()}
               />
             </UiCollapsable>
           )}

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -3,8 +3,8 @@ import * as Haptics from "expo-haptics";
 import * as Linking from "expo-linking";
 import { useRouter } from "expo-router";
 import { openBrowserAsync } from "expo-web-browser";
-import { useContext, useRef, useState } from "react";
-import { View } from "react-native";
+import { useContext, useEffect, useRef, useState } from "react";
+import { AppState, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { FeedIcon, NotificationIcon, SafetyIcon } from "#/components/Icons";
@@ -43,10 +43,12 @@ const Onboarding = () => {
 
   const isFoss = Config.isFoss ?? false;
   const hasRequestedNotificationPermission = useRef(false);
+  const isOnNotificationStepRef = useRef(false);
   const [notificationPermissionDenied, setNotificationPermissionDenied] =
     useState(false);
 
   const onStepChange = (item: OnBoardingData) => {
+    isOnNotificationStepRef.current = item.id === NOTIFICATION_STEP_ID;
     if (item.id !== NOTIFICATION_STEP_ID) return;
     if (hasRequestedNotificationPermission.current) return;
     hasRequestedNotificationPermission.current = true;
@@ -60,6 +62,28 @@ const Onboarding = () => {
         console.error("Failed to request notification permission:", error);
       });
   };
+
+  // If the user backgrounds the app to flip the OS permission in system
+  // Settings (via the disabled-message deep link) and comes back while still
+  // on the notification step, re-check the outcome so the switches unlock
+  // without waiting for a remount. Only re-checks, never re-prompts.
+  useEffect(() => {
+    if (isFoss) return;
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState !== "active") return;
+      if (!hasRequestedNotificationPermission.current) return;
+      if (!isOnNotificationStepRef.current) return;
+
+      Notifications.getPermissions()
+        .then((permissions) => {
+          setNotificationPermissionDenied(permissions.status === "denied");
+        })
+        .catch((error) => {
+          console.error("Failed to re-check notification permission:", error);
+        });
+    });
+    return () => subscription.remove();
+  }, [isFoss]);
 
   const agreeToTerms = async () => {
     await PersonalStore.setOnboardingDone();

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -4,7 +4,7 @@ import * as Linking from "expo-linking";
 import { useRouter } from "expo-router";
 import { openBrowserAsync } from "expo-web-browser";
 import { useContext, useEffect, useRef, useState } from "react";
-import { AppState, View } from "react-native";
+import { AppState, Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { FeedIcon, NotificationIcon, SafetyIcon } from "#/components/Icons";
@@ -67,8 +67,11 @@ const Onboarding = () => {
   // Settings (via the disabled-message deep link) and comes back while still
   // on the notification step, re-check the outcome so the switches unlock
   // without waiting for a remount. Only re-checks, never re-prompts.
+  // Skipped on web: there is no notification module there, getPermissions
+  // reports a stub "denied", and reacting to it would falsely lock the
+  // switches whenever the browser tab loses and regains visibility.
   useEffect(() => {
-    if (isFoss) return;
+    if (isFoss || Platform.OS === "web") return;
     const subscription = AppState.addEventListener("change", (nextState) => {
       if (nextState !== "active") return;
       if (!hasRequestedNotificationPermission.current) return;
@@ -91,13 +94,21 @@ const Onboarding = () => {
     router.replace("/");
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
 
-    // Permission was already requested on the notification step; this just
-    // makes sure the token/server registration is in sync, fire-and-forget
-    // so it doesn't block the home screen.
+    // Permission was already requested on the notification step; if granted,
+    // make sure the token/server registration is in sync (fire-and-forget so
+    // it doesn't block the home screen). Skipped when not granted, because
+    // registerForPushNotifications would re-request permission and show a
+    // second OS dialog on Android right after the user just denied.
     if (!isFoss) {
-      Notifications.registerForPushNotifications().catch((error) => {
-        console.error("Failed to register for push notifications:", error);
-      });
+      Notifications.getPermissions()
+        .then((permissions) =>
+          permissions.granted
+            ? Notifications.registerForPushNotifications()
+            : undefined,
+        )
+        .catch((error) => {
+          console.error("Failed to register for push notifications:", error);
+        });
     }
   };
 

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -59,6 +59,10 @@ const Onboarding = () => {
         setNotificationPermissionDenied(status === "denied");
       })
       .catch((error) => {
+        // Allow a retry when the user revisits this step — otherwise a
+        // transient failure would leave the switches un-initialized for
+        // the rest of the session.
+        hasRequestedNotificationPermission.current = false;
         console.error("Failed to request notification permission:", error);
       });
   };

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -1,8 +1,9 @@
 import Constants from "expo-constants";
 import * as Haptics from "expo-haptics";
+import * as Linking from "expo-linking";
 import { useRouter } from "expo-router";
 import { openBrowserAsync } from "expo-web-browser";
-import { useContext, useState } from "react";
+import { useContext, useRef, useState } from "react";
 import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -20,9 +21,12 @@ import { SettingsContext } from "#/helpers/provider/SettingsProvider";
 import { isVolksverpetzer } from "#/helpers/utils/variant";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 import FlatBoard from "#/screens/Onboarding/components/Flatboard";
+import type { OnBoardingData } from "#/screens/Onboarding/components/Flatboard";
 import type { NotificationSettingType, SettingType } from "#/types";
 
 import WelcomeVVP from "#assets/images/welcome.webp";
+
+const NOTIFICATION_STEP_ID = 7;
 
 const Onboarding = () => {
   const [notificationSettings, setNotificationSettings] =
@@ -38,6 +42,24 @@ const Onboarding = () => {
   const router = useRouter();
 
   const isFoss = Config.isFoss ?? false;
+  const hasRequestedNotificationPermission = useRef(false);
+  const [notificationPermissionDenied, setNotificationPermissionDenied] =
+    useState(false);
+
+  const onStepChange = (item: OnBoardingData) => {
+    if (item.id !== NOTIFICATION_STEP_ID) return;
+    if (hasRequestedNotificationPermission.current) return;
+    hasRequestedNotificationPermission.current = true;
+
+    Notifications.requestPermissionAndApplyDefaults()
+      .then(({ status, notificationSettings: updatedNotificationSettings }) => {
+        setNotificationSettings(updatedNotificationSettings);
+        setNotificationPermissionDenied(status === "denied");
+      })
+      .catch((error) => {
+        console.error("Failed to request notification permission:", error);
+      });
+  };
 
   const agreeToTerms = async () => {
     await PersonalStore.setOnboardingDone();
@@ -45,7 +67,9 @@ const Onboarding = () => {
     router.replace("/");
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
 
-    // Fire-and-forget so the permission dialog doesn't block the home screen.
+    // Permission was already requested on the notification step; this just
+    // makes sure the token/server registration is in sync, fire-and-forget
+    // so it doesn't block the home screen.
     if (!isFoss) {
       Notifications.registerForPushNotifications().catch((error) => {
         console.error("Failed to register for push notifications:", error);
@@ -111,7 +135,7 @@ const Onboarding = () => {
     ...(!isFoss
       ? [
           {
-            id: 7,
+            id: NOTIFICATION_STEP_ID,
             title: "Push Benachrichtigungen",
             description: `Faktenchecks hinken naturgemäß immer hinterher. Um schnellstmöglich Faktenchecks zu erhalten und zu teilen, kannst du dir Push-Benachrichtigungen aktivieren. Das kann wichtig sein, damit die Fakten deine Freunde oder Familie erreichen, bevor der Fake sie aufs Glatteis führt.`,
             Component: () => (
@@ -138,6 +162,9 @@ const Onboarding = () => {
                 <SettingsList
                   saveSettings={saveNotificationSetting}
                   settings={notificationSettings}
+                  disabled={notificationPermissionDenied}
+                  disabledMessage="Benachrichtigungen sind deaktiviert. Tippe hier, um sie in den Einstellungen zu aktivieren."
+                  onDisabledPress={() => Linking.openSettings()}
                 />
               </View>
             ),
@@ -182,6 +209,7 @@ const Onboarding = () => {
       <FlatBoard
         data={data}
         onFinish={agreeToTerms}
+        onStepChange={onStepChange}
         accentColor={corporate}
         buttonTitle="Los geht's"
         hideIndicator

--- a/src/components/views/SettingsList.tsx
+++ b/src/components/views/SettingsList.tsx
@@ -57,17 +57,25 @@ const SettingsList = (properties: SettingsListProperties) => {
 
   return (
     <View style={{ paddingVertical: 20, paddingHorizontal: 20 }}>
-      {disabled && disabledMessage && (
-        <UiPressable
-          accessibilityRole="button"
-          onPress={onDisabledPress}
-          style={{ paddingBottom: 10 }}
-        >
-          <UiText size="base" style={{ color: textMuted }}>
-            {disabledMessage}
-          </UiText>
-        </UiPressable>
-      )}
+      {disabled &&
+        disabledMessage &&
+        (onDisabledPress ? (
+          <UiPressable
+            accessibilityRole="button"
+            onPress={onDisabledPress}
+            style={{ paddingBottom: 10 }}
+          >
+            <UiText size="base" style={{ color: textMuted }}>
+              {disabledMessage}
+            </UiText>
+          </UiPressable>
+        ) : (
+          <View style={{ paddingBottom: 10 }}>
+            <UiText size="base" style={{ color: textMuted }}>
+              {disabledMessage}
+            </UiText>
+          </View>
+        ))}
       {Object.keys(properties.settings)
         .sort((keyA, keyB) => {
           return properties.settings[keyA].name.localeCompare(

--- a/src/components/views/SettingsList.tsx
+++ b/src/components/views/SettingsList.tsx
@@ -2,6 +2,7 @@ import { type ComponentProps, useState } from "react";
 import type { ColorValue } from "react-native";
 import { Switch, View } from "react-native";
 
+import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
 import Config from "#/constants/Config";
@@ -21,6 +22,12 @@ interface SettingsListProperties {
   settings: {
     [id: string]: SettingType;
   };
+  // Used when every switch in this list is gated behind a single external
+  // permission (e.g. OS notification permission) that's been denied — the
+  // switches can't do anything until the user re-enables it in Settings.
+  disabled?: boolean;
+  disabledMessage?: string;
+  onDisabledPress?: () => void;
 }
 
 // Extend native Switch props locally to allow `activeThumbColor` which
@@ -46,9 +53,21 @@ const SettingsList = (properties: SettingsListProperties) => {
     onPrimary,
   } = Colors[colorScheme];
   const activeSettings = getEnabledFeeds(Config.feeds);
+  const { disabled, disabledMessage, onDisabledPress } = properties;
 
   return (
     <View style={{ paddingVertical: 20, paddingHorizontal: 20 }}>
+      {disabled && disabledMessage && (
+        <UiPressable
+          accessibilityRole="button"
+          onPress={onDisabledPress}
+          style={{ paddingBottom: 10 }}
+        >
+          <UiText size="base" style={{ color: textMuted }}>
+            {disabledMessage}
+          </UiText>
+        </UiPressable>
+      )}
       {Object.keys(properties.settings)
         .sort((keyA, keyB) => {
           return properties.settings[keyA].name.localeCompare(
@@ -72,14 +91,14 @@ const SettingsList = (properties: SettingsListProperties) => {
             ios_backgroundColor: isDarkMode(colorScheme) // ios only
               ? surface
               : onPrimary,
-            thumbColor: setting.value ? corporate : textMuted,
+            thumbColor: setting.value && !disabled ? corporate : textMuted,
             trackColor: {
               // Dark track under the light grey thumb — the thumb itself is
               // textMuted, so the off-track must not use the same grey
               false: isDarkMode(colorScheme) ? surfaceDisabled : surfaceInput,
               true: primaryMuted,
             },
-            disabled: pendingKeys.has(key),
+            disabled: disabled || pendingKeys.has(key),
             onValueChange: (value: boolean) => {
               setPendingKeys((prev) => new Set(prev).add(key));
               Promise.resolve()
@@ -95,7 +114,7 @@ const SettingsList = (properties: SettingsListProperties) => {
                   });
                 });
             },
-            value: setting.value,
+            value: disabled ? false : setting.value,
           };
 
           return (

--- a/src/helpers/Notifications.ts
+++ b/src/helpers/Notifications.ts
@@ -221,12 +221,15 @@ const NotificationManager = {
   },
 
   /**
-   * Requests OS notification permission whenever it is not already granted
-   * and syncs all notification-category switches to match the outcome:
-   * granted -> all on, denied/dismissed -> all off. The OS only actually
-   * shows a dialog while it may still ask (undetermined, or denied with
-   * canAskAgain on Android); otherwise the request resolves silently with
-   * the existing denial.
+   * Requests OS notification permission when it is not already granted and
+   * syncs all notification-category switches to the outcome of that request:
+   * freshly granted -> all on, denied/dismissed -> all off. When permission
+   * was already granted beforehand (no prompt shown, e.g. onboarding was
+   * re-entered), the stored switch values are kept as-is and only the
+   * token/server registration is refreshed. The OS only actually shows a
+   * dialog while it may still ask (undetermined, or denied with canAskAgain
+   * on Android); otherwise the request resolves silently with the existing
+   * denial.
    * Used by the onboarding notification step, which wants the OS prompt to
    * appear as soon as the step is shown rather than per-switch.
    */
@@ -251,12 +254,16 @@ const NotificationManager = {
 
     const { status: existingStatus } =
       await Notifications.getPermissionsAsync();
-    let finalStatus = existingStatus;
-    if (existingStatus !== "granted") {
-      const { status } = await Notifications.requestPermissionsAsync();
-      finalStatus = status;
+
+    if (existingStatus === "granted") {
+      // Permission was already granted before this step — no prompt was
+      // shown, so don't force the all-on defaults over switch values the
+      // user may have customized; just refresh token/server registration.
+      return await NotificationManager.registerForPushNotifications();
     }
 
+    const { status: finalStatus } =
+      await Notifications.requestPermissionsAsync();
     const granted = finalStatus === "granted";
     const notificationSettings = Object.fromEntries(
       Object.entries(currentSettings).map(([key, setting]) => [

--- a/src/helpers/Notifications.ts
+++ b/src/helpers/Notifications.ts
@@ -262,6 +262,16 @@ const NotificationManager = {
       ]),
     ) as NotificationSettingType;
 
+    if (!granted) {
+      // Persist the all-off settings locally, but skip
+      // registerForPushNotifications: its own permission check would call
+      // requestPermissionsAsync a second time (re-prompting on platforms
+      // where canAskAgain is still true), and without permission there is
+      // no token to register anyway.
+      await SettingsStore.setNotificationSettings(notificationSettings);
+      return { status: finalStatus, notificationSettings };
+    }
+
     return await NotificationManager.registerForPushNotifications(
       notificationSettings,
     );

--- a/src/helpers/Notifications.ts
+++ b/src/helpers/Notifications.ts
@@ -221,9 +221,12 @@ const NotificationManager = {
   },
 
   /**
-   * Requests OS notification permission (prompting the user if the status is
-   * still undetermined) and syncs all notification-category switches to
-   * match the outcome: granted -> all on, denied/dismissed -> all off.
+   * Requests OS notification permission whenever it is not already granted
+   * and syncs all notification-category switches to match the outcome:
+   * granted -> all on, denied/dismissed -> all off. The OS only actually
+   * shows a dialog while it may still ask (undetermined, or denied with
+   * canAskAgain on Android); otherwise the request resolves silently with
+   * the existing denial.
    * Used by the onboarding notification step, which wants the OS prompt to
    * appear as soon as the step is shown rather than per-switch.
    */

--- a/src/helpers/Notifications.ts
+++ b/src/helpers/Notifications.ts
@@ -221,6 +221,53 @@ const NotificationManager = {
   },
 
   /**
+   * Requests OS notification permission (prompting the user if the status is
+   * still undetermined) and syncs all notification-category switches to
+   * match the outcome: granted -> all on, denied/dismissed -> all off.
+   * Used by the onboarding notification step, which wants the OS prompt to
+   * appear as soon as the step is shown rather than per-switch.
+   */
+  async requestPermissionAndApplyDefaults(): Promise<{
+    status: string;
+    notificationSettings: NotificationSettingType;
+  }> {
+    const storedSettings = await SettingsStore.getNotificationSettings();
+    const currentSettings = {
+      ...SettingsStore.defaultNotificationSettings,
+      ...storedSettings,
+    };
+
+    if (Config.isFoss) {
+      return { status: "foss", notificationSettings: currentSettings };
+    }
+    ensureNotificationsConfigured();
+    const Notifications = getNotifications();
+    if (!Notifications || !Device.isDevice) {
+      return { status: "unavailable", notificationSettings: currentSettings };
+    }
+
+    const { status: existingStatus } =
+      await Notifications.getPermissionsAsync();
+    let finalStatus = existingStatus;
+    if (existingStatus !== "granted") {
+      const { status } = await Notifications.requestPermissionsAsync();
+      finalStatus = status;
+    }
+
+    const granted = finalStatus === "granted";
+    const notificationSettings = Object.fromEntries(
+      Object.entries(currentSettings).map(([key, setting]) => [
+        key,
+        { ...setting, value: granted },
+      ]),
+    ) as NotificationSettingType;
+
+    return await NotificationManager.registerForPushNotifications(
+      notificationSettings,
+    );
+  },
+
+  /**
    * On app launch check current permissions and request them when appropriate.
    * - If status is UNDETERMINED -> request permissions
    * - If status is DENIED but canAskAgain -> request permissions

--- a/src/screens/Onboarding/components/Flatboard.tsx
+++ b/src/screens/Onboarding/components/Flatboard.tsx
@@ -1,6 +1,6 @@
 import { Image } from "expo-image";
 import type { FC } from "react";
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type {
   ColorValue,
   GestureResponderEvent,
@@ -32,6 +32,7 @@ export type OnBoardingData = {
 interface FlatBoardProperties {
   data: OnBoardingData[];
   onFinish: (event: GestureResponderEvent) => void;
+  onStepChange?: (item: OnBoardingData, step: number) => void;
   accentColor?: ColorValue;
   buttonTitle?: string;
   variant?: "standard" | "modern";
@@ -129,12 +130,18 @@ const FlatBoard = (properties: FlatBoardProperties) => {
   const {
     data,
     onFinish,
+    onStepChange,
     accentColor,
     buttonTitle,
     headingStyle,
     descriptionStyle,
   } = properties;
   const carouselRef = useRef<ICarouselInstance>(null);
+
+  useEffect(() => {
+    onStepChange?.(data[step], step);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step]);
 
   const nextStep = () => {
     const next = Math.min(targetStepRef.current + 1, data.length - 1);

--- a/src/screens/Onboarding/components/Flatboard.tsx
+++ b/src/screens/Onboarding/components/Flatboard.tsx
@@ -139,7 +139,8 @@ const FlatBoard = (properties: FlatBoardProperties) => {
   const carouselRef = useRef<ICarouselInstance>(null);
 
   useEffect(() => {
-    onStepChange?.(data[step], step);
+    const item = data[step];
+    if (item) onStepChange?.(item, step);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step]);
 

--- a/src/screens/Onboarding/components/Flatboard.tsx
+++ b/src/screens/Onboarding/components/Flatboard.tsx
@@ -138,10 +138,19 @@ const FlatBoard = (properties: FlatBoardProperties) => {
   } = properties;
   const carouselRef = useRef<ICarouselInstance>(null);
 
+  // Keep the latest data/callback in refs so the step effect below always
+  // sees fresh values without re-firing when the parent re-renders with new
+  // prop identities while the step stays the same.
+  const dataRef = useRef(data);
+  const onStepChangeRef = useRef(onStepChange);
   useEffect(() => {
-    const item = data[step];
-    if (item) onStepChange?.(item, step);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    dataRef.current = data;
+    onStepChangeRef.current = onStepChange;
+  });
+
+  useEffect(() => {
+    const item = dataRef.current[step];
+    if (item) onStepChangeRef.current?.(item, step);
   }, [step]);
 
   const nextStep = () => {


### PR DESCRIPTION
## Summary
- The onboarding notification step now fires the OS permission dialog as soon as it's shown (once per session), instead of waiting for a switch toggle or the final "Los geht's" tap.
- All three notification-category switches sync to that single OS-level grant/deny outcome — neither iOS nor Android exposes independent per-category permissions, so there's no finer control to request.
- When denied, the switches are disabled and show a message that opens the system Settings app (`Linking.openSettings()`) instead of a live-looking control that can't do anything.
- The persistent Settings tab mirrors the same disabled/Settings-link behavior, re-checking the OS permission on focus so it reflects reality if the user later changes it outside the app.

## Test plan
- [x] `pnpm check:ts` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 115 suites / 891 passed (added coverage for the new permission-request flow, disabled-switch rendering, and Settings-deep-link behavior in Onboarding, Settings tab, SettingsList, and Notifications helper tests)
- [ ] Manual: run onboarding on a real device/simulator, confirm the OS dialog appears on the notification step and switches follow the outcome; then deny in system Settings and confirm the Settings tab reflects it on next focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)