### PR TITLE
Fix share count for URLs without a trailing slash

### DIFF
--- a/__tests__/helpers/Networking/Engagement.test.ts
+++ b/__tests__/helpers/Networking/Engagement.test.ts
@@ -112,11 +112,50 @@ describe("Engagement", () => {
       expect(parseSpy).toHaveBeenCalledWith(
         "https://www.volksverpetzer.de/article",
       );
+      // The path is queried exactly as Plausible recorded it — no slash is
+      // appended, or the "Share" event for this page would never match.
       expect(getSpy).toHaveBeenCalledWith(
         expect.anything(),
-        "/proxy/shares/article/?site=volksverpetzer.de",
+        "/proxy/shares/article?site=volksverpetzer.de",
       );
       expect(result).toBe(42);
+    });
+
+    it("keeps the trailing slash of a WordPress permalink", async () => {
+      parseSpy.mockReturnValue({
+        path: "/faktencheck/slug/",
+        hostname: "www.volksverpetzer.de",
+      });
+      getSpy.mockResolvedValue({ events: 7 });
+
+      await getShares("https://www.volksverpetzer.de/faktencheck/slug/");
+
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "/proxy/shares/faktencheck/slug/?site=volksverpetzer.de",
+      );
+    });
+
+    it("queries a slash-less URL without adding one", async () => {
+      // Regression: podcast episode URLs have no trailing slash, so Plausible
+      // records "/25-folge-24". Querying "/25-folge-24/" matched nothing and
+      // the share count stayed at 0 no matter how often it was shared.
+      // URL-aware mock: the site lookup parses Config.wpUrl separately, and an
+      // unknown host falls back to that primary site.
+      parseSpy.mockImplementation((url: string) =>
+        url.includes("episode")
+          ? { path: "/25-folge-24", hostname: "podcast.example.com" }
+          : { path: "/", hostname: "www.volksverpetzer.de" },
+      );
+      getSpy.mockResolvedValue({ events: 3 });
+
+      const result = await getShares("https://podcast.example.com/episode");
+
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "/proxy/shares/25-folge-24?site=volksverpetzer.de",
+      );
+      expect(result).toBe(3);
     });
 
     it("should handle missing permalink by using default wpUrl", async () => {

--- a/src/helpers/network/Engagement.ts
+++ b/src/helpers/network/Engagement.ts
@@ -1,3 +1,5 @@
+import * as Linking from "expo-linking";
+
 import Config from "#/constants/Config";
 import { parsePath } from "#/helpers/Linking";
 import { registerEvent } from "#/helpers/network/Analytics";
@@ -15,6 +17,21 @@ const client = createClient(apiUrl);
  */
 const siteQuery = (permalink?: HttpsUrl): string =>
   `?site=${encodeURIComponent(resolveAnalyticsSite(permalink ?? wpUrl))}`;
+
+/**
+ * Path of a resource as Plausible records it, i.e. exactly the path of the URL
+ * the event was reported for — including whether it ends in a slash.
+ *
+ * `parsePath` deliberately forces a trailing slash (it normalizes WordPress
+ * canonical-redirect variants for the in-app WebView), but Plausible stores
+ * `event:page` verbatim: a share of ".../25-folge-24" is recorded under
+ * "/25-folge-24", so querying "/25-folge-24/" matches nothing. Since the same
+ * permalink feeds both registerEvent and this lookup, preserving the URL's own
+ * shape keeps write and read consistent for any URL. WordPress permalinks
+ * already end in a slash, so article counts are unaffected.
+ */
+export const analyticsPath = (url: string): string =>
+  (Linking.parse(url).path ?? "").replace(/^\/+/, "");
 
 /**
  * Returns the page views for the current permalink
@@ -42,7 +59,9 @@ const getShares = async (permalink?: HttpsUrl): Promise<number> => {
   try {
     const data = await get<{ events: number }>(
       client,
-      `/proxy/shares/${parsePath(permalink ?? wpUrl)}${siteQuery(permalink)}`,
+      // Uses analyticsPath (not parsePath): the shares route preserves the
+      // path it's given, so a slash-less permalink is queried as recorded.
+      `/proxy/shares/${analyticsPath(permalink ?? wpUrl)}${siteQuery(permalink)}`,
     );
     return data.events;
   } catch (error) {

--- a/src/helpers/network/Engagement.ts
+++ b/src/helpers/network/Engagement.ts
@@ -30,7 +30,7 @@ const siteQuery = (permalink?: HttpsUrl): string =>
  * shape keeps write and read consistent for any URL. WordPress permalinks
  * already end in a slash, so article counts are unaffected.
  */
-export const analyticsPath = (url: string): string =>
+const analyticsPath = (url: string): string =>
   (Linking.parse(url).path ?? "").replace(/^\/+/, "");
 
 /**


### PR DESCRIPTION
## The bug
Sharing a link bumped the share number by one, but it reset to 0 on the next load — the count never actually stuck for URLs that don't end in a slash.

**Why:** `getShares` built its lookup path with `parsePath`, which always appends a trailing slash. Plausible stores `event:page` verbatim (derived from the URL's pathname, query dropped), so:

| | page |
|---|---|
| `"Share"` event recorded for `…/25-folge-24` | `/25-folge-24` |
| count queried by the app | `/25-folge-24/` |

The two never match, so the query returns 0 forever. WordPress permalinks already end in a slash, which is why articles were unaffected and this went unnoticed.

## The fix
Add `analyticsPath`, which preserves the URL's own shape, and use it for the shares lookup. The same permalink feeds both `registerEvent` and this lookup, so write and read now agree **for any URL** — rather than only for URLs that happen to end in a slash. Article counts are unchanged (their permalinks already have the slash).

`parsePath` itself is deliberately **not** touched: its forced trailing slash normalizes WordPress canonical-redirect variants for the in-app WebView (the white-page-loop regression fixed in #326, with a test pinning it).

## Expected effect after release
Share counts that were pinned at 0 will start showing their real value for every slash-less shareable — Bluesky, Bot feed, TikTok, YouTube, podcast episodes, and the `/unterstutzen` support link. Expect a visible one-off jump on those cards. Articles and Instagram (both already slash-terminated) are byte-identical.

## Known gap — the other three counters
Only the **share** count is fixed here. The `stats` (views), `favs` and `links` proxy routes require a trailing slash in the Django route *and* hard-code `page = f"/{remaining}/"` server-side, so slash-less URLs can't be counted there without a backend change.

Consequence worth knowing: for a slash-less resource the app now asks Plausible about two different pages for the same card — shares at `/x`, views/favs at `/x/`. Those view/fav counts were already permanently 0, so nothing regresses, but a correct share count sitting next to a 0 view count may look odd until the backend routes are fixed. Happy to do that as a follow-up.

## Test plan
- [x] `pnpm test` — full suite green
- [x] New tests: slash-less URL queried as recorded, WordPress permalink keeps its slash
- [x] `pnpm check` (tsc + cspell) and `pnpm lint` clean
- [x] Adversarial review pass: diagnosis confirmed (path, site and backend routing all line up), no merge-blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)