### PR TITLE
Track the onboarding funnel in Plausible

### DIFF
--- a/__tests__/app/Onboarding.test.tsx
+++ b/__tests__/app/Onboarding.test.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import Onboarding from "#/app/onboarding";
 import Notifications from "#/helpers/Notifications";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
+import { registerEvent } from "#/helpers/network/Analytics";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
 
 // Controlled isFoss flag — changed per test
@@ -84,6 +85,10 @@ jest.mock("expo-web-browser", () => ({
 
 jest.mock("expo-linking", () => ({
   openSettings: jest.fn(),
+}));
+
+jest.mock("#/helpers/network/Analytics", () => ({
+  registerEvent: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock("#/helpers/Stores/SettingsStore", () => ({
@@ -314,6 +319,64 @@ describe("Onboarding", () => {
 
       const listProps = await renderNotificationStepAndGetListProps();
       expect(listProps?.disabled).toBe(false);
+    });
+  });
+
+  describe("funnel tracking", () => {
+    it("fires Onboarding Started once on mount", async () => {
+      await render(<Onboarding />);
+
+      expect(registerEvent).toHaveBeenCalledWith(
+        undefined,
+        "Onboarding Started",
+      );
+      expect(
+        (registerEvent as jest.Mock).mock.calls.filter(
+          ([, event]) => event === "Onboarding Started",
+        ),
+      ).toHaveLength(1);
+    });
+
+    it("fires Onboarding Step with step and stepId on forward progress", async () => {
+      await render(<Onboarding />);
+
+      await act(async () => {
+        capturedOnStepChange!({ id: 3 }, 1);
+        await Promise.resolve();
+      });
+
+      expect(registerEvent).toHaveBeenCalledWith(undefined, "Onboarding Step", {
+        step: 1,
+        stepId: 3,
+      });
+    });
+
+    it("does not re-fire Onboarding Step when revisiting a step", async () => {
+      await render(<Onboarding />);
+
+      await act(async () => {
+        capturedOnStepChange!({ id: 3 }, 1);
+        capturedOnStepChange!({ id: 1 }, 0);
+        capturedOnStepChange!({ id: 3 }, 1);
+        await Promise.resolve();
+      });
+
+      expect(
+        (registerEvent as jest.Mock).mock.calls.filter(
+          ([, event]) => event === "Onboarding Step",
+        ),
+      ).toHaveLength(1);
+    });
+
+    it("fires Onboarding Completed on finish", async () => {
+      await render(<Onboarding />);
+
+      await capturedOnFinish!();
+
+      expect(registerEvent).toHaveBeenCalledWith(
+        undefined,
+        "Onboarding Completed",
+      );
     });
   });
 

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -16,6 +16,7 @@ import Config from "#/constants/Config";
 import Notifications from "#/helpers/Notifications";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
 import SettingsStore from "#/helpers/Stores/SettingsStore";
+import { registerEvent } from "#/helpers/network/Analytics";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
 import { SettingsContext } from "#/helpers/provider/SettingsProvider";
 import { isVolksverpetzer } from "#/helpers/utils/variant";
@@ -43,11 +44,26 @@ const Onboarding = () => {
 
   const isFoss = Config.isFoss ?? false;
   const hasRequestedNotificationPermission = useRef(false);
+  // Furthest step the user has reached, so "Onboarding Step" fires once per
+  // step on forward progress only — swiping back and forth doesn't re-count.
+  const furthestStepRef = useRef(0);
+
+  useEffect(() => {
+    registerEvent(Config.wpUrl, "Onboarding Started");
+  }, []);
+
   const isOnNotificationStepRef = useRef(false);
   const [notificationPermissionDenied, setNotificationPermissionDenied] =
     useState(false);
 
-  const onStepChange = (item: OnBoardingData) => {
+  const onStepChange = (item: OnBoardingData, step: number) => {
+    if (step > furthestStepRef.current) {
+      furthestStepRef.current = step;
+      registerEvent(Config.wpUrl, "Onboarding Step", {
+        step,
+        stepId: item.id,
+      });
+    }
     isOnNotificationStepRef.current = item.id === NOTIFICATION_STEP_ID;
     if (item.id !== NOTIFICATION_STEP_ID) return;
     if (hasRequestedNotificationPermission.current) return;
@@ -93,6 +109,7 @@ const Onboarding = () => {
   }, [isFoss]);
 
   const agreeToTerms = async () => {
+    registerEvent(Config.wpUrl, "Onboarding Completed");
     await PersonalStore.setOnboardingDone();
     updateBadgeState({ personal: false, action: true });
     router.replace("/");

--- a/src/helpers/network/Analytics.ts
+++ b/src/helpers/network/Analytics.ts
@@ -25,7 +25,10 @@ export type AnalyticsEvent =
   | "Report Submitted"
   | "Contact Submitted"
   | "Pruefpunkt View"
-  | "Post Interaction";
+  | "Post Interaction"
+  | "Onboarding Started"
+  | "Onboarding Step"
+  | "Onboarding Completed";
 
 /**
  * Props that registerEvent always sets on every event. Callers must not pass


### PR DESCRIPTION
## What

Adds onboarding funnel tracking so we can measure how many users start vs. finish onboarding — and where they drop off. Previously there was no onboarding tracking at all.

Three new events in the `AnalyticsEvent` union:

- **"Onboarding Started"** — fires once when the onboarding screen mounts
- **"Onboarding Step"** — fires with `step` (index) and `stepId` props on forward progress only; a `furthestStepRef` guard ensures swiping back and forth doesn't re-count
- **"Onboarding Completed"** — fires when the user finishes via `agreeToTerms`

In Plausible, the funnel can be built as Started → Step (broken down by the `step` prop) → Completed goals.

## Notes for reviewers

- Events go through the existing `registerEvent` guards: skipped for Mimikama/FOSS (`enableAnalytics: false`) and beta builds.
- Covered by four new tests in the existing `__tests__/app/Onboarding.test.tsx` harness (mount, step progress, no re-fire on revisit, completion). Full suite, lint, and `tsc` pass.
- **Open question before merge:** the privacy slide says "wir tracken dich nicht" and the Datenschutzerklärung is accepted only on finish — these events fire before that point. Plausible is cookieless/anonymous, but the wording vs. behavior should be reviewed.

> Parked for a later release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)