### PR TITLE
Persist notification toggles immediately instead of behind the sync chain

### DIFF
--- a/__tests__/helpers/Notifications.test.ts
+++ b/__tests__/helpers/Notifications.test.ts
@@ -193,6 +193,68 @@ describe("NotificationManager", () => {
       expect(setOrder).toBeLessThan(permissionsOrder);
     });
 
+    it("persists a toggle immediately while an earlier sync is still fetching its token", async () => {
+      // Regression test for the onboarding bug: the permission grant kicks
+      // off an all-on registration whose token fetch takes seconds; a
+      // toggle made during that window must reach storage right away, not
+      // queue behind the network work — otherwise the settings tab reads
+      // stale all-on values.
+      let storage: Record<string, unknown> = {};
+      (
+        SettingsStore.getNotificationSettings as jest.MockedFunction<
+          () => Promise<any>
+        >
+      ).mockImplementation(() => Promise.resolve({ ...storage } as any));
+      (
+        SettingsStore.setNotificationSettings as jest.MockedFunction<
+          (s: any) => Promise<void>
+        >
+      ).mockImplementation((s: any) => {
+        storage = s;
+        return Promise.resolve();
+      });
+      jest
+        .spyOn(Notifications, "getPermissionsAsync")
+        .mockResolvedValue({ status: "granted" } as any);
+      let resolveToken: () => void = () => {};
+      jest
+        .spyOn(Notifications, "getExpoPushTokenAsync")
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveToken = () =>
+                resolve({ data: "ExponentPushToken[slow]" } as any);
+            }),
+        )
+        .mockResolvedValue({ data: "ExponentPushToken[fast]" } as any);
+      const API = (jest.requireMock("#/helpers/network/ServerAPI") as any)
+        .default;
+      API.registerNotifications.mockResolvedValue({ status: "ok" });
+
+      // All-on registration (permission grant) — token fetch hangs.
+      const first = NotificationManager.registerForPushNotifications({
+        new_post: { value: true, name: "New Posts" },
+      } as any);
+      // User toggles off while the first sync is stuck on its token.
+      const second = NotificationManager.registerForPushNotifications({
+        new_post: { value: false, name: "New Posts" },
+      } as any);
+
+      // Let the persist chain flush without resolving the token.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect((storage as any).new_post.value).toBe(false);
+
+      resolveToken();
+      await Promise.all([first, second]);
+      expect((storage as any).new_post.value).toBe(false);
+      // Every POST carries the latest settings, including the first sync
+      // whose own snapshot was outdated by the time it reached the server.
+      for (const call of API.registerNotifications.mock.calls) {
+        expect((call[0] as any).settings.new_post.value).toBe(false);
+      }
+      expect(API.registerNotifications).toHaveBeenCalledTimes(2);
+    });
+
     it("persists and returns the merged settings on simulators/emulators without registering a token", async () => {
       const Device = jest.requireMock("expo-device") as any;
       Device.__setIsDeviceValue(false);

--- a/src/helpers/Notifications.ts
+++ b/src/helpers/Notifications.ts
@@ -12,7 +12,10 @@ import SettingsStore from "./Stores/SettingsStore";
 
 let cachedNotifications: typeof ExpoNotifications | null = null;
 let notificationsConfigured = false;
-// Serializes registerForPushNotifications calls (see its doc comment).
+// Serializes the fast local read-merge-write of notification settings so
+// concurrent calls can't resurrect each other's stale values in storage.
+let persistChain: Promise<void> = Promise.resolve();
+// Serializes the slow network part (token fetch + server registration).
 let registrationChain: Promise<void> = Promise.resolve();
 // Android notification channels only need to be created once per process;
 // re-creating them on every registration adds two awaits to each settings
@@ -134,10 +137,13 @@ const NotificationManager = {
   /**
    * Registers the device for push notifications and sends the token along with settings.
    *
-   * Calls are serialized through a shared promise chain: each registration
-   * reads stored settings, merges its own keys, and writes/POSTs the full
-   * object, so two concurrent calls could otherwise resurrect each other's
-   * stale values (read-merge-write race).
+   * Two-phase design: the local read-merge-write of settings happens
+   * immediately (serialized only against other persists, which take
+   * milliseconds), while the slow token fetch + server registration is
+   * serialized on its own chain. Persisting inside the network chain
+   * caused a real bug: a toggle's persist queued behind an earlier call's
+   * multi-second token fetch, so storage kept the earlier call's values
+   * long enough for the settings tab to read stale data.
    * @param newSettings - Optional new notification settings to be sent to the server.
    * @returns A promise that resolves to an object containing the status and notification settings.
    */
@@ -147,10 +153,35 @@ const NotificationManager = {
     status: string;
     notificationSettings: NotificationSettingType;
   }> {
-    const run = registrationChain.then(() =>
-      this.performRegistration(newSettings),
+    // Phase 1 — merge and persist right away, so storage reflects the
+    // user's latest choice within milliseconds even while earlier syncs
+    // are still doing network work.
+    const persisted = persistChain.then(async () => {
+      const storedSettings = await SettingsStore.getNotificationSettings();
+      const notificationSettings = {
+        ...SettingsStore.defaultNotificationSettings,
+        ...storedSettings,
+        ...newSettings,
+      };
+      await SettingsStore.setNotificationSettings(notificationSettings);
+      return notificationSettings;
+    });
+    // Keep the chains alive after failures so the next call still runs.
+    persistChain = persisted.then(
+      () => undefined,
+      () => undefined,
     );
-    // Keep the chain alive after failures so the next call still runs.
+
+    // Phase 2 — slow token/server sync, serialized separately. Capture the
+    // previous chain now: reading the variable inside the callback would
+    // see the already-reassigned chain (which includes this run) and
+    // deadlock waiting on itself.
+    const previousRegistration = registrationChain;
+    const run = persisted.then((notificationSettings) =>
+      previousRegistration.then(() =>
+        this.performServerRegistration(notificationSettings),
+      ),
+    );
     registrationChain = run.then(
       () => undefined,
       () => undefined,
@@ -158,25 +189,15 @@ const NotificationManager = {
     return run;
   },
 
-  /** Inner implementation of registerForPushNotifications — do not call
-   * directly, it must only run serialized through the chain above. */
-  async performRegistration(
-    newSettings?: Partial<NotificationSettingType>,
+  /** Network half of registerForPushNotifications (permission check, token
+   * fetch, server registration) — do not call directly, it must only run
+   * serialized through the registration chain above. */
+  async performServerRegistration(
+    notificationSettings: NotificationSettingType,
   ): Promise<{
     status: string;
     notificationSettings: NotificationSettingType;
   }> {
-    const storedSettings = await SettingsStore.getNotificationSettings();
-    const notificationSettings = {
-      ...SettingsStore.defaultNotificationSettings,
-      ...storedSettings,
-      ...newSettings,
-    };
-    // Persist locally right away so settings survive even if push
-    // registration below fails or is unavailable (FOSS build, web, no
-    // permission, no device).
-    await SettingsStore.setNotificationSettings(notificationSettings);
-
     if (Config.isFoss) {
       return { status: "foss", notificationSettings };
     }
@@ -241,9 +262,15 @@ const NotificationManager = {
       return { status: "ok", notificationSettings };
     }
 
+    // Re-read storage right before the POST: while this sync waited in the
+    // chain, a newer toggle may already have persisted — the server should
+    // always receive the latest settings, not this sync's snapshot. The
+    // caller still gets this call's own merge back (callers guard against
+    // stale trailing updates themselves via their sync ids).
+    const latestSettings = await SettingsStore.getNotificationSettings();
     const body = {
       expo_token: token,
-      settings: notificationSettings,
+      settings: latestSettings,
       os: Platform.OS,
       version: Application?.nativeBuildVersion,
     };


### PR DESCRIPTION
## What

Fixes the beta bug found on device (Fairphone 6, 2.4.0-beta.6): deselecting a notification category during onboarding still showed **all three switches enabled** in the settings tab afterwards — reproducibly, even after clearing storage.

## Root cause

The serialization added in #433 put the storage write and the slow network work in the **same** chain. On the notification step:

1. The permission grant kicks off an all-on registration → persists all-on, then spends **seconds** fetching the FCM push token (always slow on a fresh install/cleared storage — which is why this reproduced deterministically)
2. The user's toggle queues **behind** that token fetch — its persist hasn't happened yet
3. The user finishes onboarding and opens settings within a few seconds → the focus-load reads storage → still all-on
4. The toggle's persist lands moments later, but settings doesn't re-read without a re-focus

The user's choice *was* eventually saved — the settings tab just read storage inside the multi-second stale window.

## Fix

`registerForPushNotifications` is split into two phases with separate serialization:

- **Persist phase** (fast, own chain): read-merge-write of the settings — lands within milliseconds of the toggle
- **Network phase** (slow, own chain): permission check, token fetch, server registration

The POST re-reads storage right before sending, so the server always receives the latest settings even when an older queued sync is the one sending them. Callers still get their own call's merge back (their sync-id guards handle stale trailing updates).

## Notes for reviewers

- Includes a regression test that hangs the first sync's token fetch, fires a second toggle, and asserts the toggle reaches storage before the first sync completes — and that every server POST carries the latest values.
- Subtle bit in the implementation: the network phase must capture `registrationChain` **before** reassigning it — reading the variable inside the callback would see the reassigned chain (which includes the new run itself) and deadlock. There's a comment on this.
- `pnpm lint`, `pnpm check:ts`, and `pnpm test` (115 suites / 894 tests, incl. the new regression test) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)