### PR TITLE
Fix hard lag when toggling notification switches

### DIFF
--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -1,4 +1,5 @@
 import * as Application from "expo-application";
+import * as Haptics from "expo-haptics";
 import * as Linking from "expo-linking";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
@@ -46,6 +47,11 @@ const SettingsScreen = () => {
     useState<NotificationSettingType>(
       SettingsStore.defaultNotificationSettings,
     );
+  // Monotonic id for settings syncs: a sync only applies its full-object
+  // result to state if no newer sync started in the meantime — otherwise a
+  // slow, stale sync would visibly revert a newer optimistic toggle of a
+  // *different* switch.
+  const settingsSyncSeqRef = useRef(0);
   const [notificationPermissionDenied, setNotificationPermissionDenied] =
     useState(false);
   const {
@@ -89,13 +95,17 @@ const SettingsScreen = () => {
     const newSetting = { ...setting, value };
     // Flip the switch immediately — the token fetch and server registration
     // below can take seconds on a real device and must not block the UI.
-    // The synced result still wins afterwards (it can differ, e.g. when
-    // permission is missing and the registration bails out).
+    // The sync's merged full-settings result is applied afterwards, but only
+    // if no newer sync started meanwhile (see settingsSyncSeqRef).
     setNotificationSettings((previous) => ({ ...previous, [key]: newSetting }));
+    Haptics.selectionAsync();
+    const syncId = ++settingsSyncSeqRef.current;
     try {
       const { notificationSettings: updatedNotificationSettings } =
         await Notifications.registerForPushNotifications({ [key]: newSetting });
-      setNotificationSettings(updatedNotificationSettings);
+      if (syncId === settingsSyncSeqRef.current) {
+        setNotificationSettings(updatedNotificationSettings);
+      }
     } catch (error) {
       console.error("Failed to sync notification setting:", error);
     }
@@ -103,28 +113,49 @@ const SettingsScreen = () => {
 
   useEffect(() => {
     const getToken = async () => {
-      const token = await Notifications.getToken();
-      setToken(token);
+      try {
+        const token = await Notifications.getToken();
+        setToken(token);
+      } catch (error) {
+        // getToken rethrows (no network, no Play Services, …) — the token
+        // line simply stays empty in that case.
+        console.error("Failed to get push token:", error);
+      }
     };
     getToken();
   }, []);
 
   // Re-check the OS permission whenever this tab regains focus (e.g. the
   // user just came back from toggling it in the system Settings app), so the
-  // switches reflect reality rather than a request made once at mount.
+  // switches reflect reality rather than a request made once at mount. Also
+  // load the stored notification settings — without this the switches show
+  // the defaults, not what the user actually configured.
   useFocusEffect(
     useCallback(() => {
-      if (Config.isFoss || Platform.OS === "web") return;
       let isActive = true;
-      Notifications.getPermissions()
-        .then((permissions) => {
-          if (isActive) {
-            setNotificationPermissionDenied(permissions.status === "denied");
+      const seqAtFocus = settingsSyncSeqRef.current;
+      SettingsStore.getNotificationSettings()
+        .then((storedSettings) => {
+          // Skip if a toggle sync started since focus — its optimistic state
+          // is newer than what storage held when this load began.
+          if (isActive && seqAtFocus === settingsSyncSeqRef.current) {
+            setNotificationSettings(storedSettings);
           }
         })
         .catch((error) => {
-          console.error("Failed to check notification permission:", error);
+          console.error("Failed to load notification settings:", error);
         });
+      if (!Config.isFoss && Platform.OS !== "web") {
+        Notifications.getPermissions()
+          .then((permissions) => {
+            if (isActive) {
+              setNotificationPermissionDenied(permissions.status === "denied");
+            }
+          })
+          .catch((error) => {
+            console.error("Failed to check notification permission:", error);
+          });
+      }
       return () => {
         isActive = false;
       };

--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -87,9 +87,18 @@ const SettingsScreen = () => {
     setting: SettingType,
   ): Promise<void> => {
     const newSetting = { ...setting, value };
-    const { notificationSettings: updatedNotificationSettings } =
-      await Notifications.registerForPushNotifications({ [key]: newSetting });
-    setNotificationSettings(updatedNotificationSettings);
+    // Flip the switch immediately — the token fetch and server registration
+    // below can take seconds on a real device and must not block the UI.
+    // The synced result still wins afterwards (it can differ, e.g. when
+    // permission is missing and the registration bails out).
+    setNotificationSettings((previous) => ({ ...previous, [key]: newSetting }));
+    try {
+      const { notificationSettings: updatedNotificationSettings } =
+        await Notifications.registerForPushNotifications({ [key]: newSetting });
+      setNotificationSettings(updatedNotificationSettings);
+    } catch (error) {
+      console.error("Failed to sync notification setting:", error);
+    }
   };
 
   useEffect(() => {

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -44,6 +44,11 @@ const Onboarding = () => {
   const isFoss = Config.isFoss ?? false;
   const hasRequestedNotificationPermission = useRef(false);
   const isOnNotificationStepRef = useRef(false);
+  // Monotonic id for settings syncs: a sync only applies its full-object
+  // result to state if no newer sync (toggle or permission request) started
+  // in the meantime — otherwise a slow, stale sync would visibly revert a
+  // newer optimistic toggle of a *different* switch.
+  const settingsSyncSeqRef = useRef(0);
   const [notificationPermissionDenied, setNotificationPermissionDenied] =
     useState(false);
 
@@ -53,9 +58,12 @@ const Onboarding = () => {
     if (hasRequestedNotificationPermission.current) return;
     hasRequestedNotificationPermission.current = true;
 
+    const syncId = ++settingsSyncSeqRef.current;
     Notifications.requestPermissionAndApplyDefaults()
       .then(({ status, notificationSettings: updatedNotificationSettings }) => {
-        setNotificationSettings(updatedNotificationSettings);
+        if (syncId === settingsSyncSeqRef.current) {
+          setNotificationSettings(updatedNotificationSettings);
+        }
         setNotificationPermissionDenied(status === "denied");
       })
       .catch((error) => {
@@ -134,14 +142,17 @@ const Onboarding = () => {
     const newSetting = { ...setting, value };
     // Flip the switch immediately — the token fetch and server registration
     // below can take seconds on a real device and must not block the UI.
-    // The synced result still wins afterwards (it can differ, e.g. when
-    // permission is missing and the registration bails out).
+    // The sync's merged full-settings result is applied afterwards, but only
+    // if no newer sync started meanwhile (see settingsSyncSeqRef).
     setNotificationSettings((previous) => ({ ...previous, [key]: newSetting }));
     Haptics.selectionAsync();
+    const syncId = ++settingsSyncSeqRef.current;
     try {
       const { notificationSettings: updatedNotificationSettings } =
         await Notifications.registerForPushNotifications({ [key]: newSetting });
-      setNotificationSettings(updatedNotificationSettings);
+      if (syncId === settingsSyncSeqRef.current) {
+        setNotificationSettings(updatedNotificationSettings);
+      }
     } catch (error) {
       console.error("Failed to sync notification setting:", error);
     }

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -132,10 +132,19 @@ const Onboarding = () => {
     setting: SettingType,
   ): Promise<void> => {
     const newSetting = { ...setting, value };
-    const { notificationSettings: updatedNotificationSettings } =
-      await Notifications.registerForPushNotifications({ [key]: newSetting });
-    setNotificationSettings(updatedNotificationSettings);
+    // Flip the switch immediately — the token fetch and server registration
+    // below can take seconds on a real device and must not block the UI.
+    // The synced result still wins afterwards (it can differ, e.g. when
+    // permission is missing and the registration bails out).
+    setNotificationSettings((previous) => ({ ...previous, [key]: newSetting }));
     Haptics.selectionAsync();
+    try {
+      const { notificationSettings: updatedNotificationSettings } =
+        await Notifications.registerForPushNotifications({ [key]: newSetting });
+      setNotificationSettings(updatedNotificationSettings);
+    } catch (error) {
+      console.error("Failed to sync notification setting:", error);
+    }
   };
 
   const data = [

--- a/src/helpers/Notifications.ts
+++ b/src/helpers/Notifications.ts
@@ -12,6 +12,12 @@ import SettingsStore from "./Stores/SettingsStore";
 
 let cachedNotifications: typeof ExpoNotifications | null = null;
 let notificationsConfigured = false;
+// Serializes registerForPushNotifications calls (see its doc comment).
+let registrationChain: Promise<void> = Promise.resolve();
+// Android notification channels only need to be created once per process;
+// re-creating them on every registration adds two awaits to each settings
+// toggle for nothing (Android freezes channel config after first creation).
+let channelsConfigured = false;
 
 const getNotifications = (): typeof ExpoNotifications | null => {
   if (Config.isFoss) return null;
@@ -127,10 +133,34 @@ const NotificationManager = {
 
   /**
    * Registers the device for push notifications and sends the token along with settings.
+   *
+   * Calls are serialized through a shared promise chain: each registration
+   * reads stored settings, merges its own keys, and writes/POSTs the full
+   * object, so two concurrent calls could otherwise resurrect each other's
+   * stale values (read-merge-write race).
    * @param newSettings - Optional new notification settings to be sent to the server.
    * @returns A promise that resolves to an object containing the status and notification settings.
    */
-  async registerForPushNotifications(
+  registerForPushNotifications(
+    newSettings?: Partial<NotificationSettingType>,
+  ): Promise<{
+    status: string;
+    notificationSettings: NotificationSettingType;
+  }> {
+    const run = registrationChain.then(() =>
+      this.performRegistration(newSettings),
+    );
+    // Keep the chain alive after failures so the next call still runs.
+    registrationChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  },
+
+  /** Inner implementation of registerForPushNotifications — do not call
+   * directly, it must only run serialized through the chain above. */
+  async performRegistration(
     newSettings?: Partial<NotificationSettingType>,
   ): Promise<{
     status: string;
@@ -158,7 +188,8 @@ const NotificationManager = {
 
     let token: string;
 
-    if (Platform.OS === "android") {
+    if (Platform.OS === "android" && !channelsConfigured) {
+      channelsConfigured = true;
       // Create a default channel for general notifications
       await Notifications.setNotificationChannelAsync("default", {
         name: "Default Notifications",


### PR DESCRIPTION
## What

Found while testing the onboarding on a physical device (Fairphone 6): toggling a push-notification switch froze the switch for seconds.

**Cause:** `saveNotificationSetting` awaited the entire sync chain — AsyncStorage write, Android notification-channel setup, OS permission check, Expo push-token fetch, and the server registration call — before updating the switch state via `setNotificationSettings`.

**Fix:** flip the local switch state optimistically right away and run `registerForPushNotifications` in the background. The sync's merged result is applied afterwards only if no newer sync started in the meantime (monotonic sync id), so a slow stale sync can never visibly revert a newer toggle. Applies to both the onboarding notification step (`src/app/onboarding.tsx`) and the settings tab (`src/app/(tabs)/settings.tsx`).

## Hardening from adversarial review

- **Serialized `registerForPushNotifications`** through a shared promise chain — each call does a read-merge-write of the full settings object, so concurrent calls could resurrect stale values in storage/on the server
- **Sync-id guard** on all trailing full-object state updates, including the onboarding permission auto-request
- **Settings tab now loads stored notification settings on focus** — previously it always showed the defaults until the first toggle
- **Android channels created once per process** instead of on every toggle (two awaits saved per toggle; Android freezes channel config after first creation anyway)
- **Token fetch on settings mount wrapped in try/catch** (`getToken` rethrows → was an unhandled rejection)
- Toggle haptic added to settings for parity with onboarding

## Notes for reviewers

- On bail-out paths (permission missing, no token, FOSS, web) the registration returns the merged settings *including* the user's choice — it does not force switches off; the all-off forcing lives only in `requestPermissionAndApplyDefaults`.
- Known, deliberately out of scope (pre-existing): settings tab has no AppState re-check for permission revoked while the app is backgrounded on that tab; the notification UI is visible-but-no-op on web. Both predate this PR.
- `pnpm lint`, `pnpm check:ts`, and `pnpm test` (115 suites / 893 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)