### PR TITLE
Add Podigee podcast episodes as home feed items

### DIFF
--- a/__tests__/app/podcast/PodcastScreen.test.tsx
+++ b/__tests__/app/podcast/PodcastScreen.test.tsx
@@ -1,0 +1,97 @@
+import { render, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+import PodcastScreen from "#/app/podcast/[id]";
+
+const mockRouterBack = jest.fn();
+const mockGetPodcastFeed = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: jest.fn(() => ({ id: "abc123" })),
+  useRouter: jest.fn(() => ({ back: mockRouterBack })),
+}));
+
+jest.mock("#/helpers/network/ServerAPI", () => ({
+  __esModule: true,
+  default: {
+    getPodcastFeed: (...args: unknown[]) => mockGetPodcastFeed(...args),
+  },
+}));
+
+jest.mock("#/helpers/Sharing", () => ({ onShare: jest.fn() }));
+
+jest.mock("#/hooks/useAppColorScheme", () => ({
+  useAppColorScheme: jest.fn(() => "light"),
+  useCorporateColor: jest.fn(() => "#1B7194"),
+}));
+
+jest.mock("#/constants/Colors", () => ({
+  __esModule: true,
+  default: {
+    light: { background: "#ffffff", textMuted: "#666" },
+    dark: { background: "#000000", textMuted: "#AAA" },
+  },
+}));
+
+jest.mock("react-native-gesture-handler", () => ({
+  ScrollView: jest.fn(({ children }: any) => children),
+}));
+
+jest.mock("expo-image", () => ({ __esModule: true, Image: () => null }));
+jest.mock("#/components/audio/AudioPlayer", () => jest.fn(() => null));
+jest.mock("#/components/bars/NavBar", () => jest.fn(() => null));
+jest.mock("#/components/views/Footer", () => jest.fn(() => null));
+jest.mock("#/components/ui/UiSpinner", () => {
+  const { Text } = jest.requireActual("react-native") as {
+    Text: React.ComponentType<{ testID?: string; children?: React.ReactNode }>;
+  };
+  return jest.fn(({ text }: { text?: string }) => (
+    <Text testID="spinner">{text}</Text>
+  ));
+});
+
+const episode = {
+  id: "abc123",
+  title: "Folge 24: Testfolge",
+  description: "Beschreibung der Folge.",
+  published_at: "2026-06-26T04:00:00+00:00",
+  link: "https://volksverpetzer.podigee.io/25-folge-24",
+  audio_url: "https://audio.example.com/ep24.mp3",
+  image_url: "https://example.com/cover.png",
+  duration: 3539,
+};
+
+describe("PodcastScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows a spinner while the feed is loading", async () => {
+    mockGetPodcastFeed.mockReturnValue(new Promise(() => {}));
+    const { getByTestId } = await render(<PodcastScreen />);
+    expect(getByTestId("spinner")).toBeTruthy();
+  });
+
+  it("renders the episode found by id", async () => {
+    mockGetPodcastFeed.mockResolvedValue([episode]);
+    const { getByText } = await render(<PodcastScreen />);
+    await waitFor(() => {
+      expect(getByText("Folge 24: Testfolge")).toBeTruthy();
+      expect(getByText("Beschreibung der Folge.")).toBeTruthy();
+      expect(getByText("26.6.2026 | 59 Min.")).toBeTruthy();
+    });
+  });
+
+  it("navigates back when the episode is not in the feed", async () => {
+    mockGetPodcastFeed.mockResolvedValue([{ ...episode, id: "other" }]);
+    await render(<PodcastScreen />);
+    await waitFor(() => expect(mockRouterBack).toHaveBeenCalled());
+  });
+
+  it("navigates back when the feed request fails", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockGetPodcastFeed.mockRejectedValue(new Error("network"));
+    await render(<PodcastScreen />);
+    await waitFor(() => expect(mockRouterBack).toHaveBeenCalled());
+  });
+});

--- a/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
+++ b/__tests__/components/PersonalTabFeeds/MyFavs.test.tsx
@@ -8,7 +8,7 @@ import WordPressAPI from "#/helpers/network/WordPressAPI";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
 import { WordPressFetcher } from "#/screens/Home/fetchers/WordPressFetcher";
 import MyFavs from "#/screens/PersonalTab/components/MyFavs";
-import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA } from "#/types";
+import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA, FAV_TYPE_PODCAST } from "#/types";
 
 const mockUseIsFocused = jest.fn(() => true);
 
@@ -104,6 +104,19 @@ jest.mock("#/screens/Home/fetchers/WordPressFetcher", () => ({
   WordPressFetcher: {
     mapArticleToPost: jest.fn(),
   },
+}));
+
+// Mock PodcastFetcher so MyFavs doesn't pull in the audio player / expo-audio
+// through PodcastPost during the test.
+const mockMapPodcastEpisode = jest.fn((episode) => ({
+  id: episode.id,
+  component: jest.fn(),
+  data: episode,
+  contentFavIdentifier: episode.id,
+  contentType: "podcast",
+}));
+jest.mock("#/screens/Home/fetchers/PodcastFetcher", () => ({
+  mapPodcastEpisode: (episode: unknown) => mockMapPodcastEpisode(episode),
 }));
 
 describe("MyFavs", () => {
@@ -303,6 +316,44 @@ describe("MyFavs", () => {
             url: "https://www.instagram.com/p/ppShortcode/",
           },
         ],
+      }),
+    );
+  });
+
+  it("rebuilds a podcast favorite from its stored snapshot", async () => {
+    const episode = {
+      id: "ep-guid-1",
+      title: "Folge 24",
+      description: "Beschreibung",
+      published_at: "2026-01-05T12:00:00Z",
+      link: "https://volksverpetzer.podigee.io/25-folge-24",
+      audio_url: "https://audio.example.com/ep24.mp3",
+      image_url: "https://example.com/cover.png",
+      duration: 3539,
+    };
+
+    (FavoritesStore.getAllFavorites as jest.Mock).mockResolvedValue({
+      "ep-guid-1": { contentType: FAV_TYPE_PODCAST, payload: episode },
+    });
+
+    await render(<MyFavs />);
+
+    await waitFor(() => {
+      expect(GenericPost).toHaveBeenCalledTimes(1);
+    });
+
+    // Rebuilt from the snapshot via the shared mapper; the feed is not fetched
+    // and the favorite is not purged.
+    expect(mockMapPodcastEpisode).toHaveBeenCalledWith(episode);
+    expect(FavoritesStore.removeFavorite).not.toHaveBeenCalled();
+
+    const genericPostCalls = (
+      GenericPost as unknown as jest.Mock
+    ).mock.calls.map(([properties]) => properties);
+    expect(genericPostCalls[0]).toEqual(
+      expect.objectContaining({
+        contentFavIdentifier: "ep-guid-1",
+        contentType: FAV_TYPE_PODCAST,
       }),
     );
   });

--- a/__tests__/components/audio/AudioPlayer.test.tsx
+++ b/__tests__/components/audio/AudioPlayer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import {
   setAudioModeAsync,
   useAudioPlayer,
@@ -37,6 +37,19 @@ jest.mock("#/hooks/useAppColorScheme", () => ({
 // `setActiveForLockScreen` is a synchronous native `Function` (not
 // `AsyncFunction`) despite expo-audio's `void`-typed signature — mocking it
 // as async would hide bugs tied to it actually being synchronous.
+
+const mockGetAudioPosition = jest.fn().mockResolvedValue(0);
+const mockSetAudioPosition = jest.fn().mockResolvedValue(undefined);
+const mockClearAudioPosition = jest.fn().mockResolvedValue(undefined);
+jest.mock("#/helpers/Stores/PersonalStore", () => ({
+  __esModule: true,
+  default: {
+    getAudioPosition: (...args: unknown[]) => mockGetAudioPosition(...args),
+    setAudioPosition: (...args: unknown[]) => mockSetAudioPosition(...args),
+    clearAudioPosition: (...args: unknown[]) => mockClearAudioPosition(...args),
+  },
+}));
+
 const mockPlayer = {
   id: "player-1",
   play: jest.fn().mockResolvedValue(undefined),
@@ -314,6 +327,71 @@ describe("AudioPlayer — clamping", () => {
   });
 });
 
+describe("AudioPlayer — autoPlay", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
+  });
+
+  it("plays once automatically after load when autoPlay is set", async () => {
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue(loadedStatus as AudioStatus);
+    const { rerender } = await render(
+      <AudioPlayer audioUrl={TEST_URL} autoPlay />,
+    );
+    expect(mockPlayer.play).toHaveBeenCalledTimes(1);
+    // Status updates must not re-trigger autoplay
+    await rerender(<AudioPlayer audioUrl={TEST_URL} autoPlay />);
+    expect(mockPlayer.play).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not autoplay before the audio is loaded", async () => {
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue({ ...loadedStatus, isLoaded: false } as AudioStatus);
+    await render(<AudioPlayer audioUrl={TEST_URL} autoPlay />);
+    expect(mockPlayer.play).not.toHaveBeenCalled();
+  });
+
+  it("does not autoplay without the prop (article usage)", async () => {
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue(loadedStatus as AudioStatus);
+    await render(<AudioPlayer audioUrl={TEST_URL} />);
+    expect(mockPlayer.play).not.toHaveBeenCalled();
+  });
+});
+
+describe("AudioPlayer — showFeedback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
+  });
+
+  it("renders a spinner while loading instead of nothing", async () => {
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue({ ...loadedStatus, isLoaded: false } as AudioStatus);
+    const { toJSON } = await render(
+      <AudioPlayer audioUrl={TEST_URL} showFeedback />,
+    );
+    expect(toJSON()).not.toBeNull();
+  });
+
+  it("renders an error message when loading fails", async () => {
+    jest.mocked(useAudioPlayerStatus).mockReturnValue({
+      ...loadedStatus,
+      isLoaded: false,
+      error: "404 Not Found",
+    } as AudioStatus);
+    const { getByText } = await render(
+      <AudioPlayer audioUrl={TEST_URL} showFeedback />,
+    );
+    expect(getByText("Audio konnte nicht geladen werden.")).toBeTruthy();
+  });
+});
+
 describe("AudioPlayer — remaining time display", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -338,4 +416,107 @@ describe("AudioPlayer — remaining time display", () => {
       expect(getByText(expected)).toBeTruthy();
     },
   );
+});
+
+describe("AudioPlayer — resume playback", () => {
+  const RESUME_URL = "https://audio.example.com/episode.mp3";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
+    mockGetAudioPosition.mockResolvedValue(0);
+  });
+
+  it("seeks to the stored position once loaded", async () => {
+    mockGetAudioPosition.mockResolvedValue(100);
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue(loadedStatus as AudioStatus);
+
+    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
+
+    await waitFor(() => {
+      expect(mockGetAudioPosition).toHaveBeenCalledWith(RESUME_URL);
+      expect(mockPlayer.seekTo).toHaveBeenCalledWith(100);
+    });
+  });
+
+  it("ignores stored positions near the start", async () => {
+    mockGetAudioPosition.mockResolvedValue(5);
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue(loadedStatus as AudioStatus);
+
+    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
+
+    await waitFor(() => expect(mockGetAudioPosition).toHaveBeenCalled());
+    expect(mockPlayer.seekTo).not.toHaveBeenCalled();
+  });
+
+  it("ignores stored positions near the end", async () => {
+    // duration is 120 in loadedStatus; 115 is within the end margin
+    mockGetAudioPosition.mockResolvedValue(115);
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue(loadedStatus as AudioStatus);
+
+    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
+
+    await waitFor(() => expect(mockGetAudioPosition).toHaveBeenCalled());
+    expect(mockPlayer.seekTo).not.toHaveBeenCalled();
+  });
+
+  it("delays autoplay until the restore finished, then plays", async () => {
+    mockGetAudioPosition.mockResolvedValue(100);
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue(loadedStatus as AudioStatus);
+
+    await render(
+      <AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} autoPlay />,
+    );
+
+    await waitFor(() => {
+      expect(mockPlayer.seekTo).toHaveBeenCalledWith(100);
+      expect(mockPlayer.play).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not touch the store without a resumeKey", async () => {
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue(loadedStatus as AudioStatus);
+
+    await render(<AudioPlayer audioUrl={RESUME_URL} />);
+
+    expect(mockGetAudioPosition).not.toHaveBeenCalled();
+    expect(mockSetAudioPosition).not.toHaveBeenCalled();
+  });
+
+  it("clears the stored position when the audio finishes", async () => {
+    jest.mocked(useAudioPlayerStatus).mockReturnValue({
+      ...loadedStatus,
+      didJustFinish: true,
+    } as AudioStatus);
+
+    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
+
+    await waitFor(() =>
+      expect(mockClearAudioPosition).toHaveBeenCalledWith(RESUME_URL),
+    );
+  });
+
+  it("persists progress during playback", async () => {
+    jest.mocked(useAudioPlayerStatus).mockReturnValue({
+      ...loadedStatus,
+      playing: true,
+      currentTime: 42,
+    } as AudioStatus);
+
+    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
+
+    await waitFor(() =>
+      expect(mockSetAudioPosition).toHaveBeenCalledWith(RESUME_URL, 42),
+    );
+  });
 });

--- a/__tests__/components/audio/AudioPlayer.test.tsx
+++ b/__tests__/components/audio/AudioPlayer.test.tsx
@@ -1,31 +1,16 @@
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
-import {
-  setAudioModeAsync,
-  useAudioPlayer,
-  useAudioPlayerStatus,
-} from "expo-audio";
-import type { AudioStatus } from "expo-audio";
+import { fireEvent, render } from "@testing-library/react-native";
 
 import AudioPlayer from "#/components/audio/AudioPlayer";
 
-jest.mock("expo-audio", () => ({
-  useAudioPlayer: jest.fn(),
-  useAudioPlayerStatus: jest.fn(),
-  setAudioModeAsync: jest.fn().mockResolvedValue(undefined),
-}));
-
 jest.mock("@react-native-vector-icons/octicons/static", () => "Octicons");
 
-jest.mock("#/components/Icons", () => ({
-  PauseIcon: () => null,
-  UnmuteIcon: () => null,
-}));
+jest.mock("#/components/Icons", () => ({ PauseIcon: () => null }));
 
 jest.mock("#/constants/Colors", () => ({
   __esModule: true,
   default: {
-    light: { muted: "#DDD", textMuted: "#AAA" },
-    dark: { muted: "#333", textMuted: "#AAA" },
+    light: { textMuted: "#AAA", surfaceDisabled: "#DDD", error: "#C62828" },
+    dark: { textMuted: "#AAA", surfaceDisabled: "#333", error: "#EF5350" },
   },
 }));
 
@@ -34,489 +19,118 @@ jest.mock("#/hooks/useAppColorScheme", () => ({
   useCorporateColor: () => "#1B7194",
 }));
 
-// `setActiveForLockScreen` is a synchronous native `Function` (not
-// `AsyncFunction`) despite expo-audio's `void`-typed signature — mocking it
-// as async would hide bugs tied to it actually being synchronous.
+jest.mock("#/components/ui/UiSpinner", () => {
+  const { Text } = jest.requireActual("react-native") as {
+    Text: React.ComponentType<{ testID?: string }>;
+  };
+  return jest.fn(() => <Text testID="spinner" />);
+});
 
-const mockGetAudioPosition = jest.fn().mockResolvedValue(0);
-const mockSetAudioPosition = jest.fn().mockResolvedValue(undefined);
-const mockClearAudioPosition = jest.fn().mockResolvedValue(undefined);
-jest.mock("#/helpers/Stores/PersonalStore", () => ({
-  __esModule: true,
-  default: {
-    getAudioPosition: (...args: unknown[]) => mockGetAudioPosition(...args),
-    setAudioPosition: (...args: unknown[]) => mockSetAudioPosition(...args),
-    clearAudioPosition: (...args: unknown[]) => mockClearAudioPosition(...args),
-  },
-}));
-
-const mockPlayer = {
-  id: "player-1",
-  play: jest.fn().mockResolvedValue(undefined),
-  pause: jest.fn().mockResolvedValue(undefined),
-  seekTo: jest.fn().mockResolvedValue(undefined),
-  setActiveForLockScreen: jest.fn(),
-};
-
-const loadedStatus: Partial<AudioStatus> = {
-  isLoaded: true,
+const audioState = {
+  currentUrl: null as string | null,
+  isLoaded: false,
   playing: false,
   currentTime: 0,
-  duration: 120,
-  error: null,
-  didJustFinish: false,
+  duration: 0,
+  error: false,
+};
+const mockPlayTrack = jest.fn();
+const mockToggle = jest.fn();
+const mockSeekTo = jest.fn();
+const mockIsCurrent = jest.fn();
+
+jest.mock("#/helpers/provider/AudioProvider", () => ({
+  useAudio: () => ({
+    currentUrl: audioState.currentUrl,
+    isLoaded: audioState.isLoaded,
+    playing: audioState.playing,
+    currentTime: audioState.currentTime,
+    duration: audioState.duration,
+    error: audioState.error,
+    playTrack: mockPlayTrack,
+    toggle: mockToggle,
+    pause: jest.fn(),
+    seekTo: mockSeekTo,
+    isCurrent: (url: string) => mockIsCurrent(url),
+  }),
+}));
+
+const URL = "https://audio.example.com/ep.mp3";
+
+const setCurrent = (over: Partial<typeof audioState>) => {
+  mockIsCurrent.mockReturnValue(true);
+  Object.assign(audioState, { currentUrl: URL, isLoaded: true, ...over });
 };
 
-const TEST_URL = "https://vvpaudio.b-cdn.net/audio/test-article.mp3";
-
-describe("AudioPlayer — visibility", () => {
+describe("AudioPlayer (provider-bound controls)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
-  });
-
-  it("renders nothing while the audio is not yet loaded", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, isLoaded: false } as AudioStatus);
-    const { toJSON } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(toJSON()).toBeNull();
-  });
-
-  it("renders nothing when the audio file has a load error (e.g. 404)", async () => {
-    jest.mocked(useAudioPlayerStatus).mockReturnValue({
-      ...loadedStatus,
-      error: "404 Not Found",
-    } as AudioStatus);
-    const { toJSON } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(toJSON()).toBeNull();
-  });
-
-  it("renders the player once audio is loaded", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue(loadedStatus as AudioStatus);
-    const { toJSON } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(toJSON()).not.toBeNull();
-  });
-});
-
-describe("AudioPlayer — playback controls", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue(loadedStatus as AudioStatus);
-  });
-
-  it("does not enable background playback on mount while paused", async () => {
-    await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(setAudioModeAsync).not.toHaveBeenCalled();
-  });
-
-  it("calls player.play() when button is pressed while paused", async () => {
-    const { getByRole } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-    await fireEvent.press(getByRole("button"));
-    expect(mockPlayer.play).toHaveBeenCalledTimes(1);
-    expect(mockPlayer.pause).not.toHaveBeenCalled();
-  });
-
-  it("calls player.pause() when button is pressed while playing", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, playing: true } as AudioStatus);
-    const { getByRole } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-    await fireEvent.press(getByRole("button"));
-    expect(mockPlayer.pause).toHaveBeenCalledTimes(1);
-    expect(mockPlayer.play).not.toHaveBeenCalled();
-  });
-
-  it("enables background playback and lock screen controls once status reports playing", async () => {
-    const { rerender } = await render(
-      <AudioPlayer audioUrl={TEST_URL} title="Titel" artworkUrl="art.jpg" />,
-    );
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, playing: true } as AudioStatus);
-    await rerender(
-      <AudioPlayer audioUrl={TEST_URL} title="Titel" artworkUrl="art.jpg" />,
-    );
-
-    expect(setAudioModeAsync).toHaveBeenCalledWith({
-      playsInSilentMode: true,
-      interruptionMode: "doNotMix",
-      shouldPlayInBackground: true,
-    });
-    expect(mockPlayer.setActiveForLockScreen).toHaveBeenCalledWith(
-      true,
-      expect.objectContaining({ title: "Titel", artworkUrl: "art.jpg" }),
-    );
-  });
-
-  it("refreshes lock screen metadata when title/artwork change while still playing", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, playing: true } as AudioStatus);
-    const { rerender } = await render(
-      <AudioPlayer
-        audioUrl={TEST_URL}
-        title="Alter Titel"
-        artworkUrl="old.jpg"
-      />,
-    );
-    expect(mockPlayer.setActiveForLockScreen).toHaveBeenCalledWith(
-      true,
-      expect.objectContaining({ title: "Alter Titel", artworkUrl: "old.jpg" }),
-    );
-
-    await rerender(
-      <AudioPlayer
-        audioUrl={TEST_URL}
-        title="Neuer Titel"
-        artworkUrl="new.jpg"
-      />,
-    );
-
-    expect(mockPlayer.setActiveForLockScreen).toHaveBeenLastCalledWith(
-      true,
-      expect.objectContaining({ title: "Neuer Titel", artworkUrl: "new.jpg" }),
-    );
-  });
-
-  it("disables background playback once status reports paused again", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, playing: true } as AudioStatus);
-    const { rerender } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, playing: false } as AudioStatus);
-    await rerender(<AudioPlayer audioUrl={TEST_URL} />);
-
-    expect(setAudioModeAsync).toHaveBeenLastCalledWith({
-      playsInSilentMode: true,
-      interruptionMode: "doNotMix",
-      shouldPlayInBackground: false,
-    });
-  });
-
-  it("calls seekTo(0) when the audio finishes", async () => {
-    jest.mocked(useAudioPlayerStatus).mockReturnValue({
-      ...loadedStatus,
-      didJustFinish: true,
-    } as AudioStatus);
-    await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(mockPlayer.seekTo).toHaveBeenCalledWith(0);
-  });
-
-  it("does not call seekTo(0) during normal playback", async () => {
-    jest.mocked(useAudioPlayerStatus).mockReturnValue({
-      ...loadedStatus,
-      currentTime: 45,
-      didJustFinish: false,
-    } as AudioStatus);
-    await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(mockPlayer.seekTo).not.toHaveBeenCalled();
-  });
-});
-
-describe("AudioPlayer — exclusive background playback across instances", () => {
-  const URL_A = "https://vvpaudio.b-cdn.net/audio/article-a.mp3";
-  const URL_B = "https://vvpaudio.b-cdn.net/audio/article-b.mp3";
-
-  const playerA = {
-    id: "player-a",
-    play: jest.fn().mockResolvedValue(undefined),
-    pause: jest.fn().mockResolvedValue(undefined),
-    seekTo: jest.fn().mockResolvedValue(undefined),
-    setActiveForLockScreen: jest.fn(),
-  };
-  const playerB = {
-    id: "player-b",
-    play: jest.fn().mockResolvedValue(undefined),
-    pause: jest.fn().mockResolvedValue(undefined),
-    seekTo: jest.fn().mockResolvedValue(undefined),
-    setActiveForLockScreen: jest.fn(),
-  };
-
-  let statusA: AudioStatus;
-  let statusB: AudioStatus;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    statusA = { ...loadedStatus, playing: false } as AudioStatus;
-    statusB = { ...loadedStatus, playing: false } as AudioStatus;
-    jest
-      .mocked(useAudioPlayer)
-      .mockImplementation((url) => (url === URL_A ? playerA : playerB) as any);
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockImplementation((player: any) =>
-        player === playerA ? statusA : statusB,
-      );
-  });
-
-  it("pauses the currently active player when a different player starts playing", async () => {
-    const { rerender } = await render(
-      <>
-        <AudioPlayer audioUrl={URL_A} />
-        <AudioPlayer audioUrl={URL_B} />
-      </>,
-    );
-
-    statusA = { ...statusA, playing: true };
-    await rerender(
-      <>
-        <AudioPlayer audioUrl={URL_A} />
-        <AudioPlayer audioUrl={URL_B} />
-      </>,
-    );
-    expect(playerA.pause).not.toHaveBeenCalled();
-
-    statusB = { ...statusB, playing: true };
-    await rerender(
-      <>
-        <AudioPlayer audioUrl={URL_A} />
-        <AudioPlayer audioUrl={URL_B} />
-      </>,
-    );
-
-    expect(playerA.pause).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("AudioPlayer — accessibility labels", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
-  });
-
-  it("labels the button 'Abspielen' when paused", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, playing: false } as AudioStatus);
-    const { getByRole } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(getByRole("button", { name: "Abspielen" })).toBeTruthy();
-  });
-
-  it("labels the button 'Pause' when playing", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, playing: true } as AudioStatus);
-    const { getByRole } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(getByRole("button", { name: "Pause" })).toBeTruthy();
-  });
-});
-
-describe("AudioPlayer — clamping", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
-  });
-
-  it("clamps remaining time to 0 when currentTime overshoots duration", async () => {
-    jest.mocked(useAudioPlayerStatus).mockReturnValue({
-      ...loadedStatus,
-      duration: 60,
-      currentTime: 61,
-    } as AudioStatus);
-    const { getByText } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(getByText("0:00")).toBeTruthy();
-  });
-});
-
-describe("AudioPlayer — autoPlay", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
-  });
-
-  it("plays once automatically after load when autoPlay is set", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue(loadedStatus as AudioStatus);
-    const { rerender } = await render(
-      <AudioPlayer audioUrl={TEST_URL} autoPlay />,
-    );
-    expect(mockPlayer.play).toHaveBeenCalledTimes(1);
-    // Status updates must not re-trigger autoplay
-    await rerender(<AudioPlayer audioUrl={TEST_URL} autoPlay />);
-    expect(mockPlayer.play).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not autoplay before the audio is loaded", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, isLoaded: false } as AudioStatus);
-    await render(<AudioPlayer audioUrl={TEST_URL} autoPlay />);
-    expect(mockPlayer.play).not.toHaveBeenCalled();
-  });
-
-  it("does not autoplay without the prop (article usage)", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue(loadedStatus as AudioStatus);
-    await render(<AudioPlayer audioUrl={TEST_URL} />);
-    expect(mockPlayer.play).not.toHaveBeenCalled();
-  });
-});
-
-describe("AudioPlayer — showFeedback", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
-  });
-
-  it("renders a spinner while loading instead of nothing", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue({ ...loadedStatus, isLoaded: false } as AudioStatus);
-    const { toJSON } = await render(
-      <AudioPlayer audioUrl={TEST_URL} showFeedback />,
-    );
-    expect(toJSON()).not.toBeNull();
-  });
-
-  it("renders an error message when loading fails", async () => {
-    jest.mocked(useAudioPlayerStatus).mockReturnValue({
-      ...loadedStatus,
+    Object.assign(audioState, {
+      currentUrl: null,
       isLoaded: false,
-      error: "404 Not Found",
-    } as AudioStatus);
+      playing: false,
+      currentTime: 0,
+      duration: 0,
+      error: false,
+    });
+    mockIsCurrent.mockReturnValue(false);
+  });
+
+  it("shows a play button and starts the track when it is not current", async () => {
+    const { getByLabelText } = await render(
+      <AudioPlayer audioUrl={URL} title="Ep" resumeKey={URL} />,
+    );
+    await fireEvent.press(getByLabelText("Abspielen"));
+    expect(mockPlayTrack).toHaveBeenCalledWith({
+      audioUrl: URL,
+      title: "Ep",
+      artworkUrl: undefined,
+      resumeKey: URL,
+    });
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it("shows pause and toggles when the current track is playing", async () => {
+    setCurrent({ playing: true, duration: 120, currentTime: 30 });
+    const { getByLabelText } = await render(<AudioPlayer audioUrl={URL} />);
+    await fireEvent.press(getByLabelText("Pause"));
+    expect(mockToggle).toHaveBeenCalledTimes(1);
+    expect(mockPlayTrack).not.toHaveBeenCalled();
+  });
+
+  it("shows play and toggles when the current track is paused", async () => {
+    setCurrent({ playing: false, duration: 120 });
+    const { getByLabelText } = await render(<AudioPlayer audioUrl={URL} />);
+    await fireEvent.press(getByLabelText("Abspielen"));
+    expect(mockToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a spinner while the current track loads (showFeedback)", async () => {
+    setCurrent({ isLoaded: false });
+    const { getByTestId } = await render(
+      <AudioPlayer audioUrl={URL} showFeedback />,
+    );
+    expect(getByTestId("spinner")).toBeTruthy();
+  });
+
+  it("shows an error message when the current track failed (showFeedback)", async () => {
+    setCurrent({ isLoaded: false, error: true });
     const { getByText } = await render(
-      <AudioPlayer audioUrl={TEST_URL} showFeedback />,
+      <AudioPlayer audioUrl={URL} showFeedback />,
     );
     expect(getByText("Audio konnte nicht geladen werden.")).toBeTruthy();
   });
-});
 
-describe("AudioPlayer — remaining time display", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
+  it("shows the remaining time of the current track", async () => {
+    setCurrent({ duration: 120, currentTime: 30 });
+    const { getByText } = await render(<AudioPlayer audioUrl={URL} />);
+    expect(getByText("1:30")).toBeTruthy();
   });
 
-  it.each([
-    ["1:30", 120, 30],
-    ["1:05", 65, 0],
-    ["0:00", 60, 60],
-    ["60:00", 3661, 61],
-    ["0:05", 90, 85],
-  ])(
-    "shows %s remaining when duration=%s and currentTime=%s",
-    async (expected, duration, currentTime) => {
-      jest.mocked(useAudioPlayerStatus).mockReturnValue({
-        ...loadedStatus,
-        duration,
-        currentTime,
-      } as AudioStatus);
-      const { getByText } = await render(<AudioPlayer audioUrl={TEST_URL} />);
-      expect(getByText(expected)).toBeTruthy();
-    },
-  );
-});
-
-describe("AudioPlayer — resume playback", () => {
-  const RESUME_URL = "https://audio.example.com/episode.mp3";
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as any);
-    mockGetAudioPosition.mockResolvedValue(0);
-  });
-
-  it("seeks to the stored position once loaded", async () => {
-    mockGetAudioPosition.mockResolvedValue(100);
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue(loadedStatus as AudioStatus);
-
-    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
-
-    await waitFor(() => {
-      expect(mockGetAudioPosition).toHaveBeenCalledWith(RESUME_URL);
-      expect(mockPlayer.seekTo).toHaveBeenCalledWith(100);
-    });
-  });
-
-  it("ignores stored positions near the start", async () => {
-    mockGetAudioPosition.mockResolvedValue(5);
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue(loadedStatus as AudioStatus);
-
-    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
-
-    await waitFor(() => expect(mockGetAudioPosition).toHaveBeenCalled());
-    expect(mockPlayer.seekTo).not.toHaveBeenCalled();
-  });
-
-  it("ignores stored positions near the end", async () => {
-    // duration is 120 in loadedStatus; 115 is within the end margin
-    mockGetAudioPosition.mockResolvedValue(115);
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue(loadedStatus as AudioStatus);
-
-    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
-
-    await waitFor(() => expect(mockGetAudioPosition).toHaveBeenCalled());
-    expect(mockPlayer.seekTo).not.toHaveBeenCalled();
-  });
-
-  it("delays autoplay until the restore finished, then plays", async () => {
-    mockGetAudioPosition.mockResolvedValue(100);
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue(loadedStatus as AudioStatus);
-
-    await render(
-      <AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} autoPlay />,
+  it("shows the known duration as remaining before playback (idle)", async () => {
+    const { getByText } = await render(
+      <AudioPlayer audioUrl={URL} durationSeconds={120} />,
     );
-
-    await waitFor(() => {
-      expect(mockPlayer.seekTo).toHaveBeenCalledWith(100);
-      expect(mockPlayer.play).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("does not touch the store without a resumeKey", async () => {
-    jest
-      .mocked(useAudioPlayerStatus)
-      .mockReturnValue(loadedStatus as AudioStatus);
-
-    await render(<AudioPlayer audioUrl={RESUME_URL} />);
-
-    expect(mockGetAudioPosition).not.toHaveBeenCalled();
-    expect(mockSetAudioPosition).not.toHaveBeenCalled();
-  });
-
-  it("clears the stored position when the audio finishes", async () => {
-    jest.mocked(useAudioPlayerStatus).mockReturnValue({
-      ...loadedStatus,
-      didJustFinish: true,
-    } as AudioStatus);
-
-    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
-
-    await waitFor(() =>
-      expect(mockClearAudioPosition).toHaveBeenCalledWith(RESUME_URL),
-    );
-  });
-
-  it("persists progress during playback", async () => {
-    jest.mocked(useAudioPlayerStatus).mockReturnValue({
-      ...loadedStatus,
-      playing: true,
-      currentTime: 42,
-    } as AudioStatus);
-
-    await render(<AudioPlayer audioUrl={RESUME_URL} resumeKey={RESUME_URL} />);
-
-    await waitFor(() =>
-      expect(mockSetAudioPosition).toHaveBeenCalledWith(RESUME_URL, 42),
-    );
+    expect(getByText("2:00")).toBeTruthy();
   });
 });

--- a/__tests__/components/posts/PodcastPost.test.tsx
+++ b/__tests__/components/posts/PodcastPost.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render } from "@testing-library/react-native";
+
+import PodcastPost from "#/components/posts/PodcastPost";
+import type { PodcastEpisodeProperties } from "#/types";
+
+jest.mock("@react-native-vector-icons/octicons/static", () => "Octicons");
+
+jest.mock("expo-image", () => ({
+  __esModule: true,
+  Image: "Image",
+}));
+
+jest.mock("#/components/audio/AudioPlayer", () => {
+  const { Text } = jest.requireActual("react-native") as {
+    Text: React.ComponentType<{ testID?: string; children?: React.ReactNode }>;
+  };
+  const MockAudioPlayer = ({ audioUrl }: { audioUrl: string }) => (
+    <Text testID="audio-player">{audioUrl}</Text>
+  );
+  return { __esModule: true, default: MockAudioPlayer };
+});
+
+const mockRegisterPostInteraction = jest.fn();
+jest.mock("#/helpers/network/Analytics", () => ({
+  __esModule: true,
+  registerPostInteraction: (...args: unknown[]) =>
+    mockRegisterPostInteraction(...args),
+}));
+
+const mockGetAudioPosition = jest.fn<() => Promise<number>>();
+jest.mock("#/helpers/Stores/PersonalStore", () => ({
+  __esModule: true,
+  default: {
+    getAudioPosition: () => mockGetAudioPosition(),
+  },
+}));
+
+jest.mock("#/hooks/useAppColorScheme", () => ({
+  useAppColorScheme: () => "light",
+  useCorporateColor: () => "#1B7194",
+}));
+
+const episode: PodcastEpisodeProperties = {
+  id: "abc123",
+  title: "Folge 24: Testfolge",
+  description: "Beschreibung der Folge.",
+  published_at: "2026-06-26T04:00:00+00:00",
+  link: "https://volksverpetzer.podigee.io/25-folge-24",
+  audio_url: "https://audio.example.com/ep24.mp3",
+  image_url: "https://example.com/episode.png",
+  duration: 3539,
+};
+
+describe("PodcastPost", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAudioPosition.mockResolvedValue(0);
+  });
+
+  it("renders title, date and duration", async () => {
+    const { getByText } = await render(<PodcastPost {...episode} />);
+    expect(getByText("Folge 24: Testfolge")).toBeTruthy();
+    expect(getByText("Beschreibung der Folge.")).toBeTruthy();
+    expect(getByText("26.6.2026 | 59 Min.")).toBeTruthy();
+  });
+
+  it("shows at least 1 Min. for very short episodes", async () => {
+    const { getByText } = await render(
+      <PodcastPost {...episode} duration={20} published_at={null} />,
+    );
+    expect(getByText("1 Min.")).toBeTruthy();
+  });
+
+  it("omits the date/duration row when both are missing", async () => {
+    const { queryByText } = await render(
+      <PodcastPost {...episode} duration={null} published_at={null} />,
+    );
+    expect(queryByText(/Min\./)).toBeNull();
+  });
+
+  it("does not mount the audio player before the play tap", async () => {
+    const { queryByTestId, getByText } = await render(
+      <PodcastPost {...episode} />,
+    );
+    expect(queryByTestId("audio-player")).toBeNull();
+    expect(getByText("Folge abspielen")).toBeTruthy();
+  });
+
+  it("mounts the audio player and tracks the interaction on play tap", async () => {
+    const { getByText, getByTestId, queryByText } = await render(
+      <PodcastPost {...episode} />,
+    );
+    await fireEvent.press(getByText("Folge abspielen"));
+    expect(getByTestId("audio-player").props.children).toBe(episode.audio_url);
+    expect(queryByText("Folge abspielen")).toBeNull();
+    expect(mockRegisterPostInteraction).toHaveBeenCalledWith(
+      episode.link,
+      "podcast",
+      "play",
+    );
+  });
+
+  it("offers to resume when a playback position is stored", async () => {
+    mockGetAudioPosition.mockResolvedValue(2592);
+    const { findByText } = await render(<PodcastPost {...episode} />);
+    expect(await findByText("Fortsetzen bei 43:12")).toBeTruthy();
+  });
+
+  it("shows the plain play label for positions near the start", async () => {
+    mockGetAudioPosition.mockResolvedValue(5);
+    const { findByText } = await render(<PodcastPost {...episode} />);
+    expect(await findByText("Folge abspielen")).toBeTruthy();
+  });
+
+  it("falls back to the audio url for analytics when link is null", async () => {
+    const { getByText } = await render(
+      <PodcastPost {...episode} link={null} />,
+    );
+    await fireEvent.press(getByText("Folge abspielen"));
+    expect(mockRegisterPostInteraction).toHaveBeenCalledWith(
+      episode.audio_url,
+      "podcast",
+      "play",
+    );
+  });
+});

--- a/__tests__/components/posts/PodcastPost.test.tsx
+++ b/__tests__/components/posts/PodcastPost.test.tsx
@@ -163,8 +163,13 @@ describe("PodcastPost", () => {
   });
 
   it("url-encodes the id when navigating", async () => {
+    // Episode ids are opaque strings from the feed, so they can contain
+    // characters that must not go into a route path raw. Kept in a variable
+    // rather than an inline `id="..."` so HTML-oriented linters don't read it
+    // as a DOM id attribute (this is a component prop, not markup).
+    const episodeIdWithSpecialCharacters = "a/b c";
     const { getByLabelText } = await render(
-      <PodcastPost {...episode} id="a/b c" />,
+      <PodcastPost {...episode} id={episodeIdWithSpecialCharacters} />,
     );
     await fireEvent.press(
       getByLabelText(`Podcast Folge öffnen: ${episode.title}`),

--- a/__tests__/components/posts/PodcastPost.test.tsx
+++ b/__tests__/components/posts/PodcastPost.test.tsx
@@ -42,6 +42,12 @@ jest.mock("expo-router", () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
+const mockPlayTrack = jest.fn();
+const mockIsCurrent = jest.fn<(url: string) => boolean>();
+jest.mock("#/helpers/provider/AudioProvider", () => ({
+  useAudio: () => ({ isCurrent: mockIsCurrent, playTrack: mockPlayTrack }),
+}));
+
 jest.mock("#/hooks/useAppColorScheme", () => ({
   useAppColorScheme: () => "light",
   useCorporateColor: () => "#1B7194",
@@ -62,6 +68,7 @@ describe("PodcastPost", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetAudioPosition.mockResolvedValue(0);
+    mockIsCurrent.mockReturnValue(false);
   });
 
   it("renders title, date and duration", async () => {
@@ -85,7 +92,7 @@ describe("PodcastPost", () => {
     expect(queryByText(/Min\./)).toBeNull();
   });
 
-  it("does not mount the audio player before the play tap", async () => {
+  it("shows the play button (not live controls) when not the active track", async () => {
     const { queryByTestId, getByText } = await render(
       <PodcastPost {...episode} />,
     );
@@ -93,18 +100,29 @@ describe("PodcastPost", () => {
     expect(getByText("Folge abspielen")).toBeTruthy();
   });
 
-  it("mounts the audio player and tracks the interaction on play tap", async () => {
-    const { getByText, getByTestId, queryByText } = await render(
-      <PodcastPost {...episode} />,
-    );
+  it("starts the episode and tracks the interaction on play tap", async () => {
+    const { getByText } = await render(<PodcastPost {...episode} />);
     await fireEvent.press(getByText("Folge abspielen"));
-    expect(getByTestId("audio-player").props.children).toBe(episode.audio_url);
-    expect(queryByText("Folge abspielen")).toBeNull();
+    expect(mockPlayTrack).toHaveBeenCalledWith({
+      audioUrl: episode.audio_url,
+      title: episode.title,
+      artworkUrl: episode.image_url,
+      resumeKey: episode.audio_url,
+    });
     expect(mockRegisterPostInteraction).toHaveBeenCalledWith(
       episode.link,
       "podcast",
       "play",
     );
+  });
+
+  it("shows live controls when this episode is the active track", async () => {
+    mockIsCurrent.mockReturnValue(true);
+    const { getByTestId, queryByText } = await render(
+      <PodcastPost {...episode} />,
+    );
+    expect(getByTestId("audio-player").props.children).toBe(episode.audio_url);
+    expect(queryByText("Folge abspielen")).toBeNull();
   });
 
   it("offers to resume when a playback position is stored", async () => {

--- a/__tests__/components/posts/PodcastPost.test.tsx
+++ b/__tests__/components/posts/PodcastPost.test.tsx
@@ -36,6 +36,12 @@ jest.mock("#/helpers/Stores/PersonalStore", () => ({
   },
 }));
 
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  __esModule: true,
+  useRouter: () => ({ push: mockPush }),
+}));
+
 jest.mock("#/hooks/useAppColorScheme", () => ({
   useAppColorScheme: () => "light",
   useCorporateColor: () => "#1B7194",
@@ -123,5 +129,28 @@ describe("PodcastPost", () => {
       "podcast",
       "play",
     );
+  });
+
+  it("opens the episode screen and tracks the open when the card is tapped", async () => {
+    const { getByLabelText } = await render(<PodcastPost {...episode} />);
+    await fireEvent.press(
+      getByLabelText(`Podcast Folge öffnen: ${episode.title}`),
+    );
+    expect(mockPush).toHaveBeenCalledWith("/podcast/abc123");
+    expect(mockRegisterPostInteraction).toHaveBeenCalledWith(
+      episode.link,
+      "podcast",
+      "open",
+    );
+  });
+
+  it("url-encodes the id when navigating", async () => {
+    const { getByLabelText } = await render(
+      <PodcastPost {...episode} id="a/b c" />,
+    );
+    await fireEvent.press(
+      getByLabelText(`Podcast Folge öffnen: ${episode.title}`),
+    );
+    expect(mockPush).toHaveBeenCalledWith("/podcast/a%2Fb%20c");
   });
 });

--- a/__tests__/helpers/Networking/ServerAPI.test.ts
+++ b/__tests__/helpers/Networking/ServerAPI.test.ts
@@ -173,6 +173,50 @@ describe("ServerAPI", () => {
     });
   });
 
+  describe("getPodcastFeed", () => {
+    it("should call get with correct path and return the episodes", async () => {
+      // Setup
+      const responseData = {
+        episodes: [{ id: "ep1", title: "Folge 1", audio_url: "a.mp3" }],
+      };
+      getSpy.mockResolvedValue(responseData);
+
+      // Execute
+      const result = await API.getPodcastFeed();
+
+      // Assert
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "/proxy/podcastFeed",
+        undefined,
+        undefined,
+      );
+      expect(result).toEqual(responseData.episodes);
+    });
+
+    it("should return an empty array when the response has no episodes", async () => {
+      getSpy.mockResolvedValue({});
+
+      const result = await API.getPodcastFeed();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should forward the abort signal", async () => {
+      const controller = new AbortController();
+      getSpy.mockResolvedValue({ episodes: [] });
+
+      await API.getPodcastFeed(controller.signal);
+
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "/proxy/podcastFeed",
+        { signal: controller.signal },
+        undefined,
+      );
+    });
+  });
+
   describe("getFactFeed", () => {
     it("should call get with keywords joined by comma", async () => {
       // Setup

--- a/__tests__/helpers/SettingsContext.test.tsx
+++ b/__tests__/helpers/SettingsContext.test.tsx
@@ -76,6 +76,7 @@ describe("SettingsContext Logic", () => {
         yt: { value: false, name: "Videos" },
         bsky: { value: true, name: "Tweets" },
         bot: { value: false, name: "Fact" },
+        podcast: { value: true, name: "Podcast Folgen" },
         "wp:pruefpunkt.org": { value: true, name: "Prüfpunkt Artikel" },
       };
 

--- a/__tests__/helpers/Storage.test.tsx
+++ b/__tests__/helpers/Storage.test.tsx
@@ -7,6 +7,7 @@ jest.mock("@react-native-async-storage/async-storage", () => {
   return {
     setItem: jest.fn().mockResolvedValue(undefined as never),
     getItem: jest.fn().mockResolvedValue(undefined as never),
+    removeItem: jest.fn().mockResolvedValue(undefined as never),
     getAllKeys: jest.fn().mockResolvedValue([] as never),
     multiRemove: jest.fn().mockResolvedValue(undefined as never),
     // Add other mocked methods as needed
@@ -119,6 +120,33 @@ describe("BaseStore", () => {
       const result = BaseStore.parseJSON(json, defaultValue);
 
       expect(result).toBe(defaultValue);
+    });
+  });
+
+  describe("removeItem", () => {
+    it("should remove a single item from AsyncStorage", async () => {
+      const key = "testKey";
+      const mockRemoveItem = jest.fn().mockResolvedValue(undefined as never);
+      AsyncStorage.removeItem = mockRemoveItem as never;
+
+      await BaseStore.removeItem(key);
+
+      expect(mockRemoveItem).toHaveBeenCalledWith(key);
+    });
+
+    it("should swallow errors instead of throwing", async () => {
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const mockRemoveItem = jest
+        .fn()
+        .mockRejectedValue(new Error("Storage error") as never);
+      AsyncStorage.removeItem = mockRemoveItem as never;
+
+      await expect(BaseStore.removeItem("testKey")).resolves.toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.any(Error));
+
+      consoleSpy.mockRestore();
     });
   });
 

--- a/__tests__/helpers/Stores/PersonalStore.test.ts
+++ b/__tests__/helpers/Stores/PersonalStore.test.ts
@@ -495,5 +495,33 @@ describe("PersonalStore", () => {
         "audioPosition_https://a.example/ep.mp3",
       );
     });
+
+    it("should swallow set errors and log them", async () => {
+      jest
+        .spyOn(BaseStore, "setItem")
+        .mockRejectedValue(new Error("Storage error"));
+
+      await expect(
+        PersonalStore.setAudioPosition("https://a.example/ep.mp3", 42),
+      ).resolves.toBeUndefined();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Error setting audio position:",
+        expect.any(Error),
+      );
+    });
+
+    it("should swallow clear errors and log them", async () => {
+      jest
+        .spyOn(BaseStore, "removeItem")
+        .mockRejectedValue(new Error("Storage error"));
+
+      await expect(
+        PersonalStore.clearAudioPosition("https://a.example/ep.mp3"),
+      ).resolves.toBeUndefined();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Error clearing audio position:",
+        expect.any(Error),
+      );
+    });
   });
 });

--- a/__tests__/helpers/Stores/PersonalStore.test.ts
+++ b/__tests__/helpers/Stores/PersonalStore.test.ts
@@ -9,6 +9,7 @@ jest.mock("#/helpers/Storage", () => ({
   default: {
     getItem: jest.fn(),
     setItem: jest.fn(),
+    removeItem: jest.fn(),
     parseJSON: jest.fn(),
   },
 }));
@@ -435,6 +436,64 @@ describe("PersonalStore", () => {
 
       // Cleanup
       consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe("audio positions", () => {
+    it("should construct the audio key from the resume key", () => {
+      expect(PersonalStore.getAudioKey("https://a.example/ep.mp3")).toBe(
+        "audioPosition_https://a.example/ep.mp3",
+      );
+    });
+
+    it("should store the audio position under the audio key", async () => {
+      const setItemSpy = jest.spyOn(BaseStore, "setItem");
+
+      await PersonalStore.setAudioPosition("https://a.example/ep.mp3", 123.4);
+
+      expect(setItemSpy).toHaveBeenCalledWith(
+        "audioPosition_https://a.example/ep.mp3",
+        "123.4",
+      );
+    });
+
+    it("should return the parsed audio position", async () => {
+      getItemSpy.mockResolvedValue("123.4");
+      jest.spyOn(BaseStore, "parseJSON").mockReturnValue(123.4);
+
+      const result = await PersonalStore.getAudioPosition(
+        "https://a.example/ep.mp3",
+      );
+
+      expect(getItemSpy).toHaveBeenCalledWith(
+        "audioPosition_https://a.example/ep.mp3",
+      );
+      expect(BaseStore.parseJSON).toHaveBeenCalledWith("123.4", 0);
+      expect(result).toBe(123.4);
+    });
+
+    it("should return 0 on storage errors", async () => {
+      getItemSpy.mockRejectedValue(new Error("Storage error"));
+
+      const result = await PersonalStore.getAudioPosition(
+        "https://a.example/ep.mp3",
+      );
+
+      expect(result).toBe(0);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Error retrieving audio position:",
+        expect.any(Error),
+      );
+    });
+
+    it("should remove the stored position on clear", async () => {
+      const removeItemSpy = jest.spyOn(BaseStore, "removeItem");
+
+      await PersonalStore.clearAudioPosition("https://a.example/ep.mp3");
+
+      expect(removeItemSpy).toHaveBeenCalledWith(
+        "audioPosition_https://a.example/ep.mp3",
+      );
     });
   });
 });

--- a/__tests__/helpers/Stores/SettingsStore.test.ts
+++ b/__tests__/helpers/Stores/SettingsStore.test.ts
@@ -150,6 +150,7 @@ describe("SettingsStore", () => {
         tiktok: { value: true, name: "TikTok Videos" },
         bsky: { value: false, name: "Bluesky Posts" },
         bot: { value: true, name: "Bot Feed" },
+        podcast: { value: true, name: "Podcast Folgen" },
         "wp:pruefpunkt.org": { value: true, name: "Prüfpunkt Artikel" },
       };
 

--- a/__tests__/helpers/fetchers/FeedFetcher.test.ts
+++ b/__tests__/helpers/fetchers/FeedFetcher.test.ts
@@ -7,6 +7,7 @@ import defaultExport, {
   FeedFetcher,
 } from "#/screens/Home/fetchers/FeedFetcher";
 import { InstagramFetcher } from "#/screens/Home/fetchers/InstagramFetcher";
+import { PodcastFetcher } from "#/screens/Home/fetchers/PodcastFetcher";
 import { TikTokFetcher } from "#/screens/Home/fetchers/TikTokFetcher";
 import { WordPressFetcher } from "#/screens/Home/fetchers/WordPressFetcher";
 import { YouTubeFetcher } from "#/screens/Home/fetchers/YouTubeFetcher";
@@ -57,6 +58,10 @@ jest.mock("#/screens/Home/fetchers/BotFetcher", () => ({
   BotFetcher: { feedFetcher: jest.fn() },
 }));
 
+jest.mock("#/screens/Home/fetchers/PodcastFetcher", () => ({
+  PodcastFetcher: { feedFetcher: jest.fn() },
+}));
+
 // createFetchers is called once per configured wp feed at module load time —
 // capture both results (primary site first, Prüfpunkt second).
 const createFetchersMock = WordPressFetcher.createFetchers as jest.Mock;
@@ -80,6 +85,7 @@ describe("FeedFetcher", () => {
     expect(FeedFetcher.fetchers.tiktok).toBeDefined();
     expect(FeedFetcher.fetchers.bsky).toBeDefined();
     expect(FeedFetcher.fetchers.bot).toBeDefined();
+    expect(FeedFetcher.fetchers.podcast).toBeDefined();
     expect(FeedFetcher.fetchers["wp:pruefpunkt.org"]).toBeDefined();
     expect(FeedFetcher.fetchers["wp:pruefpunkt.org:search"]).toBeDefined();
   });
@@ -104,6 +110,7 @@ describe("FeedFetcher", () => {
     expect(FeedFetcher.fetchers.tiktok).toBe(TikTokFetcher.feedFetcher);
     expect(FeedFetcher.fetchers.bsky).toBe(BlueskyFetcher.feedFetcher);
     expect(FeedFetcher.fetchers.bot).toBe(BotFetcher.feedFetcher);
+    expect(FeedFetcher.fetchers.podcast).toBe(PodcastFetcher.feedFetcher);
     expect(FeedFetcher.fetchers["wp:pruefpunkt.org"]).toBe(
       pruefpunktCreated.feedFetcher,
     );

--- a/__tests__/helpers/fetchers/PodcastFetcher.test.ts
+++ b/__tests__/helpers/fetchers/PodcastFetcher.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import API from "#/helpers/network/ServerAPI";
+import { PodcastFetcher } from "#/screens/Home/fetchers/PodcastFetcher";
+import type { PodcastEpisodeProperties } from "#/types";
+
+import "#tests/mocks/commonMocks";
+
+// Mock the PodcastPost component to avoid expo-audio dependencies
+jest.mock("#/components/posts/PodcastPost", () => ({
+  __esModule: true,
+  default: "PodcastPost",
+}));
+
+const mockEpisode: PodcastEpisodeProperties = {
+  id: "abc123",
+  title: "Folge 24: Testfolge",
+  description: "Beschreibung der Folge.",
+  published_at: "2026-06-26T04:00:00+00:00",
+  link: "https://volksverpetzer.podigee.io/25-folge-24",
+  audio_url: "https://audio.example.com/ep24.mp3",
+  image_url: "https://example.com/episode.png",
+  duration: 3539,
+};
+
+describe("PodcastFetcher", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should map episodes to posts with normalized datetimes", async () => {
+    jest.spyOn(API, "getPodcastFeed").mockResolvedValue([mockEpisode]);
+
+    const result = await PodcastFetcher.feedFetcher();
+
+    expect(API.getPodcastFeed).toHaveBeenCalled();
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe("abc123");
+    // Naive-UTC ISO shape used by the other fetchers (no trailing Z)
+    expect(result[0].datetime).toBe("2026-06-26T04:00:00.000");
+    expect(result[0].data).toHaveProperty("audio_url");
+    expect(result[0].shareable).toEqual([
+      { url: mockEpisode.link, title: "Podcast Folge teilen" },
+    ]);
+  });
+
+  it("should skip episodes without audio or date", async () => {
+    jest
+      .spyOn(API, "getPodcastFeed")
+      .mockResolvedValue([
+        { ...mockEpisode, id: "no-audio", audio_url: "" },
+        { ...mockEpisode, id: "no-date", published_at: null },
+        mockEpisode,
+      ]);
+
+    const result = await PodcastFetcher.feedFetcher();
+
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe("abc123");
+  });
+
+  it("should skip episodes with unparseable dates instead of throwing", async () => {
+    // A throw inside the mapping would propagate past safeFetch and blank the
+    // whole combined feed — garbage dates must only drop the one episode.
+    jest
+      .spyOn(API, "getPodcastFeed")
+      .mockResolvedValue([
+        { ...mockEpisode, id: "bad-date", published_at: "kein Datum" },
+        mockEpisode,
+      ]);
+
+    const result = await PodcastFetcher.feedFetcher();
+
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe("abc123");
+  });
+
+  it("should omit shareable for non-https links", async () => {
+    jest.spyOn(API, "getPodcastFeed").mockResolvedValue([
+      {
+        ...mockEpisode,
+        link: "http://insecure.example.com/ep" as never,
+      },
+    ]);
+
+    const result = await PodcastFetcher.feedFetcher();
+
+    expect(result.length).toBe(1);
+    expect(result[0].shareable).toBeUndefined();
+  });
+
+  it("should handle API errors gracefully", async () => {
+    jest
+      .spyOn(API, "getPodcastFeed")
+      .mockRejectedValue(new Error("Network error"));
+
+    const result = await PodcastFetcher.feedFetcher();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/__tests__/helpers/provider/AudioProvider.test.tsx
+++ b/__tests__/helpers/provider/AudioProvider.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { useAudioPlayer, useAudioPlayerStatus } from "expo-audio";
+import type { AudioStatus } from "expo-audio";
+import { Text } from "react-native";
+
+import { AudioProvider, useAudio } from "#/helpers/provider/AudioProvider";
+
+jest.mock("expo-audio", () => ({
+  useAudioPlayer: jest.fn(),
+  useAudioPlayerStatus: jest.fn(),
+  setAudioModeAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: { expoConfig: { name: "Volksverpetzer" } },
+}));
+
+const mockGetAudioPosition = jest.fn().mockResolvedValue(0);
+const mockSetAudioPosition = jest.fn().mockResolvedValue(undefined);
+const mockClearAudioPosition = jest.fn().mockResolvedValue(undefined);
+jest.mock("#/helpers/Stores/PersonalStore", () => ({
+  __esModule: true,
+  default: {
+    getAudioPosition: (...a: unknown[]) => mockGetAudioPosition(...a),
+    setAudioPosition: (...a: unknown[]) => mockSetAudioPosition(...a),
+    clearAudioPosition: (...a: unknown[]) => mockClearAudioPosition(...a),
+  },
+}));
+
+const mockPlayer = {
+  id: "p1",
+  play: jest.fn(),
+  pause: jest.fn(),
+  replace: jest.fn(),
+  seekTo: jest.fn().mockResolvedValue(undefined),
+  setActiveForLockScreen: jest.fn(),
+};
+
+const loadedStatus: Partial<AudioStatus> = {
+  isLoaded: true,
+  playing: false,
+  currentTime: 0,
+  duration: 120,
+  error: null,
+  didJustFinish: false,
+};
+
+const TRACK_URL = "https://audio.example.com/ep.mp3";
+
+const Consumer = () => {
+  const audio = useAudio();
+  return (
+    <>
+      <Text testID="state">
+        {`${audio.currentUrl ?? "none"}|${audio.playing}`}
+      </Text>
+      <Text
+        testID="play"
+        onPress={() =>
+          audio.playTrack({ audioUrl: TRACK_URL, resumeKey: TRACK_URL })
+        }
+      >
+        play
+      </Text>
+      <Text testID="toggle" onPress={() => audio.toggle()}>
+        toggle
+      </Text>
+    </>
+  );
+};
+
+const renderProvider = () =>
+  render(
+    <AudioProvider>
+      <Consumer />
+    </AudioProvider>,
+  );
+
+describe("AudioProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAudioPosition.mockResolvedValue(0);
+    jest.mocked(useAudioPlayer).mockReturnValue(mockPlayer as never);
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue(loadedStatus as AudioStatus);
+  });
+
+  it("loads a new track and starts it once loaded", async () => {
+    const { getByTestId } = await renderProvider();
+    await fireEvent.press(getByTestId("play"));
+    expect(mockPlayer.replace).toHaveBeenCalledWith({ uri: TRACK_URL });
+    await waitFor(() => expect(mockPlayer.play).toHaveBeenCalled());
+    expect(getByTestId("state").props.children).toContain(TRACK_URL);
+  });
+
+  it("restores the stored position before playing", async () => {
+    mockGetAudioPosition.mockResolvedValue(100);
+    const { getByTestId } = await renderProvider();
+    await fireEvent.press(getByTestId("play"));
+    await waitFor(() => {
+      expect(mockGetAudioPosition).toHaveBeenCalledWith(TRACK_URL);
+      expect(mockPlayer.seekTo).toHaveBeenCalledWith(100);
+      expect(mockPlayer.play).toHaveBeenCalled();
+    });
+  });
+
+  it("ignores a stored position near the end", async () => {
+    // duration 120, end margin 10 → 115 is within the margin
+    mockGetAudioPosition.mockResolvedValue(115);
+    const { getByTestId } = await renderProvider();
+    await fireEvent.press(getByTestId("play"));
+    await waitFor(() => expect(mockPlayer.play).toHaveBeenCalled());
+    expect(mockPlayer.seekTo).not.toHaveBeenCalled();
+  });
+
+  it("resumes the same track without reloading it", async () => {
+    const { getByTestId } = await renderProvider();
+    await fireEvent.press(getByTestId("play"));
+    await waitFor(() => expect(mockPlayer.play).toHaveBeenCalled());
+    mockPlayer.replace.mockClear();
+    await fireEvent.press(getByTestId("play"));
+    expect(mockPlayer.replace).not.toHaveBeenCalled();
+    expect(mockPlayer.play).toHaveBeenCalledTimes(2);
+  });
+
+  it("enables background playback and lock-screen controls while playing", async () => {
+    const { setAudioModeAsync } = jest.requireMock("expo-audio");
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue({ ...loadedStatus, playing: true } as AudioStatus);
+    await renderProvider();
+    await waitFor(() => {
+      expect(setAudioModeAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ shouldPlayInBackground: true }),
+      );
+      expect(mockPlayer.setActiveForLockScreen).toHaveBeenCalled();
+    });
+  });
+
+  it("pauses via toggle when playing", async () => {
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue({ ...loadedStatus, playing: true } as AudioStatus);
+    const { getByTestId } = await renderProvider();
+    await fireEvent.press(getByTestId("toggle"));
+    expect(mockPlayer.pause).toHaveBeenCalled();
+  });
+
+  it("rewinds and clears the stored position when a track finishes", async () => {
+    // The finish effect runs on the render where didJustFinish becomes true;
+    // seed a track first, then render fresh with the finished status.
+    jest
+      .mocked(useAudioPlayerStatus)
+      .mockReturnValue({ ...loadedStatus, didJustFinish: true } as AudioStatus);
+    const { getByTestId } = await renderProvider();
+    await fireEvent.press(getByTestId("play"));
+    await waitFor(() => {
+      expect(mockPlayer.seekTo).toHaveBeenCalledWith(0);
+      expect(mockClearAudioPosition).toHaveBeenCalledWith(TRACK_URL);
+    });
+  });
+});

--- a/__tests__/helpers/utils/audio.test.ts
+++ b/__tests__/helpers/utils/audio.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  RESUME_END_MARGIN_SECONDS,
+  RESUME_MIN_SECONDS,
+  RESUME_SAVE_INTERVAL_SECONDS,
+  formatTime,
+} from "#/helpers/utils/audio";
+
+describe("formatTime", () => {
+  it.each([
+    [0, "0:00"],
+    [5, "0:05"],
+    [59, "0:59"],
+    [60, "1:00"],
+    [65, "1:05"],
+    [125, "2:05"],
+    [3599, "59:59"],
+    [3600, "60:00"],
+  ])("formats %i seconds as %s", (seconds, expected) => {
+    expect(formatTime(seconds)).toBe(expected);
+  });
+
+  it("floors fractional seconds", () => {
+    expect(formatTime(90.9)).toBe("1:30");
+    expect(formatTime(9.4)).toBe("0:09");
+  });
+});
+
+describe("resume constants", () => {
+  it("uses a start threshold below the end margin window it guards", () => {
+    // Both bounds are positive and the save interval is smaller than the
+    // start threshold so progress is persisted before it becomes resumable.
+    expect(RESUME_MIN_SECONDS).toBeGreaterThan(0);
+    expect(RESUME_END_MARGIN_SECONDS).toBeGreaterThan(0);
+    expect(RESUME_SAVE_INTERVAL_SECONDS).toBeGreaterThan(0);
+    expect(RESUME_SAVE_INTERVAL_SECONDS).toBeLessThanOrEqual(
+      RESUME_MIN_SECONDS,
+    );
+  });
+});

--- a/config/volksverpetzer.config.ts
+++ b/config/volksverpetzer.config.ts
@@ -124,6 +124,7 @@ const extraConfig: ExtraConfigType = {
     ],
     yt: { enabled: true },
     bsky: { handle: "volksverpetzer.de", enabled: true },
+    podcast: { enabled: true },
   },
   colorScheme: colorScheme,
   themeColor: "#1b7194",

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -35,6 +35,7 @@
     "mimikamaapp",
     "misinfo",
     "mlarge",
+    "podigee",
     "politik",
     "prio",
     "rechercheur",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -30,6 +30,7 @@ import Colors from "#/constants/Colors";
 import { fontSizes } from "#/constants/FontSizes";
 import NotificationManager from "#/helpers/Notifications";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
+import { AudioProvider } from "#/helpers/provider/AudioProvider";
 import { BadgeProvider } from "#/helpers/provider/BadgeProvider";
 import { SettingsProvider } from "#/helpers/provider/SettingsProvider";
 import { isDarkMode } from "#/helpers/utils/color";
@@ -165,39 +166,48 @@ const RootLayout = () => {
       <GestureHandlerRootView style={{ flex: 1 }}>
         <SettingsProvider>
           <BadgeProvider>
-            <AppFrame>
-              <Stack
-                screenOptions={{
-                  headerShown: false,
-                  gestureEnabled: true,
-                }}
-              >
-                <Stack.Screen name="(tabs)" options={{ title: "Home" }} />
-                <Stack.Screen
-                  name="[category]/[slug]"
-                  options={{ title: "Artikel" }}
+            <AudioProvider>
+              <AppFrame>
+                <Stack
+                  screenOptions={{
+                    headerShown: false,
+                    gestureEnabled: true,
+                  }}
+                >
+                  <Stack.Screen name="(tabs)" options={{ title: "Home" }} />
+                  <Stack.Screen
+                    name="[category]/[slug]"
+                    options={{ title: "Artikel" }}
+                  />
+                  <Stack.Screen
+                    name="insta/[post_id]"
+                    options={{ title: "Artikel" }}
+                  />
+                  <Stack.Screen
+                    name="podcast/[id]"
+                    options={{ title: "Podcast" }}
+                  />
+                  <Stack.Screen name="search" options={{ title: "Suche" }} />
+                  <Stack.Screen
+                    name="+not-found"
+                    options={{ title: "Nicht gefunden" }}
+                  />
+                  <Stack.Screen
+                    name="support"
+                    options={{ title: "Unterstutzen" }}
+                  />
+                  <Stack.Screen
+                    name="licenses"
+                    options={{ title: "Lizenzen" }}
+                  />
+                </Stack>
+                <AppToast config={toastConfig} />
+                <ChangelogModal
+                  isVisible={showChangelog}
+                  onClose={dismissChangelog}
                 />
-                <Stack.Screen
-                  name="insta/[post_id]"
-                  options={{ title: "Artikel" }}
-                />
-                <Stack.Screen name="search" options={{ title: "Suche" }} />
-                <Stack.Screen
-                  name="+not-found"
-                  options={{ title: "Nicht gefunden" }}
-                />
-                <Stack.Screen
-                  name="support"
-                  options={{ title: "Unterstutzen" }}
-                />
-                <Stack.Screen name="licenses" options={{ title: "Lizenzen" }} />
-              </Stack>
-              <AppToast config={toastConfig} />
-              <ChangelogModal
-                isVisible={showChangelog}
-                onClose={dismissChangelog}
-              />
-            </AppFrame>
+              </AppFrame>
+            </AudioProvider>
           </BadgeProvider>
         </SettingsProvider>
       </GestureHandlerRootView>

--- a/src/app/podcast/[id].tsx
+++ b/src/app/podcast/[id].tsx
@@ -120,6 +120,7 @@ const PodcastScreen = () => {
           title={episode.title}
           artworkUrl={episode.image_url ?? undefined}
           horizontalPadding={POST_PADDING_HORIZONTAL}
+          durationSeconds={episode.duration ?? undefined}
         />
         <UiSpace size={12} />
 

--- a/src/app/podcast/[id].tsx
+++ b/src/app/podcast/[id].tsx
@@ -1,0 +1,155 @@
+import { Image } from "expo-image";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import { View } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
+
+import AudioPlayer from "#/components/audio/AudioPlayer";
+import NavBar from "#/components/bars/NavBar";
+import UiSpace from "#/components/ui/UiSpace";
+import UiSpinner from "#/components/ui/UiSpinner";
+import UiText from "#/components/ui/UiText";
+import Footer from "#/components/views/Footer";
+import Colors from "#/constants/Colors";
+import {
+  POST_PADDING_HORIZONTAL,
+  globalStyles,
+} from "#/constants/GlobalStyles";
+import { onShare } from "#/helpers/Sharing";
+import API from "#/helpers/network/ServerAPI";
+import {
+  useAppColorScheme,
+  useCorporateColor,
+} from "#/hooks/useAppColorScheme";
+import type { PodcastEpisodeProperties } from "#/types";
+
+/**
+ * Full podcast episode screen: cover, title, date/duration, the full
+ * description and the audio player. Reached from the podcast feed card.
+ *
+ * Podigee has no per-episode endpoint, so the episode is located by id in the
+ * (server-cached) podcast feed.
+ */
+const PodcastScreen = () => {
+  const [episode, setEpisode] = useState<
+    PodcastEpisodeProperties | undefined
+  >();
+  const [isLoading, setIsLoading] = useState(true);
+
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const colorScheme = useAppColorScheme();
+  const corporate = useCorporateColor();
+  const backgroundColor = Colors[colorScheme].background;
+  const greyText = Colors[colorScheme].textMuted;
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const fetchEpisode = async () => {
+      try {
+        const episodes = await API.getPodcastFeed(controller.signal);
+        if (controller.signal.aborted) return;
+        const decodedId = decodeURIComponent(id);
+        const found = episodes.find((e) => e.id === decodedId);
+        if (!found) {
+          router.back();
+          return;
+        }
+        setEpisode(found);
+        setIsLoading(false);
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error("Error loading podcast episode:", error);
+        router.back();
+      }
+    };
+
+    void fetchEpisode();
+
+    return () => {
+      controller.abort();
+    };
+  }, [id, router]);
+
+  if (isLoading || !episode) {
+    return <UiSpinner text="Lade Podcast Folge..." />;
+  }
+
+  const d = episode.published_at ? new Date(episode.published_at) : undefined;
+  const date = d ? `${d.getDate()}.${d.getMonth() + 1}.${d.getFullYear()}` : "";
+  const duration = episode.duration
+    ? `${Math.max(1, Math.round(episode.duration / 60))} Min.`
+    : "";
+  const dateDurationText = [date, duration].filter(Boolean).join(" | ");
+
+  return (
+    <View style={[globalStyles.container, { backgroundColor }]}>
+      <ScrollView>
+        {episode.image_url && (
+          <Image
+            style={{ width: "100%", height: 240, backgroundColor: corporate }}
+            source={{ uri: episode.image_url }}
+            contentFit="cover"
+            accessibilityIgnoresInvertColors
+          />
+        )}
+        <UiSpace size={16} />
+        <View style={{ paddingHorizontal: POST_PADDING_HORIZONTAL }}>
+          <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
+            Podcast
+          </UiText>
+          <UiText
+            size="xl"
+            style={{ fontFamily: "SourceSansProBold", textAlign: "left" }}
+          >
+            {episode.title}
+          </UiText>
+          {!!dateDurationText && (
+            <UiText size="sm" style={{ color: greyText, textAlign: "left" }}>
+              {dateDurationText}
+            </UiText>
+          )}
+        </View>
+
+        <UiSpace size={12} />
+        <AudioPlayer
+          audioUrl={episode.audio_url}
+          showFeedback
+          resumeKey={episode.audio_url}
+          title={episode.title}
+          artworkUrl={episode.image_url ?? undefined}
+          horizontalPadding={POST_PADDING_HORIZONTAL}
+        />
+        <UiSpace size={12} />
+
+        {!!episode.description && (
+          <UiText
+            size="base"
+            style={{
+              paddingHorizontal: POST_PADDING_HORIZONTAL,
+              textAlign: "left",
+            }}
+          >
+            {episode.description}
+          </UiText>
+        )}
+
+        {episode.link && (
+          <Footer article_link={episode.link} onShare={onShare} />
+        )}
+      </ScrollView>
+
+      <NavBar
+        link={episode.link ?? undefined}
+        shareable={
+          episode.link
+            ? [{ url: episode.link, title: "Podcast Folge teilen" }]
+            : undefined
+        }
+      />
+    </View>
+  );
+};
+
+export default PodcastScreen;

--- a/src/app/podcast/[id].tsx
+++ b/src/app/podcast/[id].tsx
@@ -23,8 +23,12 @@ import {
 } from "#/hooks/useAppColorScheme";
 import type { PodcastEpisodeProperties } from "#/types";
 
+// The square cover sits a little narrower than the text column (design), so
+// it's inset a bit more than POST_PADDING_HORIZONTAL.
+const COVER_PADDING_HORIZONTAL = POST_PADDING_HORIZONTAL + 16;
+
 /**
- * Full podcast episode screen: cover, title, date/duration, the full
+ * Full podcast episode screen: a square cover, title, date/duration, the full
  * description and the audio player. Reached from the podcast feed card.
  *
  * Podigee has no per-episode endpoint, so the episode is located by id in the
@@ -87,12 +91,22 @@ const PodcastScreen = () => {
     <View style={[globalStyles.container, { backgroundColor }]}>
       <ScrollView>
         {episode.image_url && (
-          <Image
-            style={{ width: "100%", height: 240, backgroundColor: corporate }}
-            source={{ uri: episode.image_url }}
-            contentFit="cover"
-            accessibilityIgnoresInvertColors
-          />
+          <>
+            <UiSpace size={16} />
+            <View style={{ paddingHorizontal: COVER_PADDING_HORIZONTAL }}>
+              <Image
+                style={{
+                  width: "100%",
+                  aspectRatio: 1,
+                  borderRadius: 12,
+                  backgroundColor: corporate,
+                }}
+                source={{ uri: episode.image_url }}
+                contentFit="cover"
+                accessibilityIgnoresInvertColors
+              />
+            </View>
+          </>
         )}
         <UiSpace size={16} />
         <View style={{ paddingHorizontal: POST_PADDING_HORIZONTAL }}>

--- a/src/app/podcast/[id].tsx
+++ b/src/app/podcast/[id].tsx
@@ -10,6 +10,7 @@ import UiSpace from "#/components/ui/UiSpace";
 import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
 import Footer from "#/components/views/Footer";
+import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
 import {
   POST_PADDING_HORIZONTAL,
@@ -99,7 +100,7 @@ const PodcastScreen = () => {
                 style={{
                   width: "100%",
                   aspectRatio: 1,
-                  borderRadius: 12,
+                  borderRadius: radii.md,
                   backgroundColor: corporate,
                 }}
                 source={{ uri: episode.image_url }}

--- a/src/app/podcast/[id].tsx
+++ b/src/app/podcast/[id].tsx
@@ -22,6 +22,7 @@ import {
   useCorporateColor,
 } from "#/hooks/useAppColorScheme";
 import type { PodcastEpisodeProperties } from "#/types";
+import { FAV_TYPE_PODCAST } from "#/types";
 
 // The square cover sits a little narrower than the text column (design), so
 // it's inset a bit more than POST_PADDING_HORIZONTAL.
@@ -162,6 +163,9 @@ const PodcastScreen = () => {
             ? [{ url: episode.link, title: "Podcast Folge teilen" }]
             : undefined
         }
+        contentType={episode.link ? FAV_TYPE_PODCAST : undefined}
+        contentFavIdentifier={episode.link ? episode.id : undefined}
+        favPayload={episode.link ? episode : undefined}
       />
     </View>
   );

--- a/src/components/audio/AudioPlayer.tsx
+++ b/src/components/audio/AudioPlayer.tsx
@@ -10,9 +10,17 @@ import { View } from "react-native";
 
 import { PauseIcon, UnmuteIcon } from "#/components/Icons";
 import UiPressable from "#/components/ui/UiPressable";
+import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
 import { fontSizes } from "#/constants/FontSizes";
+import PersonalStore from "#/helpers/Stores/PersonalStore";
+import {
+  RESUME_END_MARGIN_SECONDS,
+  RESUME_MIN_SECONDS,
+  RESUME_SAVE_INTERVAL_SECONDS,
+  formatTime,
+} from "#/helpers/utils/audio";
 import {
   useAppColorScheme,
   useCorporateColor,
@@ -20,15 +28,25 @@ import {
 
 interface AudioPlayerProps {
   audioUrl: string;
+  /** Title shown on the lock-screen / notification now-playing controls. */
   title?: string;
+  /** Artwork shown on the lock-screen / notification now-playing controls. */
   artworkUrl?: string;
+  /** Start playback once the audio is loaded (used by lazily mounted players). */
+  autoPlay?: boolean;
+  /**
+   * Render a spinner while loading and an error message on failure instead of
+   * rendering nothing. Used where the player appears on user interaction and
+   * silence would look like a dead control.
+   */
+  showFeedback?: boolean;
+  /**
+   * Persist and restore the playback position under this key (e.g. the
+   * episode's audio URL) via PersonalStore, so long audio survives unmounts,
+   * refreshes and app restarts. Off when omitted.
+   */
+  resumeKey?: string;
 }
-
-const formatTime = (seconds: number) => {
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60);
-  return `${m}:${s.toString().padStart(2, "0")}`;
-};
 
 // `shouldPlayInBackground` is a single, module-wide native flag shared by
 // every AudioPlayer instance (not scoped per player) — it must only be on
@@ -49,7 +67,14 @@ const applyBackgroundPlaybackMode = (enabled: boolean) => {
   });
 };
 
-const AudioPlayer = ({ audioUrl, title, artworkUrl }: AudioPlayerProps) => {
+const AudioPlayer = ({
+  audioUrl,
+  title,
+  artworkUrl,
+  autoPlay = false,
+  showFeedback = false,
+  resumeKey,
+}: AudioPlayerProps) => {
   const player = useAudioPlayer(audioUrl, { updateInterval: 250 });
   const status = useAudioPlayerStatus(player);
   const corporate = useCorporateColor();
@@ -58,7 +83,16 @@ const AudioPlayer = ({ audioUrl, title, artworkUrl }: AudioPlayerProps) => {
   const [wasLoaded, setWasLoaded] = useState(false);
   const stableTime = useRef({ currentTime: 0, duration: 0 });
   const playerId = player.id;
+  const hasAutoPlayed = useRef(false);
+  const hasRestored = useRef(false);
+  const lastSavedTime = useRef(0);
+  // Autoplay must wait for the position restore, otherwise playback starts at
+  // 0:00 for a moment before jumping to the resumed position.
+  const [restoreDone, setRestoreDone] = useState(!resumeKey);
 
+  // Single active player across the app: starting one pauses the previously
+  // active one, toggles the module-wide background-playback mode, and drives
+  // the lock-screen / notification now-playing controls.
   useEffect(() => {
     if (!status.playing) {
       if (activePlayer?.id === playerId) {
@@ -97,13 +131,74 @@ const AudioPlayer = ({ audioUrl, title, artworkUrl }: AudioPlayerProps) => {
     setWasLoaded(false);
     stableTime.current = { currentTime: 0, duration: 0 };
     barWidth.current = 0;
-  }, [audioUrl]);
+    hasAutoPlayed.current = false;
+    hasRestored.current = false;
+    lastSavedTime.current = 0;
+    setRestoreDone(!resumeKey);
+  }, [audioUrl, resumeKey]);
+
+  // Restore the stored playback position once the audio is loaded.
+  useEffect(() => {
+    if (!resumeKey || hasRestored.current || !status.isLoaded) return;
+    hasRestored.current = true;
+    const { duration } = status;
+    PersonalStore.getAudioPosition(resumeKey)
+      .then((position) => {
+        if (
+          position > RESUME_MIN_SECONDS &&
+          (duration === 0 || position < duration - RESUME_END_MARGIN_SECONDS)
+        ) {
+          lastSavedTime.current = position;
+          return player.seekTo(position);
+        }
+      })
+      .finally(() => setRestoreDone(true));
+  }, [resumeKey, status, player]);
+
+  // Persist the position every few seconds of playback so it survives
+  // unmounts (list virtualization, refresh) and app restarts.
+  useEffect(() => {
+    if (!resumeKey || !status.isLoaded || !status.playing) return;
+    if (
+      Math.abs(status.currentTime - lastSavedTime.current) >=
+      RESUME_SAVE_INTERVAL_SECONDS
+    ) {
+      lastSavedTime.current = status.currentTime;
+      void PersonalStore.setAudioPosition(resumeKey, status.currentTime);
+    }
+  }, [resumeKey, status.isLoaded, status.playing, status.currentTime]);
+
+  // Save the last known position on unmount (or clear it when the audio ended
+  // near the end margin, so the next mount starts fresh).
+  useEffect(() => {
+    if (!resumeKey) return;
+    return () => {
+      const { currentTime, duration } = stableTime.current;
+      if (duration > 0 && currentTime >= duration - RESUME_END_MARGIN_SECONDS) {
+        void PersonalStore.clearAudioPosition(resumeKey);
+      } else if (currentTime > RESUME_MIN_SECONDS) {
+        void PersonalStore.setAudioPosition(resumeKey, currentTime);
+      }
+    };
+  }, [resumeKey]);
+
+  useEffect(() => {
+    if (autoPlay && restoreDone && status.isLoaded && !hasAutoPlayed.current) {
+      hasAutoPlayed.current = true;
+      player.play();
+    }
+  }, [autoPlay, restoreDone, status.isLoaded, player]);
 
   useEffect(() => {
     if (status.didJustFinish) {
       void player.seekTo(0);
+      if (resumeKey) {
+        lastSavedTime.current = 0;
+        stableTime.current.currentTime = 0;
+        void PersonalStore.clearAudioPosition(resumeKey);
+      }
     }
-  }, [status.didJustFinish, player]);
+  }, [status.didJustFinish, player, resumeKey]);
 
   // Latch loaded state and keep a snapshot of the last good position so a
   // transient isLoaded=false during seek doesn't unmount the player or reset
@@ -118,7 +213,31 @@ const AudioPlayer = ({ audioUrl, title, artworkUrl }: AudioPlayerProps) => {
     }
   }, [status.isLoaded, status.error, status.currentTime, status.duration]);
 
-  if (status.error || (!wasLoaded && !status.isLoaded)) return null;
+  if (status.error || (!wasLoaded && !status.isLoaded)) {
+    if (!showFeedback) return null;
+    return (
+      <View
+        style={{
+          paddingHorizontal: 20,
+          paddingVertical: 12,
+          minHeight: 50,
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        {status.error ? (
+          <UiText
+            size="sm"
+            style={{ color: Colors[colorScheme].error, textAlign: "center" }}
+          >
+            Audio konnte nicht geladen werden.
+          </UiText>
+        ) : (
+          <UiSpinner size="small" />
+        )}
+      </View>
+    );
+  }
 
   const { currentTime, duration } =
     status.isLoaded && !status.error ? status : stableTime.current;

--- a/src/components/audio/AudioPlayer.tsx
+++ b/src/components/audio/AudioPlayer.tsx
@@ -1,11 +1,5 @@
 import Octicons from "@react-native-vector-icons/octicons/static";
-import {
-  setAudioModeAsync,
-  useAudioPlayer,
-  useAudioPlayerStatus,
-} from "expo-audio";
-import Constants from "expo-constants";
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { View } from "react-native";
 
 import { PauseIcon } from "#/components/Icons";
@@ -14,13 +8,8 @@ import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
 import { fontSizes } from "#/constants/FontSizes";
-import PersonalStore from "#/helpers/Stores/PersonalStore";
-import {
-  RESUME_END_MARGIN_SECONDS,
-  RESUME_MIN_SECONDS,
-  RESUME_SAVE_INTERVAL_SECONDS,
-  formatTime,
-} from "#/helpers/utils/audio";
+import { useAudio } from "#/helpers/provider/AudioProvider";
+import { formatTime } from "#/helpers/utils/audio";
 import {
   useAppColorScheme,
   useCorporateColor,
@@ -32,195 +21,66 @@ interface AudioPlayerProps {
   title?: string;
   /** Artwork shown on the lock-screen / notification now-playing controls. */
   artworkUrl?: string;
-  /** Start playback once the audio is loaded (used by lazily mounted players). */
-  autoPlay?: boolean;
-  /**
-   * Render a spinner while loading and an error message on failure instead of
-   * rendering nothing. Used where the player appears on user interaction and
-   * silence would look like a dead control.
-   */
-  showFeedback?: boolean;
   /**
    * Persist and restore the playback position under this key (e.g. the
-   * episode's audio URL) via PersonalStore, so long audio survives unmounts,
-   * refreshes and app restarts. Off when omitted.
+   * episode's audio URL) via PersonalStore. Off when omitted.
    */
   resumeKey?: string;
   /**
-   * Horizontal padding of the player row. Defaults to 20; the podcast card
-   * passes the text padding so the row lines up with the episode text.
+   * Render a spinner while the (current) track is loading and an error message
+   * on failure, instead of the plain control row.
    */
+  showFeedback?: boolean;
+  /** Horizontal padding of the player row. Defaults to 20. */
   horizontalPadding?: number;
+  /** Known total length in seconds, shown before playback starts (podcast). */
+  durationSeconds?: number;
 }
 
-// `shouldPlayInBackground` is a single, module-wide native flag shared by
-// every AudioPlayer instance (not scoped per player) — it must only be on
-// while a player is actually playing, and there must only ever be one
-// playing at a time so backgrounding the app can still pause the rest of
-// the app's audio. This module-level state (shared across all mounted
-// AudioPlayer instances, since they all import the same module) tracks
-// which player currently "owns" background playback.
-let activePlayer: { id: string; pause: () => void } | null = null;
-
-const applyBackgroundPlaybackMode = (enabled: boolean) => {
-  // The native side rebuilds AudioMode from defaults on every call rather
-  // than merging, so all fields must be passed together every time.
-  void setAudioModeAsync({
-    playsInSilentMode: true,
-    interruptionMode: "doNotMix",
-    shouldPlayInBackground: enabled,
-  });
-};
-
+/**
+ * Controls view for the app-wide audio player (see AudioProvider). When this
+ * track is the one currently loaded, the row reflects and drives live playback;
+ * otherwise the play button loads and starts it. The native player lives in the
+ * provider, so playback continues when this view unmounts (e.g. on navigation).
+ */
 const AudioPlayer = ({
   audioUrl,
   title,
   artworkUrl,
-  autoPlay = false,
-  showFeedback = false,
   resumeKey,
+  showFeedback = false,
   horizontalPadding = 20,
+  durationSeconds,
 }: AudioPlayerProps) => {
-  const player = useAudioPlayer(audioUrl, { updateInterval: 250 });
-  const status = useAudioPlayerStatus(player);
+  const audio = useAudio();
   const corporate = useCorporateColor();
   const colorScheme = useAppColorScheme();
   const barWidth = useRef(0);
-  const [wasLoaded, setWasLoaded] = useState(false);
-  const stableTime = useRef({ currentTime: 0, duration: 0 });
-  const playerId = player.id;
-  const hasAutoPlayed = useRef(false);
-  const hasRestored = useRef(false);
-  const lastSavedTime = useRef(0);
-  // Autoplay must wait for the position restore, otherwise playback starts at
-  // 0:00 for a moment before jumping to the resumed position.
-  const [restoreDone, setRestoreDone] = useState(!resumeKey);
 
-  // Single active player across the app: starting one pauses the previously
-  // active one, toggles the module-wide background-playback mode, and drives
-  // the lock-screen / notification now-playing controls.
-  useEffect(() => {
-    if (!status.playing) {
-      if (activePlayer?.id === playerId) {
-        activePlayer = null;
-        applyBackgroundPlaybackMode(false);
-      }
-      return;
-    }
+  const isCurrent = audio.isCurrent(audioUrl);
+  const playing = isCurrent && audio.playing;
+  const loaded = isCurrent && audio.isLoaded;
+  const errored = isCurrent && audio.error;
 
-    if (activePlayer && activePlayer.id !== playerId) {
-      activePlayer.pause();
-    }
-    activePlayer = { id: playerId, pause: () => player.pause() };
-    applyBackgroundPlaybackMode(true);
-    void player.setActiveForLockScreen(true, {
-      title: title ?? "Artikel anhören",
-      artist: Constants.expoConfig?.name ?? "",
-      artworkUrl,
-    });
-  }, [status.playing, player, playerId, title, artworkUrl]);
+  const currentTime = isCurrent ? audio.currentTime : 0;
+  const duration = isCurrent ? audio.duration : (durationSeconds ?? 0);
+  const progress =
+    duration > 0 ? Math.min(1, Math.max(0, currentTime / duration)) : 0;
+  const remaining = Math.max(0, duration - currentTime);
 
-  // Guards against a player being torn down (e.g. by navigating away) while
-  // it's still the active background player — reads only the id captured
-  // during render, never touches the (possibly already-released) player
-  // object itself.
-  useEffect(() => {
-    return () => {
-      if (activePlayer?.id === playerId) {
-        activePlayer = null;
-        applyBackgroundPlaybackMode(false);
-      }
-    };
-  }, [playerId]);
+  const play = () =>
+    audio.playTrack({ audioUrl, title, artworkUrl, resumeKey });
 
-  useEffect(() => {
-    setWasLoaded(false);
-    stableTime.current = { currentTime: 0, duration: 0 };
-    barWidth.current = 0;
-    hasAutoPlayed.current = false;
-    hasRestored.current = false;
-    lastSavedTime.current = 0;
-    setRestoreDone(!resumeKey);
-  }, [audioUrl, resumeKey]);
+  const onToggle = () => (isCurrent ? audio.toggle() : play());
 
-  // Restore the stored playback position once the audio is loaded.
-  useEffect(() => {
-    if (!resumeKey || hasRestored.current || !status.isLoaded) return;
-    hasRestored.current = true;
-    const { duration } = status;
-    PersonalStore.getAudioPosition(resumeKey)
-      .then((position) => {
-        if (
-          position > RESUME_MIN_SECONDS &&
-          (duration === 0 || position < duration - RESUME_END_MARGIN_SECONDS)
-        ) {
-          lastSavedTime.current = position;
-          return player.seekTo(position);
-        }
-      })
-      .finally(() => setRestoreDone(true));
-  }, [resumeKey, status, player]);
+  const handleSeek = (x: number) => {
+    if (!isCurrent || barWidth.current === 0 || duration === 0) return;
+    const ratio = Math.max(0, Math.min(1, x / barWidth.current));
+    audio.seekTo(ratio * duration);
+  };
 
-  // Persist the position every few seconds of playback so it survives
-  // unmounts (list virtualization, refresh) and app restarts.
-  useEffect(() => {
-    if (!resumeKey || !status.isLoaded || !status.playing) return;
-    if (
-      Math.abs(status.currentTime - lastSavedTime.current) >=
-      RESUME_SAVE_INTERVAL_SECONDS
-    ) {
-      lastSavedTime.current = status.currentTime;
-      void PersonalStore.setAudioPosition(resumeKey, status.currentTime);
-    }
-  }, [resumeKey, status.isLoaded, status.playing, status.currentTime]);
-
-  // Save the last known position on unmount (or clear it when the audio ended
-  // near the end margin, so the next mount starts fresh).
-  useEffect(() => {
-    if (!resumeKey) return;
-    return () => {
-      const { currentTime, duration } = stableTime.current;
-      if (duration > 0 && currentTime >= duration - RESUME_END_MARGIN_SECONDS) {
-        void PersonalStore.clearAudioPosition(resumeKey);
-      } else if (currentTime > RESUME_MIN_SECONDS) {
-        void PersonalStore.setAudioPosition(resumeKey, currentTime);
-      }
-    };
-  }, [resumeKey]);
-
-  useEffect(() => {
-    if (autoPlay && restoreDone && status.isLoaded && !hasAutoPlayed.current) {
-      hasAutoPlayed.current = true;
-      player.play();
-    }
-  }, [autoPlay, restoreDone, status.isLoaded, player]);
-
-  useEffect(() => {
-    if (status.didJustFinish) {
-      void player.seekTo(0);
-      if (resumeKey) {
-        lastSavedTime.current = 0;
-        stableTime.current.currentTime = 0;
-        void PersonalStore.clearAudioPosition(resumeKey);
-      }
-    }
-  }, [status.didJustFinish, player, resumeKey]);
-
-  // Latch loaded state and keep a snapshot of the last good position so a
-  // transient isLoaded=false during seek doesn't unmount the player or reset
-  // the progress bar.
-  useEffect(() => {
-    if (status.isLoaded && !status.error) {
-      setWasLoaded(true);
-      stableTime.current = {
-        currentTime: status.currentTime,
-        duration: status.duration,
-      };
-    }
-  }, [status.isLoaded, status.error, status.currentTime, status.duration]);
-
-  if (status.error || (!wasLoaded && !status.isLoaded)) {
-    if (!showFeedback) return null;
+  // Loading / error feedback only applies while this track is the active one.
+  if (showFeedback && isCurrent && (errored || !loaded)) {
     return (
       <View
         style={{
@@ -231,7 +91,7 @@ const AudioPlayer = ({
           alignItems: "center",
         }}
       >
-        {status.error ? (
+        {errored ? (
           <UiText
             size="sm"
             style={{ color: Colors[colorScheme].error, textAlign: "center" }}
@@ -245,19 +105,6 @@ const AudioPlayer = ({
     );
   }
 
-  const { currentTime, duration } =
-    status.isLoaded && !status.error ? status : stableTime.current;
-
-  const progress =
-    duration > 0 ? Math.min(1, Math.max(0, currentTime / duration)) : 0;
-  const remaining = Math.max(0, duration - currentTime);
-
-  const handleSeek = (x: number) => {
-    if (barWidth.current === 0 || duration === 0) return;
-    const ratio = Math.max(0, Math.min(1, x / barWidth.current));
-    void player.seekTo(ratio * duration);
-  };
-
   return (
     <View
       style={{
@@ -270,11 +117,11 @@ const AudioPlayer = ({
     >
       <UiPressable
         accessibilityRole="button"
-        accessibilityLabel={status.playing ? "Pause" : "Abspielen"}
-        onPress={() => void (status.playing ? player.pause() : player.play())}
+        accessibilityLabel={playing ? "Pause" : "Abspielen"}
+        onPress={onToggle}
         hitSlop={10}
       >
-        {status.playing ? (
+        {playing ? (
           <PauseIcon
             size={26}
             color={corporate}
@@ -307,9 +154,9 @@ const AudioPlayer = ({
         onAccessibilityAction={(e) => {
           const step = 15;
           if (e.nativeEvent.actionName === "increment") {
-            void player.seekTo(Math.min(duration, currentTime + step));
+            audio.seekTo(Math.min(duration, currentTime + step));
           } else if (e.nativeEvent.actionName === "decrement") {
-            void player.seekTo(Math.max(0, currentTime - step));
+            audio.seekTo(Math.max(0, currentTime - step));
           }
         }}
         style={{
@@ -353,7 +200,7 @@ const AudioPlayer = ({
           textAlign: "right",
         }}
       >
-        {formatTime(remaining)}
+        {duration > 0 ? formatTime(remaining) : ""}
       </UiText>
     </View>
   );

--- a/src/components/audio/AudioPlayer.tsx
+++ b/src/components/audio/AudioPlayer.tsx
@@ -15,6 +15,8 @@ import {
   useCorporateColor,
 } from "#/hooks/useAppColorScheme";
 
+const PROGRESS_BAR_HEIGHT = 4;
+
 interface AudioPlayerProps {
   audioUrl: string;
   /** Title shown on the lock-screen / notification now-playing controls. */
@@ -172,11 +174,14 @@ const AudioPlayer = ({
         onResponderGrant={(e) => handleSeek(e.nativeEvent.locationX)}
         onResponderMove={(e) => handleSeek(e.nativeEvent.locationX)}
       >
+        {/* The track and its fill are capsules: the radius is half the bar's
+            own height, so it stays off the shared radii scale on purpose (see
+            the note in constants/BorderRadius). */}
         <View
           style={{
-            height: 4,
+            height: PROGRESS_BAR_HEIGHT,
             backgroundColor: Colors[colorScheme].surfaceDisabled,
-            borderRadius: 2,
+            borderRadius: PROGRESS_BAR_HEIGHT / 2,
             overflow: "hidden",
           }}
         >
@@ -185,7 +190,7 @@ const AudioPlayer = ({
               width: `${progress * 100}%`,
               height: "100%",
               backgroundColor: corporate,
-              borderRadius: 2,
+              borderRadius: PROGRESS_BAR_HEIGHT / 2,
             }}
           />
         </View>

--- a/src/components/audio/AudioPlayer.tsx
+++ b/src/components/audio/AudioPlayer.tsx
@@ -8,7 +8,7 @@ import Constants from "expo-constants";
 import { useEffect, useRef, useState } from "react";
 import { View } from "react-native";
 
-import { PauseIcon, UnmuteIcon } from "#/components/Icons";
+import { PauseIcon } from "#/components/Icons";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
@@ -46,6 +46,11 @@ interface AudioPlayerProps {
    * refreshes and app restarts. Off when omitted.
    */
   resumeKey?: string;
+  /**
+   * Horizontal padding of the player row. Defaults to 20; the podcast card
+   * passes the text padding so the row lines up with the episode text.
+   */
+  horizontalPadding?: number;
 }
 
 // `shouldPlayInBackground` is a single, module-wide native flag shared by
@@ -74,6 +79,7 @@ const AudioPlayer = ({
   autoPlay = false,
   showFeedback = false,
   resumeKey,
+  horizontalPadding = 20,
 }: AudioPlayerProps) => {
   const player = useAudioPlayer(audioUrl, { updateInterval: 250 });
   const status = useAudioPlayerStatus(player);
@@ -218,7 +224,7 @@ const AudioPlayer = ({
     return (
       <View
         style={{
-          paddingHorizontal: 20,
+          paddingHorizontal: horizontalPadding,
           paddingVertical: 12,
           minHeight: 50,
           justifyContent: "center",
@@ -255,19 +261,13 @@ const AudioPlayer = ({
   return (
     <View
       style={{
-        paddingHorizontal: 20,
+        paddingHorizontal: horizontalPadding,
         paddingVertical: 12,
         flexDirection: "row",
         alignItems: "center",
         gap: 12,
       }}
     >
-      <UnmuteIcon
-        size={16}
-        color={Colors[colorScheme].textMuted}
-        accessible={false}
-        importantForAccessibility="no"
-      />
       <UiPressable
         accessibilityRole="button"
         accessibilityLabel={status.playing ? "Pause" : "Abspielen"}

--- a/src/components/bars/NavBar.tsx
+++ b/src/components/bars/NavBar.tsx
@@ -13,9 +13,9 @@ import { onShare } from "#/helpers/Sharing";
 import { hexToRgb } from "#/helpers/utils/color";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 import type {
+  FavPayload,
   FaveableType,
   HttpsUrl,
-  InstaPostProperties,
   ShareableType,
 } from "#/types";
 
@@ -24,7 +24,7 @@ interface NavBarProperties {
   shareable?: ShareableType[];
   contentFavIdentifier?: string;
   contentType?: FaveableType;
-  favPayload?: InstaPostProperties;
+  favPayload?: FavPayload;
 }
 /**
  * NavBar component renders a top navigation bar with a customizable

--- a/src/components/bars/ShareBar.tsx
+++ b/src/components/bars/ShareBar.tsx
@@ -6,13 +6,13 @@ import ShareCounter from "#/components/counter/ShareCounter";
 import { globalStyles } from "#/constants/GlobalStyles";
 import { multishare } from "#/helpers/Sharing";
 import { useCorporateColor } from "#/hooks/useAppColorScheme";
-import type { FaveableType, InstaPostProperties, ShareableType } from "#/types";
+import type { FavPayload, FaveableType, ShareableType } from "#/types";
 
 interface ShareBarProperties {
   shareable: ShareableType[];
   contentFavIdentifier?: string;
   contentType?: FaveableType;
-  favPayload?: InstaPostProperties;
+  favPayload?: FavPayload;
   hideShareCount?: boolean;
 }
 

--- a/src/components/counter/FavCounter.tsx
+++ b/src/components/counter/FavCounter.tsx
@@ -9,7 +9,7 @@ import { getFavs } from "#/helpers/network/Engagement";
 import { useCorporateColor } from "#/hooks/useAppColorScheme";
 import { useEngagementCount } from "#/hooks/useEngagementCount";
 import { useFavorite } from "#/hooks/useFavorite";
-import type { FaveableType, InstaPostProperties, ShareableType } from "#/types";
+import type { FavPayload, FaveableType, ShareableType } from "#/types";
 
 interface FavCounterProperties {
   shareable: ShareableType[];
@@ -17,7 +17,7 @@ interface FavCounterProperties {
   style: TextStyle;
   contentFavIdentifier?: string;
   contentType?: FaveableType;
-  favPayload?: InstaPostProperties;
+  favPayload?: FavPayload;
 }
 
 const FavCounter = (properties: FavCounterProperties) => {

--- a/src/components/posts/GenericPost.tsx
+++ b/src/components/posts/GenericPost.tsx
@@ -6,8 +6,25 @@ import { View } from "react-native";
 import ShareBar from "#/components/bars/ShareBar";
 import UiCard from "#/components/ui/UiCard";
 import { POST_PADDING_HORIZONTAL } from "#/constants/GlobalStyles";
-import type { FaveableType, InstaPostProperties, ShareableType } from "#/types";
-import { FAV_TYPE_INSTA } from "#/types";
+import type {
+  FavPayload,
+  FaveableType,
+  InstaPostProperties,
+  PodcastEpisodeProperties,
+  ShareableType,
+} from "#/types";
+import { FAV_TYPE_INSTA, FAV_TYPE_PODCAST } from "#/types";
+
+// Snapshot `data` into the favorite for the content types that can't be
+// re-fetched by id (Instagram, podcast); other types reload by URL/slug.
+const favPayloadFor = (
+  contentType: FaveableType | undefined,
+  data: object,
+): FavPayload | undefined => {
+  if (contentType === FAV_TYPE_INSTA) return data as InstaPostProperties;
+  if (contentType === FAV_TYPE_PODCAST) return data as PodcastEpisodeProperties;
+  return undefined;
+};
 
 interface ComponentProperty<T> {
   component: FC<{ inView: boolean } & T>;
@@ -46,13 +63,9 @@ const GenericPost = (properties: ComponentProperty<object>) => {
           hideShareCount={!inView}
           contentFavIdentifier={contentFavIdentifier}
           contentType={contentType}
-          // For Instagram posts `data` is the post itself; snapshot it into the
-          // favorite so it survives without the account-scoped by-id proxy.
-          favPayload={
-            contentType === FAV_TYPE_INSTA
-              ? (data as InstaPostProperties)
-              : undefined
-          }
+          // For Instagram posts and podcast episodes `data` is the item itself;
+          // snapshot it into the favorite so it survives without a by-id fetch.
+          favPayload={favPayloadFor(contentType, data)}
         />
       ) : (
         <View

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -12,6 +12,7 @@ import Colors from "#/constants/Colors";
 import {
   DEFAULT_IMAGE_ASPECT_RATIO,
   POST_PADDING_HORIZONTAL,
+  globalStyles,
 } from "#/constants/GlobalStyles";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
 import { registerPostInteraction } from "#/helpers/network/Analytics";
@@ -22,6 +23,8 @@ import {
   useCorporateColor,
 } from "#/hooks/useAppColorScheme";
 import type { PodcastEpisodeProperties } from "#/types";
+
+import Badge from "./Badge";
 
 /**
  * Renders a podcast episode (Podigee) card: full-width cover on top, then title,
@@ -89,22 +92,31 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
         onPress={openEpisode}
       >
         {image_url && (
-          <Image
-            style={{
-              width: "100%",
-              aspectRatio: 1 / DEFAULT_IMAGE_ASPECT_RATIO,
-              backgroundColor: corporate,
-            }}
-            source={{ uri: image_url }}
-            contentFit="cover"
-            accessibilityIgnoresInvertColors
-          />
+          <View style={{ position: "relative" }}>
+            <Image
+              style={{
+                width: "100%",
+                aspectRatio: 1 / DEFAULT_IMAGE_ASPECT_RATIO,
+                backgroundColor: corporate,
+              }}
+              source={{ uri: image_url }}
+              contentFit="cover"
+              accessibilityIgnoresInvertColors
+            />
+            <Badge position="topLeft" color={corporate}>
+              <UiText size="sm" style={globalStyles.whiteText}>
+                Podcast
+              </UiText>
+            </Badge>
+          </View>
         )}
         <UiSpace size={image_url ? 12 : 20} />
         <View style={{ paddingHorizontal: POST_PADDING_HORIZONTAL }}>
-          <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
-            Podcast
-          </UiText>
+          {!image_url && (
+            <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
+              Podcast
+            </UiText>
+          )}
           <UiText
             size="lg"
             numberOfLines={2}
@@ -113,7 +125,7 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
             {title}
           </UiText>
           {!!dateDurationText && (
-            <UiText size="sm" style={{ color: greyText, textAlign: "left" }}>
+            <UiText size="base" style={{ color: greyText, textAlign: "left" }}>
               {dateDurationText}
             </UiText>
           )}

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -117,6 +117,7 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
             resumeKey={audio_url}
             title={title}
             artworkUrl={image_url ?? undefined}
+            horizontalPadding={POST_PADDING_HORIZONTAL}
           />
         ) : (
           <UiPressable
@@ -130,7 +131,7 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
               flexDirection: "row",
               alignItems: "center",
               gap: 12,
-              paddingHorizontal: 20,
+              paddingHorizontal: POST_PADDING_HORIZONTAL,
               paddingVertical: 12,
             }}
           >

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -9,7 +9,10 @@ import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
-import { POST_PADDING_HORIZONTAL } from "#/constants/GlobalStyles";
+import {
+  DEFAULT_IMAGE_ASPECT_RATIO,
+  POST_PADDING_HORIZONTAL,
+} from "#/constants/GlobalStyles";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
 import { registerPostInteraction } from "#/helpers/network/Analytics";
 import { useAudio } from "#/helpers/provider/AudioProvider";
@@ -20,13 +23,12 @@ import {
 } from "#/hooks/useAppColorScheme";
 import type { PodcastEpisodeProperties } from "#/types";
 
-const COVER_SIZE = 84;
-
 /**
- * Renders a podcast episode (Podigee) card: cover, title, date/duration and a
- * play control. Tapping the body opens the full episode screen; the play button
- * drives the app-wide player (AudioProvider), and once this episode is the
- * active track the card shows live controls instead of the button.
+ * Renders a podcast episode (Podigee) card: full-width cover on top, then title,
+ * date/duration, a short description and a play control. Tapping the body opens
+ * the full episode screen; the play button drives the app-wide player
+ * (AudioProvider), and once this episode is the active track the card shows live
+ * controls instead of the button.
  */
 const PodcastPost = (properties: PodcastEpisodeProperties) => {
   const { id, title, description, published_at, link, audio_url, image_url } =
@@ -80,50 +82,41 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
   const dateDurationText = [date, duration].filter(Boolean).join(" | ");
 
   return (
-    <View style={{ paddingTop: 20 }}>
+    <View>
       <UiPressable
         accessibilityRole="button"
         accessibilityLabel={`Podcast Folge öffnen: ${title}`}
         onPress={openEpisode}
       >
-        <View
-          style={{
-            flexDirection: "row",
-            gap: 12,
-            alignItems: "flex-start",
-            paddingHorizontal: POST_PADDING_HORIZONTAL,
-          }}
-        >
-          {image_url && (
-            <Image
-              style={{
-                width: COVER_SIZE,
-                height: COVER_SIZE,
-                borderRadius: 8,
-                backgroundColor: corporate,
-              }}
-              source={{ uri: image_url }}
-              contentFit="cover"
-              accessibilityIgnoresInvertColors
-            />
+        {image_url && (
+          <Image
+            style={{
+              width: "100%",
+              aspectRatio: 1 / DEFAULT_IMAGE_ASPECT_RATIO,
+              backgroundColor: corporate,
+            }}
+            source={{ uri: image_url }}
+            contentFit="cover"
+            accessibilityIgnoresInvertColors
+          />
+        )}
+        <UiSpace size={image_url ? 12 : 20} />
+        <View style={{ paddingHorizontal: POST_PADDING_HORIZONTAL }}>
+          <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
+            Podcast
+          </UiText>
+          <UiText
+            size="lg"
+            numberOfLines={2}
+            style={{ fontFamily: "SourceSansProBold", textAlign: "left" }}
+          >
+            {title}
+          </UiText>
+          {!!dateDurationText && (
+            <UiText size="sm" style={{ color: greyText, textAlign: "left" }}>
+              {dateDurationText}
+            </UiText>
           )}
-          <View style={{ flex: 1 }}>
-            <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
-              Podcast
-            </UiText>
-            <UiText
-              size="lg"
-              numberOfLines={2}
-              style={{ fontFamily: "SourceSansProBold", textAlign: "left" }}
-            >
-              {title}
-            </UiText>
-            {!!dateDurationText && (
-              <UiText size="sm" style={{ color: greyText, textAlign: "left" }}>
-                {dateDurationText}
-              </UiText>
-            )}
-          </View>
         </View>
         {!!description && (
           <>

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -1,5 +1,6 @@
 import Octicons from "@react-native-vector-icons/octicons/static";
 import { Image } from "expo-image";
+import { useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
 import { View } from "react-native";
 
@@ -26,13 +27,21 @@ const COVER_SIZE = 84;
  * play so a feed full of episodes doesn't spawn one native player per card.
  */
 const PodcastPost = (properties: PodcastEpisodeProperties) => {
-  const { title, description, published_at, link, audio_url, image_url } =
+  const { id, title, description, published_at, link, audio_url, image_url } =
     properties;
   const [playerMounted, setPlayerMounted] = useState(false);
   const [resumePosition, setResumePosition] = useState(0);
   const colorScheme = useAppColorScheme();
   const corporate = useCorporateColor();
   const greyText = Colors[colorScheme].textMuted;
+  const router = useRouter();
+
+  // Tapping the card body opens the full episode screen (like articles/Insta);
+  // the play control below stays on the card for quick inline playback.
+  const openEpisode = () => {
+    registerPostInteraction(link ?? audio_url, "podcast", "open");
+    router.push(`/podcast/${encodeURIComponent(id)}`);
+  };
 
   // Show "Fortsetzen bei …" when a stored playback position exists.
   useEffect(() => {
@@ -55,59 +64,66 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
 
   return (
     <View style={{ paddingTop: 20 }}>
-      <View
-        style={{
-          flexDirection: "row",
-          gap: 12,
-          paddingHorizontal: POST_PADDING_HORIZONTAL,
-        }}
+      <UiPressable
+        accessibilityRole="button"
+        accessibilityLabel={`Podcast Folge öffnen: ${title}`}
+        onPress={openEpisode}
       >
-        {image_url && (
-          <Image
-            style={{
-              width: COVER_SIZE,
-              height: COVER_SIZE,
-              borderRadius: 8,
-              backgroundColor: corporate,
-            }}
-            source={{ uri: image_url }}
-            contentFit="cover"
-            accessibilityIgnoresInvertColors
-          />
-        )}
-        <View style={{ flex: 1, justifyContent: "center" }}>
-          <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
-            Podcast
-          </UiText>
-          <UiText
-            size="lg"
-            numberOfLines={3}
-            style={{ fontFamily: "SourceSansProBold", textAlign: "left" }}
-          >
-            {title}
-          </UiText>
-          {!!dateDurationText && (
-            <UiText size="sm" style={{ color: greyText, textAlign: "left" }}>
-              {dateDurationText}
-            </UiText>
+        <View
+          style={{
+            flexDirection: "row",
+            gap: 12,
+            alignItems: "flex-start",
+            paddingHorizontal: POST_PADDING_HORIZONTAL,
+          }}
+        >
+          {image_url && (
+            <Image
+              style={{
+                width: COVER_SIZE,
+                height: COVER_SIZE,
+                borderRadius: 8,
+                backgroundColor: corporate,
+              }}
+              source={{ uri: image_url }}
+              contentFit="cover"
+              accessibilityIgnoresInvertColors
+            />
           )}
+          <View style={{ flex: 1 }}>
+            <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
+              Podcast
+            </UiText>
+            <UiText
+              size="lg"
+              numberOfLines={2}
+              style={{ fontFamily: "SourceSansProBold", textAlign: "left" }}
+            >
+              {title}
+            </UiText>
+            {!!dateDurationText && (
+              <UiText size="sm" style={{ color: greyText, textAlign: "left" }}>
+                {dateDurationText}
+              </UiText>
+            )}
+          </View>
         </View>
-      </View>
-      {!!description && (
-        <>
-          <UiSpace size={10} />
-          <UiText
-            size="base"
-            numberOfLines={3}
-            style={{
-              paddingHorizontal: POST_PADDING_HORIZONTAL,
-              textAlign: "left",
-            }}
-          >
-            {description}
-          </UiText>
-        </>
-      )}
+        {!!description && (
+          <>
+            <UiSpace size={10} />
+            <UiText
+              size="base"
+              numberOfLines={2}
+              style={{
+                paddingHorizontal: POST_PADDING_HORIZONTAL,
+                textAlign: "left",
+              }}
+            >
+              {description}
+            </UiText>
+          </>
+        )}
+      </UiPressable>
       <View style={{ minHeight: 68, justifyContent: "center" }}>
         {playerMounted ? (
           <AudioPlayer

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -1,0 +1,150 @@
+import Octicons from "@react-native-vector-icons/octicons/static";
+import { Image } from "expo-image";
+import React, { useEffect, useState } from "react";
+import { View } from "react-native";
+
+import AudioPlayer from "#/components/audio/AudioPlayer";
+import UiPressable from "#/components/ui/UiPressable";
+import UiSpace from "#/components/ui/UiSpace";
+import UiText from "#/components/ui/UiText";
+import Colors from "#/constants/Colors";
+import { POST_PADDING_HORIZONTAL } from "#/constants/GlobalStyles";
+import PersonalStore from "#/helpers/Stores/PersonalStore";
+import { registerPostInteraction } from "#/helpers/network/Analytics";
+import { RESUME_MIN_SECONDS, formatTime } from "#/helpers/utils/audio";
+import {
+  useAppColorScheme,
+  useCorporateColor,
+} from "#/hooks/useAppColorScheme";
+import type { PodcastEpisodeProperties } from "#/types";
+
+const COVER_SIZE = 84;
+
+/**
+ * Renders a podcast episode (Podigee) with cover, title, date/duration and a
+ * lazily mounted audio player. The player is only created after the user taps
+ * play so a feed full of episodes doesn't spawn one native player per card.
+ */
+const PodcastPost = (properties: PodcastEpisodeProperties) => {
+  const { title, description, published_at, link, audio_url, image_url } =
+    properties;
+  const [playerMounted, setPlayerMounted] = useState(false);
+  const [resumePosition, setResumePosition] = useState(0);
+  const colorScheme = useAppColorScheme();
+  const corporate = useCorporateColor();
+  const greyText = Colors[colorScheme].textMuted;
+
+  // Show "Fortsetzen bei …" when a stored playback position exists.
+  useEffect(() => {
+    if (playerMounted) return;
+    let cancelled = false;
+    PersonalStore.getAudioPosition(audio_url).then((position) => {
+      if (!cancelled) setResumePosition(position);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [audio_url, playerMounted]);
+
+  const d = published_at ? new Date(published_at) : undefined;
+  const date = d ? `${d.getDate()}.${d.getMonth() + 1}.${d.getFullYear()}` : "";
+  const duration = properties.duration
+    ? `${Math.max(1, Math.round(properties.duration / 60))} Min.`
+    : "";
+  const dateDurationText = [date, duration].filter(Boolean).join(" | ");
+
+  return (
+    <View style={{ paddingTop: 20 }}>
+      <View
+        style={{
+          flexDirection: "row",
+          gap: 12,
+          paddingHorizontal: POST_PADDING_HORIZONTAL,
+        }}
+      >
+        {image_url && (
+          <Image
+            style={{
+              width: COVER_SIZE,
+              height: COVER_SIZE,
+              borderRadius: 8,
+              backgroundColor: corporate,
+            }}
+            source={{ uri: image_url }}
+            contentFit="cover"
+            accessibilityIgnoresInvertColors
+          />
+        )}
+        <View style={{ flex: 1, justifyContent: "center" }}>
+          <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
+            Podcast
+          </UiText>
+          <UiText
+            size="lg"
+            numberOfLines={3}
+            style={{ fontFamily: "SourceSansProBold", textAlign: "left" }}
+          >
+            {title}
+          </UiText>
+          {!!dateDurationText && (
+            <UiText size="sm" style={{ color: greyText, textAlign: "left" }}>
+              {dateDurationText}
+            </UiText>
+          )}
+        </View>
+      </View>
+      {!!description && (
+        <>
+          <UiSpace size={10} />
+          <UiText
+            size="base"
+            numberOfLines={3}
+            style={{
+              paddingHorizontal: POST_PADDING_HORIZONTAL,
+              textAlign: "left",
+            }}
+          >
+            {description}
+          </UiText>
+        </>
+      )}
+      <View style={{ minHeight: 68, justifyContent: "center" }}>
+        {playerMounted ? (
+          <AudioPlayer
+            audioUrl={audio_url}
+            autoPlay
+            showFeedback
+            resumeKey={audio_url}
+            title={title}
+            artworkUrl={image_url ?? undefined}
+          />
+        ) : (
+          <UiPressable
+            accessibilityRole="button"
+            accessibilityLabel={`Podcast Folge abspielen: ${title}`}
+            onPress={() => {
+              registerPostInteraction(link ?? audio_url, "podcast", "play");
+              setPlayerMounted(true);
+            }}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 12,
+              paddingHorizontal: 20,
+              paddingVertical: 12,
+            }}
+          >
+            <Octicons name="play" size={26} color={corporate} />
+            <UiText size="base" style={{ color: corporate }}>
+              {resumePosition > RESUME_MIN_SECONDS
+                ? `Fortsetzen bei ${formatTime(resumePosition)}`
+                : "Folge abspielen"}
+            </UiText>
+          </UiPressable>
+        )}
+      </View>
+    </View>
+  );
+};
+
+export default React.memo(PodcastPost);

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -12,6 +12,7 @@ import Colors from "#/constants/Colors";
 import { POST_PADDING_HORIZONTAL } from "#/constants/GlobalStyles";
 import PersonalStore from "#/helpers/Stores/PersonalStore";
 import { registerPostInteraction } from "#/helpers/network/Analytics";
+import { useAudio } from "#/helpers/provider/AudioProvider";
 import { RESUME_MIN_SECONDS, formatTime } from "#/helpers/utils/audio";
 import {
   useAppColorScheme,
@@ -22,19 +23,24 @@ import type { PodcastEpisodeProperties } from "#/types";
 const COVER_SIZE = 84;
 
 /**
- * Renders a podcast episode (Podigee) with cover, title, date/duration and a
- * lazily mounted audio player. The player is only created after the user taps
- * play so a feed full of episodes doesn't spawn one native player per card.
+ * Renders a podcast episode (Podigee) card: cover, title, date/duration and a
+ * play control. Tapping the body opens the full episode screen; the play button
+ * drives the app-wide player (AudioProvider), and once this episode is the
+ * active track the card shows live controls instead of the button.
  */
 const PodcastPost = (properties: PodcastEpisodeProperties) => {
   const { id, title, description, published_at, link, audio_url, image_url } =
     properties;
-  const [playerMounted, setPlayerMounted] = useState(false);
   const [resumePosition, setResumePosition] = useState(0);
   const colorScheme = useAppColorScheme();
   const corporate = useCorporateColor();
   const greyText = Colors[colorScheme].textMuted;
   const router = useRouter();
+  const audio = useAudio();
+
+  // This episode is "active" once it's the track loaded in the global player;
+  // then the card shows live controls instead of the play button.
+  const isCurrent = audio.isCurrent(audio_url);
 
   // Tapping the card body opens the full episode screen (like articles/Insta);
   // the play control below stays on the card for quick inline playback.
@@ -43,9 +49,20 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
     router.push(`/podcast/${encodeURIComponent(id)}`);
   };
 
-  // Show "Fortsetzen bei …" when a stored playback position exists.
+  const playEpisode = () => {
+    registerPostInteraction(link ?? audio_url, "podcast", "play");
+    audio.playTrack({
+      audioUrl: audio_url,
+      title,
+      artworkUrl: image_url ?? undefined,
+      resumeKey: audio_url,
+    });
+  };
+
+  // Show "Fortsetzen bei …" when a stored playback position exists (until this
+  // episode becomes the active track and shows live controls).
   useEffect(() => {
-    if (playerMounted) return;
+    if (isCurrent) return;
     let cancelled = false;
     PersonalStore.getAudioPosition(audio_url).then((position) => {
       if (!cancelled) setResumePosition(position);
@@ -53,7 +70,7 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
     return () => {
       cancelled = true;
     };
-  }, [audio_url, playerMounted]);
+  }, [audio_url, isCurrent]);
 
   const d = published_at ? new Date(published_at) : undefined;
   const date = d ? `${d.getDate()}.${d.getMonth() + 1}.${d.getFullYear()}` : "";
@@ -125,24 +142,21 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
         )}
       </UiPressable>
       <View style={{ minHeight: 68, justifyContent: "center" }}>
-        {playerMounted ? (
+        {isCurrent ? (
           <AudioPlayer
             audioUrl={audio_url}
-            autoPlay
             showFeedback
             resumeKey={audio_url}
             title={title}
             artworkUrl={image_url ?? undefined}
             horizontalPadding={POST_PADDING_HORIZONTAL}
+            durationSeconds={properties.duration ?? undefined}
           />
         ) : (
           <UiPressable
             accessibilityRole="button"
             accessibilityLabel={`Podcast Folge abspielen: ${title}`}
-            onPress={() => {
-              registerPostInteraction(link ?? audio_url, "podcast", "play");
-              setPlayerMounted(true);
-            }}
+            onPress={playEpisode}
             style={{
               flexDirection: "row",
               alignItems: "center",

--- a/src/helpers/Storage.ts
+++ b/src/helpers/Storage.ts
@@ -48,6 +48,18 @@ const BaseStore = {
   },
 
   /**
+   * Removes a single item from AsyncStorage.
+   * @param {string} key - The key of the item to remove.
+   */
+  async removeItem(key: string) {
+    try {
+      await AsyncStorage.removeItem(key);
+    } catch (error) {
+      console.error(error);
+    }
+  },
+
+  /**
    * Removes all items from AsyncStorage that start with the given prefix.
    * @param {string} prefix - The prefix to remove items with.
    */

--- a/src/helpers/Stores/FavoritesStore.ts
+++ b/src/helpers/Stores/FavoritesStore.ts
@@ -1,10 +1,5 @@
 import BaseStore from "#/helpers/Storage";
-import type {
-  FaveableType,
-  HttpsUrl,
-  InstaPostProperties,
-  StoredFavs,
-} from "#/types";
+import type { FavPayload, FaveableType, HttpsUrl, StoredFavs } from "#/types";
 
 const FavoritesStore = {
   favKey: "favs",
@@ -48,7 +43,7 @@ const FavoritesStore = {
     contentFavIdentifier: string,
     contentType: FaveableType,
     originalUrl?: HttpsUrl,
-    payload?: InstaPostProperties,
+    payload?: FavPayload,
   ): Promise<void> {
     const storedFavs = await this.getStoredFavs();
     const newStoredFavs = {

--- a/src/helpers/Stores/PersonalStore.ts
+++ b/src/helpers/Stores/PersonalStore.ts
@@ -9,6 +9,7 @@ const PersonalStore = {
   keys: {
     onboardingDone: "onboarded",
     scrollPosition: "scrollPosition",
+    audioPosition: "audioPosition",
     longPressTip: "longPressTip",
     lastSeenChangelog: "lastSeenChangelog",
     dismissedAnnouncements: "dismissedAnnouncements",
@@ -21,6 +22,14 @@ const PersonalStore = {
    */
   getScrollKey(slug: string): string {
     return `${this.keys.scrollPosition}_${slug}`;
+  },
+
+  /**
+   * Constructs the key for audio position storage for a given resume key
+   * (e.g. a podcast episode's audio URL).
+   */
+  getAudioKey(resumeKey: string): string {
+    return `${this.keys.audioPosition}_${resumeKey}`;
   },
 
   /**
@@ -134,6 +143,49 @@ const PersonalStore = {
     } catch (error) {
       console.error("Error retrieving scroll position:", error);
       return 0;
+    }
+  },
+
+  /**
+   * Stores the playback position (in seconds) for a resumable audio.
+   * @param {string} resumeKey - Identifies the audio, e.g. its URL.
+   * @param {number} position - The playback position in seconds.
+   */
+  async setAudioPosition(resumeKey: string, position: number): Promise<void> {
+    try {
+      await BaseStore.setItem(
+        this.getAudioKey(resumeKey),
+        JSON.stringify(position),
+      );
+    } catch (error) {
+      console.error("Error setting audio position:", error);
+    }
+  },
+
+  /**
+   * Retrieves the stored playback position (in seconds) for a resumable audio.
+   * @param {string} resumeKey - Identifies the audio, e.g. its URL.
+   * @returns {Promise<number>} The stored position, 0 if none.
+   */
+  async getAudioPosition(resumeKey: string): Promise<number> {
+    try {
+      const jsonValue = await BaseStore.getItem(this.getAudioKey(resumeKey));
+      return BaseStore.parseJSON<number>(jsonValue, 0);
+    } catch (error) {
+      console.error("Error retrieving audio position:", error);
+      return 0;
+    }
+  },
+
+  /**
+   * Clears the stored playback position, e.g. once the audio finished.
+   * @param {string} resumeKey - Identifies the audio, e.g. its URL.
+   */
+  async clearAudioPosition(resumeKey: string): Promise<void> {
+    try {
+      await BaseStore.removeItem(this.getAudioKey(resumeKey));
+    } catch (error) {
+      console.error("Error clearing audio position:", error);
     }
   },
 };

--- a/src/helpers/Stores/SettingsStore.ts
+++ b/src/helpers/Stores/SettingsStore.ts
@@ -39,6 +39,7 @@ const SettingsStore = {
     tiktok: { value: true, name: "TikTok Videos" },
     bsky: { value: false, name: "Bluesky Posts" },
     bot: { value: true, name: "Bot Feed" },
+    podcast: { value: true, name: "Podcast Folgen" },
     ...perFeedContentDefaults,
   } satisfies ContentSettingType,
 

--- a/src/helpers/network/Analytics.ts
+++ b/src/helpers/network/Analytics.ts
@@ -103,7 +103,7 @@ const registerEvent = async <T extends Record<string, unknown>>(
   }
 };
 
-type PostPlatform = "youtube" | "tiktok" | "instagram" | "bluesky";
+type PostPlatform = "youtube" | "tiktok" | "instagram" | "bluesky" | "podcast";
 type PostAction = "play" | "open";
 
 /**

--- a/src/helpers/network/ServerAPI.ts
+++ b/src/helpers/network/ServerAPI.ts
@@ -14,6 +14,7 @@ import type {
   InstaPostProperties,
   MastodonPostProperties,
   NotificationSettingType,
+  PodcastEpisodeProperties,
   TiktokPostProperties,
   YouTubePostProperties,
 } from "#/types";
@@ -175,6 +176,20 @@ class API {
       signal,
     );
     return response.items ?? [];
+  }
+
+  /**
+   * Fetches the podcast feed (Podigee episodes, proxied by the server).
+   */
+  static async getPodcastFeed(
+    signal?: AbortSignal,
+  ): Promise<PodcastEpisodeProperties[]> {
+    const response = await API.get<{ episodes: PodcastEpisodeProperties[] }>(
+      "/proxy/podcastFeed",
+      undefined,
+      signal,
+    );
+    return response.episodes ?? [];
   }
 
   /**

--- a/src/helpers/provider/AudioProvider.tsx
+++ b/src/helpers/provider/AudioProvider.tsx
@@ -1,0 +1,191 @@
+import {
+  setAudioModeAsync,
+  useAudioPlayer,
+  useAudioPlayerStatus,
+} from "expo-audio";
+import Constants from "expo-constants";
+import type { ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import PersonalStore from "#/helpers/Stores/PersonalStore";
+import {
+  RESUME_END_MARGIN_SECONDS,
+  RESUME_MIN_SECONDS,
+  RESUME_SAVE_INTERVAL_SECONDS,
+} from "#/helpers/utils/audio";
+
+export interface AudioTrack {
+  audioUrl: string;
+  /** Shown on the lock-screen / notification now-playing controls. */
+  title?: string;
+  /** Artwork for the lock-screen / notification now-playing controls. */
+  artworkUrl?: string;
+  /**
+   * Persist and restore the playback position under this key (e.g. the
+   * episode's audio URL) via PersonalStore. Off when omitted.
+   */
+  resumeKey?: string;
+}
+
+export interface AudioContextValue {
+  /** URL of the track the single global player currently holds, or null. */
+  currentUrl: string | null;
+  isLoaded: boolean;
+  playing: boolean;
+  currentTime: number;
+  duration: number;
+  error: boolean;
+  /** Load a track into the global player and start playback. */
+  playTrack: (track: AudioTrack) => void;
+  /** Play/pause the current track. */
+  toggle: () => void;
+  pause: () => void;
+  seekTo: (seconds: number) => void;
+  isCurrent: (audioUrl: string) => boolean;
+}
+
+const AudioContext = createContext<AudioContextValue | null>(null);
+
+// One app-wide native audio mode: only enable background playback while
+// something is actually playing (see the AudioProvider effect). Rebuilt from
+// defaults on every call, so all fields must be passed together.
+const applyBackgroundPlaybackMode = (enabled: boolean) => {
+  void setAudioModeAsync({
+    playsInSilentMode: true,
+    interruptionMode: "doNotMix",
+    shouldPlayInBackground: enabled,
+  });
+};
+
+/**
+ * Owns the single, app-wide audio player. Living above the navigator, the
+ * player survives screen changes, so playback continues while the user browses
+ * (the per-screen AudioPlayer views just render controls bound to it).
+ */
+export const AudioProvider = ({ children }: { children: ReactNode }) => {
+  const player = useAudioPlayer(null, { updateInterval: 250 });
+  const status = useAudioPlayerStatus(player);
+  const [track, setTrack] = useState<AudioTrack | null>(null);
+  const hasRestored = useRef(false);
+  const lastSavedTime = useRef(0);
+  const wantPlay = useRef(false);
+
+  const currentUrl = track?.audioUrl ?? null;
+
+  const playTrack = useCallback(
+    (next: AudioTrack) => {
+      if (track?.audioUrl === next.audioUrl) {
+        player.play();
+        return;
+      }
+      hasRestored.current = false;
+      lastSavedTime.current = 0;
+      wantPlay.current = true;
+      setTrack(next);
+      player.replace({ uri: next.audioUrl });
+    },
+    [track?.audioUrl, player],
+  );
+
+  // Restore the stored position once the new track is loaded, then start it.
+  useEffect(() => {
+    if (!track || hasRestored.current || !status.isLoaded) return;
+    hasRestored.current = true;
+    const { duration } = status;
+    const startIfWanted = () => {
+      if (wantPlay.current) {
+        wantPlay.current = false;
+        player.play();
+      }
+    };
+    if (track.resumeKey) {
+      PersonalStore.getAudioPosition(track.resumeKey)
+        .then((position) => {
+          if (
+            position > RESUME_MIN_SECONDS &&
+            (duration === 0 || position < duration - RESUME_END_MARGIN_SECONDS)
+          ) {
+            lastSavedTime.current = position;
+            return player.seekTo(position);
+          }
+        })
+        .finally(startIfWanted);
+    } else {
+      startIfWanted();
+    }
+  }, [track, status, player]);
+
+  // Toggle background mode + drive the lock-screen controls with playback.
+  useEffect(() => {
+    if (status.playing) {
+      applyBackgroundPlaybackMode(true);
+      player.setActiveForLockScreen(true, {
+        title: track?.title ?? "Volksverpetzer",
+        artist: Constants.expoConfig?.name ?? "",
+        artworkUrl: track?.artworkUrl,
+      });
+    } else {
+      applyBackgroundPlaybackMode(false);
+    }
+  }, [status.playing, player, track?.title, track?.artworkUrl]);
+
+  // Persist the position every few seconds so it survives an app restart.
+  useEffect(() => {
+    if (!track?.resumeKey || !status.isLoaded || !status.playing) return;
+    if (
+      Math.abs(status.currentTime - lastSavedTime.current) >=
+      RESUME_SAVE_INTERVAL_SECONDS
+    ) {
+      lastSavedTime.current = status.currentTime;
+      void PersonalStore.setAudioPosition(track.resumeKey, status.currentTime);
+    }
+  }, [track?.resumeKey, status.isLoaded, status.playing, status.currentTime]);
+
+  // On finish: rewind and clear the stored position so the next play starts fresh.
+  useEffect(() => {
+    if (!status.didJustFinish) return;
+    void player.seekTo(0);
+    if (track?.resumeKey) {
+      lastSavedTime.current = 0;
+      void PersonalStore.clearAudioPosition(track.resumeKey);
+    }
+  }, [status.didJustFinish, player, track?.resumeKey]);
+
+  const value = useMemo<AudioContextValue>(
+    () => ({
+      currentUrl,
+      isLoaded: status.isLoaded && !status.error,
+      playing: status.playing,
+      currentTime: status.isLoaded ? status.currentTime : 0,
+      duration: status.isLoaded ? status.duration : 0,
+      error: !!status.error,
+      playTrack,
+      toggle: () => void (status.playing ? player.pause() : player.play()),
+      pause: () => void player.pause(),
+      seekTo: (seconds: number) => void player.seekTo(seconds),
+      isCurrent: (audioUrl: string) => currentUrl === audioUrl,
+    }),
+    [currentUrl, status, player, playTrack],
+  );
+
+  return (
+    <AudioContext.Provider value={value}>{children}</AudioContext.Provider>
+  );
+};
+
+/** Access the app-wide audio player. Must be used within an AudioProvider. */
+export const useAudio = (): AudioContextValue => {
+  const ctx = useContext(AudioContext);
+  if (!ctx) {
+    throw new Error("useAudio must be used within an AudioProvider");
+  }
+  return ctx;
+};

--- a/src/helpers/utils/audio.ts
+++ b/src/helpers/utils/audio.ts
@@ -1,0 +1,13 @@
+// Resume bounds: don't bother restoring positions in the very beginning, and
+// treat positions close to the end as finished.
+export const RESUME_MIN_SECONDS = 10;
+export const RESUME_END_MARGIN_SECONDS = 10;
+// Persist at most every few seconds of playback, not on every 250ms tick.
+export const RESUME_SAVE_INTERVAL_SECONDS = 5;
+
+/** Formats seconds as m:ss, e.g. 2592 -> "43:12". */
+export const formatTime = (seconds: number) => {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+};

--- a/src/hooks/useFavorite.ts
+++ b/src/hooks/useFavorite.ts
@@ -4,8 +4,8 @@ import { Achievements } from "#/helpers/Achievements";
 import FavoritesStore from "#/helpers/Stores/FavoritesStore";
 import { registerFav } from "#/helpers/network/Engagement";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
-import type { FaveableType, HttpsUrl, InstaPostProperties } from "#/types";
-import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA } from "#/types";
+import type { FavPayload, FaveableType, HttpsUrl } from "#/types";
+import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA, FAV_TYPE_PODCAST } from "#/types";
 
 /**
  * Encapsulates the "is this content saved as a favorite" state and the toggle behavior
@@ -21,7 +21,7 @@ export const useFavorite = (
   contentFavIdentifier?: string,
   contentType?: FaveableType,
   registerUrl?: HttpsUrl,
-  favPayload?: InstaPostProperties,
+  favPayload?: FavPayload,
 ) => {
   const [isFav, setIsFav] = useState(false);
 
@@ -52,7 +52,9 @@ export const useFavorite = (
         contentFavIdentifier,
         contentType,
         contentType === FAV_TYPE_ARTICLE ? registerUrl : undefined,
-        contentType === FAV_TYPE_INSTA ? favPayload : undefined,
+        contentType === FAV_TYPE_INSTA || contentType === FAV_TYPE_PODCAST
+          ? favPayload
+          : undefined,
       );
       updateBadgeState({ personal: true });
       if (registerUrl) await registerFav(registerUrl);

--- a/src/screens/Home/fetchers/FeedFetcher.ts
+++ b/src/screens/Home/fetchers/FeedFetcher.ts
@@ -6,6 +6,7 @@ import type { FeedFetcherType, FeedType } from "#/types";
 import { BlueskyFetcher } from "./BlueskyFetcher";
 import { BotFetcher } from "./BotFetcher";
 import { InstagramFetcher } from "./InstagramFetcher";
+import { PodcastFetcher } from "./PodcastFetcher";
 import { TikTokFetcher } from "./TikTokFetcher";
 import { WordPressFetcher } from "./WordPressFetcher";
 import { YouTubeFetcher } from "./YouTubeFetcher";
@@ -47,6 +48,7 @@ export class FeedFetcher {
     tiktok: TikTokFetcher.feedFetcher,
     bsky: BlueskyFetcher.feedFetcher,
     bot: BotFetcher.feedFetcher,
+    podcast: PodcastFetcher.feedFetcher,
     ...perFeedFetcherMap,
   };
 }

--- a/src/screens/Home/fetchers/PodcastFetcher.ts
+++ b/src/screens/Home/fetchers/PodcastFetcher.ts
@@ -1,0 +1,35 @@
+import PodcastPost from "#/components/posts/PodcastPost";
+import Post from "#/helpers/Post";
+import API from "#/helpers/network/ServerAPI";
+import { isHttpsUrl } from "#/helpers/utils/networking";
+import type { PodcastEpisodeProperties } from "#/types";
+
+import FetcherUtilities from "./FetcherUtilities";
+
+export const PodcastFetcher = {
+  feedFetcher: async ({ signal }: { signal?: AbortSignal } = {}) => {
+    const episodes = await FetcherUtilities.safeFetch(
+      () => API.getPodcastFeed(signal),
+      "podcast",
+    );
+    return episodes.flatMap((episode) => {
+      if (!episode.audio_url || !episode.published_at) return [];
+      // Guard against unparseable dates: a throw here would propagate past
+      // safeFetch and blank the whole combined feed, not just this episode.
+      const parsedDate = new Date(episode.published_at);
+      if (Number.isNaN(parsedDate.getTime())) return [];
+      // Normalize to the naive-UTC ISO shape the other fetchers use so the
+      // string-based datetime sort in FetcherUtilities stays consistent.
+      const datetime = parsedDate.toISOString().replace("Z", "");
+      return new Post<PodcastEpisodeProperties>(
+        datetime,
+        episode.id,
+        PodcastPost,
+        episode,
+        isHttpsUrl(episode.link)
+          ? [{ url: episode.link, title: "Podcast Folge teilen" }]
+          : undefined,
+      );
+    });
+  },
+};

--- a/src/screens/Home/fetchers/PodcastFetcher.ts
+++ b/src/screens/Home/fetchers/PodcastFetcher.ts
@@ -3,8 +3,38 @@ import Post from "#/helpers/Post";
 import API from "#/helpers/network/ServerAPI";
 import { isHttpsUrl } from "#/helpers/utils/networking";
 import type { PodcastEpisodeProperties } from "#/types";
+import { FAV_TYPE_PODCAST } from "#/types";
 
 import FetcherUtilities from "./FetcherUtilities";
+
+/**
+ * Maps a podcast episode to a feed Post (or null if it can't be shown). Shared
+ * by the feed fetcher and MyFavs so a favorited episode rebuilds identically.
+ */
+export const mapPodcastEpisode = (
+  episode: PodcastEpisodeProperties,
+): Post<PodcastEpisodeProperties> | null => {
+  if (!episode.audio_url || !episode.published_at) return null;
+  // Guard against unparseable dates: a throw here would propagate past
+  // safeFetch and blank the whole combined feed, not just this episode.
+  const parsedDate = new Date(episode.published_at);
+  if (Number.isNaN(parsedDate.getTime())) return null;
+  // Normalize to the naive-UTC ISO shape the other fetchers use so the
+  // string-based datetime sort in FetcherUtilities stays consistent.
+  const datetime = parsedDate.toISOString().replace("Z", "");
+  return new Post<PodcastEpisodeProperties>(
+    datetime,
+    episode.id,
+    PodcastPost,
+    episode,
+    isHttpsUrl(episode.link)
+      ? [{ url: episode.link, title: "Podcast Folge teilen" }]
+      : undefined,
+    1,
+    episode.id,
+    FAV_TYPE_PODCAST,
+  );
+};
 
 export const PodcastFetcher = {
   feedFetcher: async ({ signal }: { signal?: AbortSignal } = {}) => {
@@ -13,23 +43,8 @@ export const PodcastFetcher = {
       "podcast",
     );
     return episodes.flatMap((episode) => {
-      if (!episode.audio_url || !episode.published_at) return [];
-      // Guard against unparseable dates: a throw here would propagate past
-      // safeFetch and blank the whole combined feed, not just this episode.
-      const parsedDate = new Date(episode.published_at);
-      if (Number.isNaN(parsedDate.getTime())) return [];
-      // Normalize to the naive-UTC ISO shape the other fetchers use so the
-      // string-based datetime sort in FetcherUtilities stays consistent.
-      const datetime = parsedDate.toISOString().replace("Z", "");
-      return new Post<PodcastEpisodeProperties>(
-        datetime,
-        episode.id,
-        PodcastPost,
-        episode,
-        isHttpsUrl(episode.link)
-          ? [{ url: episode.link, title: "Podcast Folge teilen" }]
-          : undefined,
-      );
+      const post = mapPodcastEpisode(episode);
+      return post ? [post] : [];
     });
   },
 };

--- a/src/screens/PersonalTab/components/MyFavs.tsx
+++ b/src/screens/PersonalTab/components/MyFavs.tsx
@@ -16,12 +16,20 @@ import API from "#/helpers/network/ServerAPI";
 import WordPressAPI from "#/helpers/network/WordPressAPI";
 import { updateBadgeState } from "#/helpers/provider/BadgeProvider";
 import { findSecondaryWpFeed } from "#/helpers/utils/feeds";
+import { mapPodcastEpisode } from "#/screens/Home/fetchers/PodcastFetcher";
 import { WordPressFetcher } from "#/screens/Home/fetchers/WordPressFetcher";
-import type { ArticleProperties, HttpsUrl, InstaPostProperties } from "#/types";
-import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA } from "#/types";
+import type {
+  ArticleProperties,
+  HttpsUrl,
+  InstaPostProperties,
+  PodcastEpisodeProperties,
+} from "#/types";
+import { FAV_TYPE_ARTICLE, FAV_TYPE_INSTA, FAV_TYPE_PODCAST } from "#/types";
 
 type FavoritePost =
-  Post<{ article: ArticleProperties }> | Post<InstaPostProperties>;
+  | Post<{ article: ArticleProperties }>
+  | Post<InstaPostProperties>
+  | Post<PodcastEpisodeProperties>;
 
 // Reuse one API client per secondary site instead of rebuilding it for every
 // favorite on every load.
@@ -96,6 +104,26 @@ const loadFavoriteInstaPost = async (
   }
 };
 
+const loadFavoritePodcast = async (
+  id: string,
+  payload?: PodcastEpisodeProperties,
+): Promise<Post<PodcastEpisodeProperties> | undefined> => {
+  try {
+    // Prefer the snapshot stored with the favorite; Podigee has no by-id
+    // endpoint, so otherwise search the (server-cached) feed for the episode.
+    const episode =
+      payload ?? (await API.getPodcastFeed()).find((e) => e.id === id);
+    if (!episode) {
+      await FavoritesStore.removeFavorite(id);
+      return undefined;
+    }
+    return mapPodcastEpisode(episode) ?? undefined;
+  } catch (error) {
+    console.error(`Failed to load podcast favorite ${id}:`, error);
+    return undefined;
+  }
+};
+
 const MyFavs = () => {
   const [posts, setPosts] = useState<FavoritePost[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -118,7 +146,15 @@ const MyFavs = () => {
                 case FAV_TYPE_ARTICLE:
                   return await loadFavoriteArticlePost(fav, originalUrl);
                 case FAV_TYPE_INSTA:
-                  return await loadFavoriteInstaPost(fav, payload);
+                  return await loadFavoriteInstaPost(
+                    fav,
+                    payload as InstaPostProperties | undefined,
+                  );
+                case FAV_TYPE_PODCAST:
+                  return await loadFavoritePodcast(
+                    fav,
+                    payload as PodcastEpisodeProperties | undefined,
+                  );
               }
             } catch (error) {
               console.error(

--- a/src/types/feeds.ts
+++ b/src/types/feeds.ts
@@ -1,7 +1,7 @@
 import type { HttpsUrl } from "./config";
 
 export type FeedType =
-  "reddit" | "wp" | "insta" | "yt" | "tiktok" | "bsky" | "bot";
+  "reddit" | "wp" | "insta" | "yt" | "tiktok" | "bsky" | "bot" | "podcast";
 
 export type FeedEntry = {
   handle?: string;

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -145,6 +145,18 @@ export interface TiktokPostProperties {
   id: string;
 }
 
+export interface PodcastEpisodeProperties {
+  id: string;
+  title: string;
+  description: string;
+  published_at: string | null;
+  link: HttpsUrl | null;
+  audio_url: string;
+  image_url: string | null;
+  duration: number | null;
+  inView?: boolean;
+}
+
 export interface YouTubePostProperties {
   id: string;
   player: {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -11,6 +11,7 @@ export type ContentSettingType = {
   tiktok: SettingType;
   bsky: SettingType;
   bot: SettingType;
+  podcast: SettingType;
 } & {
   // One entry per configured WordPress feed, keyed by getWpFeedKey()
   [key: WpFeedKey]: SettingType;

--- a/src/types/stores.ts
+++ b/src/types/stores.ts
@@ -1,10 +1,19 @@
 import type { HttpsUrl } from "#/types/config";
-import type { InstaPostProperties } from "#/types/posts";
+import type {
+  InstaPostProperties,
+  PodcastEpisodeProperties,
+} from "#/types/posts";
 
 export const FAV_TYPE_ARTICLE = "article";
 export const FAV_TYPE_INSTA = "insta";
+export const FAV_TYPE_PODCAST = "podcast";
 
-export type FaveableType = typeof FAV_TYPE_ARTICLE | typeof FAV_TYPE_INSTA;
+export type FaveableType =
+  typeof FAV_TYPE_ARTICLE | typeof FAV_TYPE_INSTA | typeof FAV_TYPE_PODCAST;
+
+// Snapshot stored with a favorite for content that can't be re-fetched by id
+// (Instagram posts across accounts, podcast episodes that age out of the feed).
+export type FavPayload = InstaPostProperties | PodcastEpisodeProperties;
 
 export type ShareableType = {
   url: HttpsUrl;
@@ -17,11 +26,12 @@ export type StoredFav = {
   // secondary WordPress feed (e.g. Prüfpunkt) can be reloaded from the correct
   // site instead of the primary one, which would 404 and purge the favorite.
   originalUrl?: HttpsUrl;
-  // Snapshot of an Instagram post, captured when it is saved. The by-id
-  // proxy (/proxy/instaById) only serves the default account, so a post from a
-  // secondary account (e.g. Prüfpunkt) can't be re-fetched; this lets MyFavs
-  // rebuild it directly. Also survives the cold-start ContentStore.clear().
-  payload?: InstaPostProperties;
+  // Snapshot of an Instagram post or podcast episode, captured when it is
+  // saved. The by-id proxy (/proxy/instaById) only serves the default account,
+  // and Podigee has no by-id endpoint, so these can't reliably be re-fetched;
+  // this lets MyFavs rebuild them directly. Also survives the cold-start
+  // ContentStore.clear().
+  payload?: FavPayload;
 };
 
 export type StoredFavs = Record<string, StoredFav>;


### PR DESCRIPTION
## Summary
- New `"podcast"` feed type: episodes from the Podigee podcast appear as items in the home feed, fetched via the server's new `/proxy/podcastFeed` endpoint (companion PR: Volksverpetzer/vvp_app_server#27)
- `PodcastFetcher` maps episodes to `Post` objects with normalized naive-UTC datetimes; unparseable dates and non-https links are dropped defensively (a throw here would blank the whole combined feed)
- New `PodcastPost` card: cover, "Podcast" label, title, date | duration, description excerpt, play button
- `AudioPlayer` is mounted **lazily on tap** (no native player per card); new props: `autoPlay` (play on first tap), `showFeedback` (spinner/error instead of rendering nothing)
- **Resume playback**: position is persisted via `PersonalStore` (keyed by audio URL), survives scrolling/refresh/app restarts; the play button becomes "Fortsetzen bei 43:12" and playback continues from there; position clears when an episode finishes
- **Only one audio plays at a time** across the app — starting a player pauses the previously active one
- Content settings switch **"Podcast Folgen"**, on by default; gated by `feeds.podcast` in the Volksverpetzer config — hidden for Mimikama
- Play taps tracked via `registerPostInteraction(…, "podcast", "play")`

> Note: the feed stays empty until the server PR is deployed.

## Known limitations (deliberate for the first iteration)
- Scrolling far past a playing card unmounts the native player and pauses playback (position is preserved and resumable); a persistent mini-player would be the follow-up

## Test plan
- [x] `pnpm check` (tsc + cspell) and `pnpm lint:fix` clean
- [x] Jest: PodcastFetcher (mapping, bad-date/no-audio/non-https guards, errors), PodcastPost component states incl. resume label, AudioPlayer (autoPlay, showFeedback, single-active-player, restore/save/clear), PersonalStore audio positions, FeedFetcher registration
- [x] Adversarial review agent ran against the branch; all merge-blocking findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)