### PR TITLE
Add Typography component for shared title/meta text roles

### DIFF
--- a/__tests__/components/ui/Typography.test.tsx
+++ b/__tests__/components/ui/Typography.test.tsx
@@ -28,6 +28,16 @@ describe("Typography", () => {
     expect(style.fontSize).toBe(fontSizes.xxl);
     expect(style.fontFamily).toBe("SourceSansProBold");
     expect(style.color).toBe(Colors.light.text);
+    expect(style.textAlign).toBe("left");
+  });
+
+  it("applies the card-title role's line height", async () => {
+    const style = await styleOf(
+      <Typography type="cardTitle">Titel</Typography>,
+    );
+
+    expect(style.fontSize).toBe(fontSizes.xl);
+    expect(style.lineHeight).toBe(26);
   });
 
   it("renders a muted meta line", async () => {

--- a/__tests__/components/ui/Typography.test.tsx
+++ b/__tests__/components/ui/Typography.test.tsx
@@ -1,0 +1,52 @@
+import { render } from "@testing-library/react-native";
+
+import Typography from "#/components/ui/Typography";
+import Colors from "#/constants/Colors";
+import { fontSizes } from "#/constants/FontSizes";
+
+type RenderedNode = {
+  props: Record<string, unknown>;
+};
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (!style) return {};
+  if (Array.isArray(style))
+    return Object.assign({}, ...style.map(flattenStyle));
+  return style as Record<string, unknown>;
+}
+
+const styleOf = async (element: React.ReactElement) => {
+  const { toJSON } = await render(element);
+  const tree = toJSON() as RenderedNode;
+  return flattenStyle(tree.props.style);
+};
+
+describe("Typography", () => {
+  it("renders a title with the screen-title role", async () => {
+    const style = await styleOf(<Typography type="title">Titel</Typography>);
+
+    expect(style.fontSize).toBe(fontSizes.xxl);
+    expect(style.fontFamily).toBe("SourceSansProBold");
+    expect(style.color).toBe(Colors.light.text);
+  });
+
+  it("renders a muted meta line", async () => {
+    const style = await styleOf(
+      <Typography type="meta">Autor | 1.1.2026 | 5 Min.</Typography>,
+    );
+
+    expect(style.fontSize).toBe(fontSizes.sm);
+    expect(style.fontFamily).toBe("SourceSansPro");
+    expect(style.color).toBe(Colors.light.textMuted);
+  });
+
+  it("lets an explicit style override the role's color", async () => {
+    const style = await styleOf(
+      <Typography type="meta" style={{ color: "#123456" }}>
+        Autor
+      </Typography>,
+    );
+
+    expect(style.color).toBe("#123456");
+  });
+});

--- a/__tests__/components/ui/Typography.test.tsx
+++ b/__tests__/components/ui/Typography.test.tsx
@@ -2,7 +2,7 @@ import { render } from "@testing-library/react-native";
 
 import Typography from "#/components/ui/Typography";
 import Colors from "#/constants/Colors";
-import { fontSizes } from "#/constants/FontSizes";
+import { LINE_HEIGHTS, fontSizes } from "#/constants/FontSizes";
 
 type RenderedNode = {
   props: Record<string, unknown>;
@@ -37,7 +37,7 @@ describe("Typography", () => {
     );
 
     expect(style.fontSize).toBe(fontSizes.xl);
-    expect(style.lineHeight).toBe(26);
+    expect(style.lineHeight).toBe(LINE_HEIGHTS.xl);
   });
 
   it("renders a muted meta line", async () => {

--- a/__tests__/components/ui/UiText.test.tsx
+++ b/__tests__/components/ui/UiText.test.tsx
@@ -22,45 +22,30 @@ const styleOf = async (element: React.ReactElement) => {
 };
 
 describe("UiText", () => {
-  it("applies size and weight from a variant", async () => {
-    const style = await styleOf(<UiText variant="title">Titel</UiText>);
-
-    expect(style.fontSize).toBe(fontSizes.xxl);
-    expect(style.fontFamily).toBe("SourceSansProBold");
-    expect(style.color).toBe(Colors.light.text);
-  });
-
-  it("applies the muted tone for meta text", async () => {
-    const style = await styleOf(
-      <UiText variant="meta">Autor | 1.1.2026</UiText>,
-    );
-
-    expect(style.fontSize).toBe(fontSizes.sm);
-    expect(style.fontFamily).toBe("SourceSansPro");
-    expect(style.color).toBe(Colors.light.textMuted);
-  });
-
-  it("lets explicit props and styles override the variant", async () => {
-    const style = await styleOf(
-      <UiText
-        variant="title"
-        size="sm"
-        bold={false}
-        style={{ color: "#ff0000" }}
-      >
-        Titel
-      </UiText>,
-    );
-
-    expect(style.fontSize).toBe(fontSizes.sm);
-    expect(style.fontFamily).toBe("SourceSansPro");
-    expect(style.color).toBe("#ff0000");
-  });
-
-  it("falls back to the default text color without a variant", async () => {
+  it("applies the font-scale size and default text color", async () => {
     const style = await styleOf(<UiText size="base">Text</UiText>);
 
     expect(style.fontSize).toBe(fontSizes.base);
+    expect(style.fontFamily).toBe("SourceSansPro");
     expect(style.color).toBe(Colors.light.text);
+  });
+
+  it("renders bold in the bold font family", async () => {
+    const style = await styleOf(
+      <UiText bold size="xl">
+        Text
+      </UiText>,
+    );
+
+    expect(style.fontFamily).toBe("SourceSansProBold");
+    expect(style.fontSize).toBe(fontSizes.xl);
+  });
+
+  it("lets an explicit style color override the default", async () => {
+    const style = await styleOf(
+      <UiText style={{ color: "#ff0000" }}>Text</UiText>,
+    );
+
+    expect(style.color).toBe("#ff0000");
   });
 });

--- a/__tests__/components/ui/UiText.test.tsx
+++ b/__tests__/components/ui/UiText.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react-native";
+
+import UiText from "#/components/ui/UiText";
+import Colors from "#/constants/Colors";
+import { fontSizes } from "#/constants/FontSizes";
+
+type RenderedNode = {
+  props: Record<string, unknown>;
+};
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (!style) return {};
+  if (Array.isArray(style))
+    return Object.assign({}, ...style.map(flattenStyle));
+  return style as Record<string, unknown>;
+}
+
+const styleOf = async (element: React.ReactElement) => {
+  const { toJSON } = await render(element);
+  const tree = toJSON() as RenderedNode;
+  return flattenStyle(tree.props.style);
+};
+
+describe("UiText", () => {
+  it("applies size and weight from a variant", async () => {
+    const style = await styleOf(<UiText variant="title">Titel</UiText>);
+
+    expect(style.fontSize).toBe(fontSizes.xxl);
+    expect(style.fontFamily).toBe("SourceSansProBold");
+    expect(style.color).toBe(Colors.light.text);
+  });
+
+  it("applies the muted tone for meta text", async () => {
+    const style = await styleOf(
+      <UiText variant="meta">Autor | 1.1.2026</UiText>,
+    );
+
+    expect(style.fontSize).toBe(fontSizes.sm);
+    expect(style.fontFamily).toBe("SourceSansPro");
+    expect(style.color).toBe(Colors.light.textMuted);
+  });
+
+  it("lets explicit props and styles override the variant", async () => {
+    const style = await styleOf(
+      <UiText
+        variant="title"
+        size="sm"
+        bold={false}
+        style={{ color: "#ff0000" }}
+      >
+        Titel
+      </UiText>,
+    );
+
+    expect(style.fontSize).toBe(fontSizes.sm);
+    expect(style.fontFamily).toBe("SourceSansPro");
+    expect(style.color).toBe("#ff0000");
+  });
+
+  it("falls back to the default text color without a variant", async () => {
+    const style = await styleOf(<UiText size="base">Text</UiText>);
+
+    expect(style.fontSize).toBe(fontSizes.base);
+    expect(style.color).toBe(Colors.light.text);
+  });
+});

--- a/src/app/(tabs)/contact.tsx
+++ b/src/app/(tabs)/contact.tsx
@@ -118,7 +118,7 @@ const ContactScreen = () => {
         },
         categoryPill: {
           backgroundColor: surfaceInput,
-          borderRadius: 20,
+          borderRadius: radii.full,
           paddingHorizontal: 14,
           paddingVertical: 8,
         },
@@ -157,7 +157,7 @@ const ContactScreen = () => {
           alignItems: "center",
           alignSelf: "center",
           backgroundColor: accent,
-          borderRadius: 40,
+          borderRadius: radii.full,
           justifyContent: "center",
           margin: 20,
           paddingVertical: 10,

--- a/src/app/(tabs)/contact.tsx
+++ b/src/app/(tabs)/contact.tsx
@@ -130,7 +130,6 @@ const ContactScreen = () => {
         },
         errorText: {
           color: errorColor,
-          fontFamily: "SourceSansProBold",
           marginBottom: 20,
           paddingHorizontal: 12,
           textAlign: "center",
@@ -423,7 +422,7 @@ const ContactScreen = () => {
           </View>
           <UiSpace size={20} />
           {error ? (
-            <UiText size="lg" style={styles.errorText}>
+            <UiText size="lg" bold style={styles.errorText}>
               {error}
             </UiText>
           ) : undefined}

--- a/src/app/(tabs)/contact.tsx
+++ b/src/app/(tabs)/contact.tsx
@@ -15,6 +15,7 @@ import { ScrollView } from "react-native-gesture-handler";
 
 import AnimatedHeader from "#/components/animations/AnimatedHeader";
 import AnimatedSuccess from "#/components/animations/AnimatedSuccess";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
@@ -325,93 +326,101 @@ const ContactScreen = () => {
           )}
           scrollEventThrottle={16}
         >
-          <UiText bold size="lg" style={{ marginBottom: 10 }}>
-            Thema wählen:
-          </UiText>
-          <View style={styles.categoryContainer}>
-            {CATEGORIES.map(({ key, label }) => (
-              <UiPressable
-                key={key}
-                accessibilityRole="button"
-                accessibilityState={{ selected: category === key }}
-                onPress={() => {
-                  setCategory(key);
-                  clearError();
-                }}
-                style={[
-                  styles.categoryPill,
-                  category === key && styles.categoryPillActive,
-                ]}
-              >
-                <UiText
+          <View style={{ gap: 10 }}>
+            <Typography type="heading">Thema wählen:</Typography>
+            <View style={styles.categoryContainer}>
+              {CATEGORIES.map(({ key, label }) => (
+                <UiPressable
+                  key={key}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: category === key }}
+                  onPress={() => {
+                    setCategory(key);
+                    clearError();
+                  }}
                   style={[
-                    globalStyles.pillLabel,
-                    category === key
-                      ? globalStyles.whiteText
-                      : styles.categoryPillLabelInactive,
+                    styles.categoryPill,
+                    category === key && styles.categoryPillActive,
                   ]}
                 >
-                  {label}
-                </UiText>
-              </UiPressable>
-            ))}
+                  <UiText
+                    style={[
+                      globalStyles.pillLabel,
+                      category === key
+                        ? globalStyles.whiteText
+                        : styles.categoryPillLabelInactive,
+                    ]}
+                  >
+                    {label}
+                  </UiText>
+                </UiPressable>
+              ))}
+            </View>
           </View>
           <UiSpace size={20} />
-          <UiText bold size="lg" style={{ marginBottom: 10 }}>
-            {texts.titleLabel}
-          </UiText>
-          <UiTextInput
-            accessibilityLabel="Text input field"
-            accessibilityHint={texts.titleHint}
-            placeholder="..."
-            placeholderTextColor={textColor}
-            value={title}
-            onChangeText={(value) => {
-              setTitle(value);
-              if (errorField === "title") clearError();
-            }}
-            style={[styles.input, errorField === "title" && styles.inputError]}
-          />
+          <View style={{ gap: 10 }}>
+            <Typography type="heading">{texts.titleLabel}</Typography>
+            <UiTextInput
+              accessibilityLabel="Text input field"
+              accessibilityHint={texts.titleHint}
+              placeholder="..."
+              placeholderTextColor={textColor}
+              value={title}
+              onChangeText={(value) => {
+                setTitle(value);
+                if (errorField === "title") clearError();
+              }}
+              style={[
+                styles.input,
+                errorField === "title" && styles.inputError,
+              ]}
+            />
+          </View>
           <UiSpace size={20} />
-          <UiText bold size="lg" style={{ marginBottom: 10 }}>
-            {texts.messageLabel}
-          </UiText>
-          <UiTextInput
-            accessibilityLabel="Text input field"
-            accessibilityHint="Gib deine Nachricht ein"
-            placeholder="..."
-            placeholderTextColor={textColor}
-            value={message}
-            onChangeText={(value) => {
-              setMessage(value);
-              if (errorField === "message") clearError();
-            }}
-            multiline
-            style={[
-              styles.input,
-              { height: 120 },
-              errorField === "message" && styles.inputError,
-            ]}
-          />
+          <View style={{ gap: 10 }}>
+            <Typography type="heading">{texts.messageLabel}</Typography>
+            <UiTextInput
+              accessibilityLabel="Text input field"
+              accessibilityHint="Gib deine Nachricht ein"
+              placeholder="..."
+              placeholderTextColor={textColor}
+              value={message}
+              onChangeText={(value) => {
+                setMessage(value);
+                if (errorField === "message") clearError();
+              }}
+              multiline
+              style={[
+                styles.input,
+                { height: 120 },
+                errorField === "message" && styles.inputError,
+              ]}
+            />
+          </View>
           <UiSpace size={20} />
-          <UiText bold size="lg" style={{ marginBottom: 10 }}>
-            E-Mail für Rückfragen (optional)
-          </UiText>
-          <UiTextInput
-            accessibilityLabel="Text input field"
-            accessibilityHint="Gib deine E-Mail-Adresse ein"
-            placeholder="..."
-            placeholderTextColor={textColor}
-            value={email}
-            onChangeText={(value) => {
-              setEmail(value);
-              if (errorField === "email") clearError();
-            }}
-            autoCapitalize="none"
-            autoComplete="email"
-            keyboardType="email-address"
-            style={[styles.input, errorField === "email" && styles.inputError]}
-          />
+          <View style={{ gap: 10 }}>
+            <Typography type="heading">
+              E-Mail für Rückfragen (optional)
+            </Typography>
+            <UiTextInput
+              accessibilityLabel="Text input field"
+              accessibilityHint="Gib deine E-Mail-Adresse ein"
+              placeholder="..."
+              placeholderTextColor={textColor}
+              value={email}
+              onChangeText={(value) => {
+                setEmail(value);
+                if (errorField === "email") clearError();
+              }}
+              autoCapitalize="none"
+              autoComplete="email"
+              keyboardType="email-address"
+              style={[
+                styles.input,
+                errorField === "email" && styles.inputError,
+              ]}
+            />
+          </View>
           <UiSpace size={20} />
           {error ? (
             <UiText size="lg" style={styles.errorText}>

--- a/src/app/+not-found.tsx
+++ b/src/app/+not-found.tsx
@@ -3,7 +3,7 @@ import { ScrollView, View } from "react-native";
 
 import { ErrorIcon } from "#/components/Icons";
 import NavBar from "#/components/bars/NavBar";
-import UiText from "#/components/ui/UiText";
+import Typography from "#/components/ui/Typography";
 import EmptyComponent from "#/components/views/EmptyComponent";
 import Colors from "#/constants/Colors";
 import { globalStyles } from "#/constants/GlobalStyles";
@@ -26,9 +26,7 @@ const NotFoundScreen = () => {
           },
         ]}
       >
-        <UiText bold size="lg">
-          404 Whoops!
-        </UiText>
+        <Typography type="heading">404 Whoops!</Typography>
         <EmptyComponent
           text="Die angeforderte Seite konnte nicht gefunden werden."
           icon={<ErrorIcon size={60} />}

--- a/src/app/game/[level].tsx
+++ b/src/app/game/[level].tsx
@@ -83,7 +83,7 @@ const GameScreen = () => {
         { backgroundColor: Colors[colorScheme].background },
       ]}
     >
-      <UiText size="xl" style={styles.title}>
+      <UiText size="xl" bold style={styles.title}>
         Memory-Spiel: {gameId}
       </UiText>
       <View style={styles.levelContainer}>
@@ -149,7 +149,7 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   levelText: { marginRight: 10 },
-  title: { fontFamily: "SourceSansProBold", marginBottom: 20 },
+  title: { marginBottom: 20 },
 });
 
 export default GameScreen;

--- a/src/app/game/index.tsx
+++ b/src/app/game/index.tsx
@@ -17,7 +17,7 @@ const HomeScreen = () => {
         { backgroundColor: Colors[colorScheme].background },
       ]}
     >
-      <UiText size="xxl" style={styles.title}>
+      <UiText size="xxl" bold style={styles.title}>
         Willkommen zum Memory-Spiel
       </UiText>
       <UiText size="base" style={styles.description}>
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
     fontFamily: "SourceSansPro",
     fontSize: fontSizes.base,
   },
-  title: { fontFamily: "SourceSansProBold", marginBottom: 20 },
+  title: { marginBottom: 20 },
 });
 
 export default HomeScreen;

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -8,6 +8,7 @@ import { AppState, Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { FeedIcon, NotificationIcon, SafetyIcon } from "#/components/Icons";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import SettingsList from "#/components/views/SettingsList";
@@ -180,9 +181,7 @@ const Onboarding = () => {
             }}
           >
             <FeedIcon color={corporate} size={20} />
-            <UiText bold size="lg" style={{ textAlign: "left" }}>
-              Feed-Einstellungen
-            </UiText>
+            <Typography type="heading">Feed-Einstellungen</Typography>
           </View>
           <SettingsList
             saveSettings={saveContentSetting}

--- a/src/app/podcast/[id].tsx
+++ b/src/app/podcast/[id].tsx
@@ -9,7 +9,6 @@ import NavBar from "#/components/bars/NavBar";
 import Typography from "#/components/ui/Typography";
 import UiSpace from "#/components/ui/UiSpace";
 import UiSpinner from "#/components/ui/UiSpinner";
-import UiText from "#/components/ui/UiText";
 import Footer from "#/components/views/Footer";
 import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
@@ -131,15 +130,12 @@ const PodcastScreen = () => {
         <UiSpace size={12} />
 
         {!!episode.description && (
-          <UiText
-            size="base"
-            style={{
-              paddingHorizontal: POST_PADDING_HORIZONTAL,
-              textAlign: "left",
-            }}
+          <Typography
+            type="body"
+            style={{ paddingHorizontal: POST_PADDING_HORIZONTAL }}
           >
             {episode.description}
-          </UiText>
+          </Typography>
         )}
 
         {episode.link && (

--- a/src/app/podcast/[id].tsx
+++ b/src/app/podcast/[id].tsx
@@ -6,6 +6,7 @@ import { ScrollView } from "react-native-gesture-handler";
 
 import AudioPlayer from "#/components/audio/AudioPlayer";
 import NavBar from "#/components/bars/NavBar";
+import Typography from "#/components/ui/Typography";
 import UiSpace from "#/components/ui/UiSpace";
 import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
@@ -47,7 +48,6 @@ const PodcastScreen = () => {
   const colorScheme = useAppColorScheme();
   const corporate = useCorporateColor();
   const backgroundColor = Colors[colorScheme].background;
-  const greyText = Colors[colorScheme].textMuted;
 
   useEffect(() => {
     const controller = new AbortController();
@@ -112,19 +112,13 @@ const PodcastScreen = () => {
         )}
         <UiSpace size={16} />
         <View style={{ paddingHorizontal: POST_PADDING_HORIZONTAL }}>
-          <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
-            Podcast
-          </UiText>
-          <UiText
-            size="xl"
-            style={{ fontFamily: "SourceSansProBold", textAlign: "left" }}
-          >
+          <Typography type="title" style={{ textAlign: "left" }}>
             {episode.title}
-          </UiText>
+          </Typography>
           {!!dateDurationText && (
-            <UiText size="sm" style={{ color: greyText, textAlign: "left" }}>
+            <Typography type="meta" style={{ textAlign: "left" }}>
               {dateDurationText}
-            </UiText>
+            </Typography>
           )}
         </View>
 

--- a/src/app/podcast/[id].tsx
+++ b/src/app/podcast/[id].tsx
@@ -112,13 +112,9 @@ const PodcastScreen = () => {
         )}
         <UiSpace size={16} />
         <View style={{ paddingHorizontal: POST_PADDING_HORIZONTAL }}>
-          <Typography type="title" style={{ textAlign: "left" }}>
-            {episode.title}
-          </Typography>
+          <Typography type="title">{episode.title}</Typography>
           {!!dateDurationText && (
-            <Typography type="meta" style={{ textAlign: "left" }}>
-              {dateDurationText}
-            </Typography>
+            <Typography type="meta">{dateDurationText}</Typography>
           )}
         </View>
 

--- a/src/components/popups/ChangelogModal.tsx
+++ b/src/components/popups/ChangelogModal.tsx
@@ -7,6 +7,7 @@ import UiText from "#/components/ui/UiText";
 import { radii } from "#/constants/BorderRadius";
 import Changelog from "#/constants/Changelog";
 import Colors from "#/constants/Colors";
+import { LINE_HEIGHTS } from "#/constants/FontSizes";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
 interface ChangelogModalProperties {
@@ -61,7 +62,7 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
   notes: {
-    lineHeight: 22,
+    lineHeight: LINE_HEIGHTS.base,
   },
   button: {
     alignItems: "center",

--- a/src/components/popups/ChangelogModal.tsx
+++ b/src/components/popups/ChangelogModal.tsx
@@ -42,7 +42,7 @@ const ChangelogModal = ({ isVisible, onClose }: ChangelogModalProperties) => {
         onPress={onClose}
         style={[styles.button, { backgroundColor: corporate }]}
       >
-        <UiText size="base" style={[styles.buttonText, { color: onPrimary }]}>
+        <UiText size="base" bold style={{ color: onPrimary }}>
           Alles klar
         </UiText>
       </UiPressable>
@@ -67,9 +67,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     borderRadius: radii.md,
     paddingVertical: 14,
-  },
-  buttonText: {
-    fontFamily: "SourceSansProBold",
   },
 });
 

--- a/src/components/popups/MissionPopup.tsx
+++ b/src/components/popups/MissionPopup.tsx
@@ -33,13 +33,7 @@ const MissionPopup = ({ text1, text2 }: MissionPopupProperties) => {
     >
       <View style={{ flexDirection: "row", justifyContent: "flex-start" }}>
         <SuccessIcon size={24} color={corporate} />
-        <UiText
-          style={{
-            paddingLeft: 10,
-            color: corporate,
-            fontFamily: "SourceSansProBold",
-          }}
-        >
+        <UiText bold style={{ paddingLeft: 10, color: corporate }}>
           {text1}
         </UiText>
       </View>

--- a/src/components/popups/ToastShareSheet.tsx
+++ b/src/components/popups/ToastShareSheet.tsx
@@ -20,7 +20,7 @@ const ToastShareSheet = ({ items, onCancel }: ToastShareSheetProperties) => {
         { backgroundColor: Colors[colorScheme].background },
       ]}
     >
-      <UiText size="lg" style={styles.title}>
+      <UiText size="lg" bold style={styles.title}>
         Teilen
       </UiText>
       <ScrollView style={styles.list}>
@@ -41,7 +41,11 @@ const ToastShareSheet = ({ items, onCancel }: ToastShareSheetProperties) => {
           style={[styles.button, styles.cancelButton]}
           onPress={onCancel}
         >
-          <UiText size="base" style={[styles.buttonText, styles.cancelText]}>
+          <UiText
+            size="base"
+            bold
+            style={[styles.buttonText, styles.cancelText]}
+          >
             Abbrechen
           </UiText>
         </UiPressable>
@@ -67,7 +71,6 @@ const styles = StyleSheet.create({
   },
   cancelText: {
     color: "#b00",
-    fontFamily: "SourceSansProBold",
   },
   container: {
     alignItems: "center",
@@ -81,7 +84,6 @@ const styles = StyleSheet.create({
   },
   title: {
     color: "#333",
-    fontFamily: "SourceSansProBold",
     marginBottom: 12,
   },
 });

--- a/src/components/posts/AnnouncementCard.tsx
+++ b/src/components/posts/AnnouncementCard.tsx
@@ -70,7 +70,7 @@ const AnnouncementCard = ({
             switch (token.type) {
               case "bold":
                 return (
-                  <UiText key={key} style={{ fontFamily: "SourceSansProBold" }}>
+                  <UiText key={key} bold>
                     {token.content}
                   </UiText>
                 );
@@ -122,13 +122,7 @@ const AnnouncementCard = ({
               paddingVertical: 12,
             }}
           >
-            <UiText
-              size="base"
-              style={{
-                color: text,
-                fontFamily: "SourceSansProBold",
-              }}
-            >
+            <UiText size="base" bold style={{ color: text }}>
               Alles klar!
             </UiText>
           </UiPressable>
@@ -143,13 +137,7 @@ const AnnouncementCard = ({
               paddingVertical: 12,
             }}
           >
-            <UiText
-              size="base"
-              style={{
-                color: onPrimary,
-                fontFamily: "SourceSansProBold",
-              }}
-            >
+            <UiText size="base" bold style={{ color: onPrimary }}>
               {announcement.actionLabel}
             </UiText>
           </UiPressable>

--- a/src/components/posts/AnnouncementCard.tsx
+++ b/src/components/posts/AnnouncementCard.tsx
@@ -9,6 +9,7 @@ import UiText from "#/components/ui/UiText";
 import type { AnnouncementEntry } from "#/constants/Announcements";
 import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
+import { LINE_HEIGHTS } from "#/constants/FontSizes";
 import { AppImages } from "#/helpers/AppImages";
 import { onLinkPress } from "#/helpers/Linking";
 import { parseInlineMarkdown } from "#/helpers/utils/inlineMarkdown";
@@ -64,7 +65,7 @@ const AnnouncementCard = ({
         />
       )}
       <UiCard>
-        <UiText size="base" style={{ lineHeight: 22 }}>
+        <UiText size="base" style={{ lineHeight: LINE_HEIGHTS.base }}>
           {parseInlineMarkdown(announcement.message).map((token, index) => {
             const key = String(index);
             switch (token.type) {

--- a/src/components/posts/ArticlePost.tsx
+++ b/src/components/posts/ArticlePost.tsx
@@ -14,7 +14,7 @@ import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
 import Config from "#/constants/Config";
 import {
-  CARD_TITLE_META_GAP,
+  CARD_CONTENT_GAP,
   DEFAULT_IMAGE_ASPECT_RATIO,
   POST_PADDING_HORIZONTAL,
   globalStyles,
@@ -241,7 +241,7 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
         </View>
         <View style={progressBarStyle} />
         <UiSpace size={10} />
-        <View style={{ gap: CARD_TITLE_META_GAP }}>
+        <View style={{ gap: CARD_CONTENT_GAP }}>
           <Typography type="cardTitle" style={titleStyle}>
             {article.title}
           </Typography>

--- a/src/components/posts/ArticlePost.tsx
+++ b/src/components/posts/ArticlePost.tsx
@@ -5,6 +5,7 @@ import type { DimensionValue, TextStyle } from "react-native";
 import { View } from "react-native";
 
 import ViewCounter from "#/components/counter/ViewCounter";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiSpinner from "#/components/ui/UiSpinner";
@@ -31,7 +32,6 @@ import Badge from "./Badge";
 import ImageCreditBadge from "./ImageCreditBadge";
 
 const titleStyle: TextStyle = {
-  fontFamily: "SourceSansProBold",
   paddingHorizontal: POST_PADDING_HORIZONTAL,
   lineHeight: 26,
   textAlign: "left",
@@ -65,7 +65,6 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
   // Hooks and derived values.
   const colorScheme = useAppColorScheme();
   const corporate = Colors[colorScheme].primary;
-  const greyText = Colors[colorScheme].textMuted;
   const { width } = useFeedDimensions();
   const router = useRouter();
   const height = useMemo(() => DEFAULT_IMAGE_ASPECT_RATIO * width, [width]);
@@ -202,9 +201,8 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
     () => ({
       paddingHorizontal: POST_PADDING_HORIZONTAL,
       textAlign: "left" as const,
-      color: greyText,
     }),
-    [greyText],
+    [],
   );
   const categoryTextStyle: TextStyle[] = [
     globalStyles.whiteText,
@@ -242,13 +240,13 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
         </View>
         <View style={progressBarStyle} />
         <UiSpace size={10} />
-        <UiText size="xl" style={titleStyle}>
+        <Typography type="cardTitle" style={titleStyle}>
           {article.title}
-        </UiText>
+        </Typography>
         <UiSpace size={10} />
-        <UiText size="base" style={authorDateStyle}>
+        <Typography type="meta" style={authorDateStyle}>
           {authorDateText}
-        </UiText>
+        </Typography>
         <UiSpace size={10} />
         {(article.sourceName || categoryText) && (
           <Badge position="topLeft" color={corporate}>

--- a/src/components/posts/ArticlePost.tsx
+++ b/src/components/posts/ArticlePost.tsx
@@ -14,6 +14,7 @@ import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
 import Config from "#/constants/Config";
 import {
+  CARD_TITLE_META_GAP,
   DEFAULT_IMAGE_ASPECT_RATIO,
   POST_PADDING_HORIZONTAL,
   globalStyles,
@@ -240,13 +241,14 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
         </View>
         <View style={progressBarStyle} />
         <UiSpace size={10} />
-        <Typography type="cardTitle" style={titleStyle}>
-          {article.title}
-        </Typography>
-        <UiSpace size={10} />
-        <Typography type="meta" style={authorDateStyle}>
-          {authorDateText}
-        </Typography>
+        <View style={{ gap: CARD_TITLE_META_GAP }}>
+          <Typography type="cardTitle" style={titleStyle}>
+            {article.title}
+          </Typography>
+          <Typography type="meta" style={authorDateStyle}>
+            {authorDateText}
+          </Typography>
+        </View>
         <UiSpace size={10} />
         {(article.sourceName || categoryText) && (
           <Badge position="topLeft" color={corporate}>

--- a/src/components/posts/ArticlePost.tsx
+++ b/src/components/posts/ArticlePost.tsx
@@ -32,12 +32,6 @@ import type { ArticleProperties, ImageCredit } from "#/types";
 import Badge from "./Badge";
 import ImageCreditBadge from "./ImageCreditBadge";
 
-const titleStyle: TextStyle = {
-  paddingHorizontal: POST_PADDING_HORIZONTAL,
-  lineHeight: 26,
-  textAlign: "left",
-};
-
 // Define the component props type.
 interface ArticlePostScreenProperties {
   article: ArticleProperties;
@@ -198,13 +192,6 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
     }),
     [scrollProgress, corporate],
   );
-  const authorDateStyle = useMemo(
-    () => ({
-      paddingHorizontal: POST_PADDING_HORIZONTAL,
-      textAlign: "left" as const,
-    }),
-    [],
-  );
   const categoryTextStyle: TextStyle[] = [
     globalStyles.whiteText,
     { textAlign: "right" },
@@ -241,13 +228,14 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
         </View>
         <View style={progressBarStyle} />
         <UiSpace size={10} />
-        <View style={{ gap: CARD_CONTENT_GAP }}>
-          <Typography type="cardTitle" style={titleStyle}>
-            {article.title}
-          </Typography>
-          <Typography type="meta" style={authorDateStyle}>
-            {authorDateText}
-          </Typography>
+        <View
+          style={{
+            gap: CARD_CONTENT_GAP,
+            paddingHorizontal: POST_PADDING_HORIZONTAL,
+          }}
+        >
+          <Typography type="cardTitle">{article.title}</Typography>
+          <Typography type="meta">{authorDateText}</Typography>
         </View>
         <UiSpace size={10} />
         {(article.sourceName || categoryText) && (

--- a/src/components/posts/ClaimPost.tsx
+++ b/src/components/posts/ClaimPost.tsx
@@ -4,6 +4,7 @@ import { View } from "react-native";
 import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
+import { LINE_HEIGHTS } from "#/constants/FontSizes";
 import { POST_PADDING_HORIZONTAL } from "#/constants/GlobalStyles";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 import type { ClaimProperties } from "#/types";
@@ -27,7 +28,7 @@ const ClaimPost = (properties: ClaimProperties) => {
           bold
           style={{
             paddingHorizontal: POST_PADDING_HORIZONTAL,
-            lineHeight: 26,
+            lineHeight: LINE_HEIGHTS.xl,
             textAlign: "left",
             paddingTop: 20,
           }}

--- a/src/components/posts/ClaimPost.tsx
+++ b/src/components/posts/ClaimPost.tsx
@@ -24,8 +24,8 @@ const ClaimPost = (properties: ClaimProperties) => {
       <View style={{ paddingBottom: 0, flex: 1 }}>
         <UiText
           size="xl"
+          bold
           style={{
-            fontFamily: "SourceSansProBold",
             paddingHorizontal: POST_PADDING_HORIZONTAL,
             lineHeight: 26,
             textAlign: "left",

--- a/src/components/posts/MastodonPost.tsx
+++ b/src/components/posts/MastodonPost.tsx
@@ -4,6 +4,7 @@ import { decode } from "html-entities";
 import { View } from "react-native";
 import { Hyperlink } from "react-native-hyperlink";
 
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
@@ -79,9 +80,9 @@ const MastodonPost = (properties: MastodonPostScreenProperties) => {
               style={{ width: 40, height: 40, borderRadius: 20 }}
             />
             <View style={{ marginLeft: 10 }}>
-              <UiText bold size="lg">
+              <Typography type="heading">
                 &nbsp;{account.display_name}&nbsp;
-              </UiText>
+              </Typography>
               <UiText size="sm" style={{ color: grey }}>
                 &nbsp;@{account.acct}&nbsp;
               </UiText>

--- a/src/components/posts/MastodonPost.tsx
+++ b/src/components/posts/MastodonPost.tsx
@@ -9,6 +9,7 @@ import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
+import { LINE_HEIGHTS } from "#/constants/FontSizes";
 import {
   POST_PADDING_HORIZONTAL,
   globalStyles,
@@ -98,14 +99,21 @@ const MastodonPost = (properties: MastodonPostScreenProperties) => {
             excerpt.length < fulltext.length && (
               <UiText
                 size="lg"
-                style={{ lineHeight: 24, color: corporate, marginBottom: 20 }}
+                style={{
+                  lineHeight: LINE_HEIGHTS.lg,
+                  color: corporate,
+                  marginBottom: 20,
+                }}
               >
                 Mehr Lesen
               </UiText>
             )}
           {displayText !== DISPLAY_TEXT_FULL && (
             <View style={globalStyles.row}>
-              <UiText size="lg" style={{ lineHeight: 24, color: grey }}>
+              <UiText
+                size="lg"
+                style={{ lineHeight: LINE_HEIGHTS.lg, color: grey }}
+              >
                 {new Date(created_at).toLocaleTimeString("de-DE", {
                   year: "numeric",
                   month: "numeric",
@@ -115,7 +123,10 @@ const MastodonPost = (properties: MastodonPostScreenProperties) => {
                 })}
               </UiText>
               {answers && answers.length > 0 && (
-                <UiText size="lg" style={{ lineHeight: 24, color: corporate }}>
+                <UiText
+                  size="lg"
+                  style={{ lineHeight: LINE_HEIGHTS.lg, color: corporate }}
+                >
                   Thread 1 von {answers.length + 1}
                 </UiText>
               )}

--- a/src/components/posts/MastodonPost.tsx
+++ b/src/components/posts/MastodonPost.tsx
@@ -90,9 +90,9 @@ const MastodonPost = (properties: MastodonPostScreenProperties) => {
           </View>
           <UiSpace size={20} />
           {displayText !== DISPLAY_TEXT_NONE && (
-            <UiText size="lg" style={{ lineHeight: 24 }}>
+            <Typography type="body">
               {displayText === DISPLAY_TEXT_FULL ? fulltext : excerpt}
-            </UiText>
+            </Typography>
           )}
           {displayText === DISPLAY_TEXT_EXCERPT &&
             excerpt.length < fulltext.length && (
@@ -134,13 +134,9 @@ const MastodonPost = (properties: MastodonPostScreenProperties) => {
                   .replaceAll(htmlPattern, ""),
               );
               return (
-                <UiText
-                  key={String(index)}
-                  size="lg"
-                  style={{ lineHeight: 24 }}
-                >
+                <Typography key={String(index)} type="body">
                   {fullText}
-                </UiText>
+                </Typography>
               );
             })}
         </View>

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -108,11 +108,6 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
         )}
         <UiSpace size={image_url ? 12 : 20} />
         <View style={{ paddingHorizontal: POST_PADDING_HORIZONTAL }}>
-          {!image_url && (
-            <UiText size="sm" style={{ color: corporate, textAlign: "left" }}>
-              Podcast
-            </UiText>
-          )}
           <View style={{ gap: CARD_CONTENT_GAP }}>
             <Typography type="cardTitle" style={{ textAlign: "left" }}>
               {title}

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -5,10 +5,10 @@ import React, { useEffect, useState } from "react";
 import { View } from "react-native";
 
 import AudioPlayer from "#/components/audio/AudioPlayer";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
-import Colors from "#/constants/Colors";
 import {
   DEFAULT_IMAGE_ASPECT_RATIO,
   POST_PADDING_HORIZONTAL,
@@ -18,10 +18,7 @@ import PersonalStore from "#/helpers/Stores/PersonalStore";
 import { registerPostInteraction } from "#/helpers/network/Analytics";
 import { useAudio } from "#/helpers/provider/AudioProvider";
 import { RESUME_MIN_SECONDS, formatTime } from "#/helpers/utils/audio";
-import {
-  useAppColorScheme,
-  useCorporateColor,
-} from "#/hooks/useAppColorScheme";
+import { useCorporateColor } from "#/hooks/useAppColorScheme";
 import type { PodcastEpisodeProperties } from "#/types";
 
 import Badge from "./Badge";
@@ -37,9 +34,7 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
   const { id, title, description, published_at, link, audio_url, image_url } =
     properties;
   const [resumePosition, setResumePosition] = useState(0);
-  const colorScheme = useAppColorScheme();
   const corporate = useCorporateColor();
-  const greyText = Colors[colorScheme].textMuted;
   const router = useRouter();
   const audio = useAudio();
 
@@ -117,17 +112,17 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
               Podcast
             </UiText>
           )}
-          <UiText
-            size="lg"
+          <Typography
+            type="cardTitle"
             numberOfLines={2}
-            style={{ fontFamily: "SourceSansProBold", textAlign: "left" }}
+            style={{ textAlign: "left" }}
           >
             {title}
-          </UiText>
+          </Typography>
           {!!dateDurationText && (
-            <UiText size="base" style={{ color: greyText, textAlign: "left" }}>
+            <Typography type="meta" style={{ textAlign: "left" }}>
               {dateDurationText}
-            </UiText>
+            </Typography>
           )}
         </View>
         {!!description && (

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -10,6 +10,7 @@ import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
 import {
+  CARD_TITLE_META_GAP,
   DEFAULT_IMAGE_ASPECT_RATIO,
   POST_PADDING_HORIZONTAL,
   globalStyles,
@@ -112,18 +113,20 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
               Podcast
             </UiText>
           )}
-          <Typography
-            type="cardTitle"
-            numberOfLines={2}
-            style={{ textAlign: "left" }}
-          >
-            {title}
-          </Typography>
-          {!!dateDurationText && (
-            <Typography type="meta" style={{ textAlign: "left" }}>
-              {dateDurationText}
+          <View style={{ gap: CARD_TITLE_META_GAP }}>
+            <Typography
+              type="cardTitle"
+              numberOfLines={2}
+              style={{ textAlign: "left" }}
+            >
+              {title}
             </Typography>
-          )}
+            {!!dateDurationText && (
+              <Typography type="meta" style={{ textAlign: "left" }}>
+                {dateDurationText}
+              </Typography>
+            )}
+          </View>
         </View>
         {!!description && (
           <>

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -114,11 +114,7 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
             </UiText>
           )}
           <View style={{ gap: CARD_TITLE_META_GAP }}>
-            <Typography
-              type="cardTitle"
-              numberOfLines={2}
-              style={{ textAlign: "left" }}
-            >
+            <Typography type="cardTitle" style={{ textAlign: "left" }}>
               {title}
             </Typography>
             {!!dateDurationText && (

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -10,7 +10,7 @@ import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
 import {
-  CARD_TITLE_META_GAP,
+  CARD_CONTENT_GAP,
   DEFAULT_IMAGE_ASPECT_RATIO,
   POST_PADDING_HORIZONTAL,
   globalStyles,
@@ -113,7 +113,7 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
               Podcast
             </UiText>
           )}
-          <View style={{ gap: CARD_TITLE_META_GAP }}>
+          <View style={{ gap: CARD_CONTENT_GAP }}>
             <Typography type="cardTitle" style={{ textAlign: "left" }}>
               {title}
             </Typography>

--- a/src/components/posts/PodcastPost.tsx
+++ b/src/components/posts/PodcastPost.tsx
@@ -109,13 +109,9 @@ const PodcastPost = (properties: PodcastEpisodeProperties) => {
         <UiSpace size={image_url ? 12 : 20} />
         <View style={{ paddingHorizontal: POST_PADDING_HORIZONTAL }}>
           <View style={{ gap: CARD_CONTENT_GAP }}>
-            <Typography type="cardTitle" style={{ textAlign: "left" }}>
-              {title}
-            </Typography>
+            <Typography type="cardTitle">{title}</Typography>
             {!!dateDurationText && (
-              <Typography type="meta" style={{ textAlign: "left" }}>
-                {dateDurationText}
-              </Typography>
+              <Typography type="meta">{dateDurationText}</Typography>
             )}
           </View>
         </View>

--- a/src/components/posts/RedditPost.tsx
+++ b/src/components/posts/RedditPost.tsx
@@ -5,6 +5,7 @@ import { View } from "react-native";
 
 import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
+import { LINE_HEIGHTS } from "#/constants/FontSizes";
 import {
   DEFAULT_IMAGE_ASPECT_RATIO,
   POST_PADDING_HORIZONTAL,
@@ -107,7 +108,7 @@ const RedditPost = (properties: RedditProperties) => {
             bold
             style={{
               paddingHorizontal: POST_PADDING_HORIZONTAL,
-              lineHeight: size === 16 ? 22 : 24,
+              lineHeight: size === 16 ? LINE_HEIGHTS.base : LINE_HEIGHTS.lg,
               textAlign: "left",
               paddingTop: 20,
             }}

--- a/src/components/posts/RedditPost.tsx
+++ b/src/components/posts/RedditPost.tsx
@@ -104,10 +104,10 @@ const RedditPost = (properties: RedditProperties) => {
           />
           <UiText
             size={size === 16 ? "base" : "lg"}
+            bold
             style={{
               paddingHorizontal: POST_PADDING_HORIZONTAL,
               lineHeight: size === 16 ? 22 : 24,
-              fontFamily: "SourceSansProBold",
               textAlign: "left",
               paddingTop: 20,
             }}

--- a/src/components/posts/bsky/BlueskyPostCard.tsx
+++ b/src/components/posts/bsky/BlueskyPostCard.tsx
@@ -6,6 +6,7 @@ import { Hyperlink } from "react-native-hyperlink";
 
 import { ExternalLinkIcon } from "#/components/Icons";
 import { BlueskyPostHeader } from "#/components/posts/bsky/BlueskyPostHeader";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
@@ -98,9 +99,9 @@ const BlueskyPostCard = (properties: BlueskyPostProperties) => {
           linkStyle={{ color: corporate }}
           onPress={(url: HttpsUrl) => onLinkPress(url, router, uri)}
         >
-          <UiText size="lg" style={{ lineHeight: 24 }}>
+          <Typography type="body">
             {isTruncated ? `${excerpt}…` : excerpt}
-          </UiText>
+          </Typography>
         </Hyperlink>
 
         <View style={globalStyles.row}>

--- a/src/components/posts/bsky/BlueskyPostDetail.tsx
+++ b/src/components/posts/bsky/BlueskyPostDetail.tsx
@@ -7,8 +7,8 @@ import { Hyperlink } from "react-native-hyperlink";
 import { ExternalLinkIcon } from "#/components/Icons";
 import { BlueskyPostHeader } from "#/components/posts/bsky/BlueskyPostHeader";
 import { PostText } from "#/components/posts/bsky/PostText";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
-import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
 import Config from "#/constants/Config";
 import { POST_PADDING_HORIZONTAL } from "#/constants/GlobalStyles";
@@ -64,9 +64,7 @@ const BlueskyPostDetail = ({ post, replies }: BlueskyPostProperties) => {
         style={{ flex: 1 }}
         onPress={(url: HttpsUrl) => onLinkPress(url, router, uri)}
       >
-        <UiText size="lg" style={{ lineHeight: 24 }}>
-          {fulltext}
-        </UiText>
+        <Typography type="body">{fulltext}</Typography>
       </Hyperlink>
 
       {replies &&

--- a/src/components/posts/bsky/BlueskyPostHeader.tsx
+++ b/src/components/posts/bsky/BlueskyPostHeader.tsx
@@ -1,7 +1,7 @@
 import { Image } from "expo-image";
 import { View } from "react-native";
 
-import UiText from "#/components/ui/UiText";
+import Typography from "#/components/ui/Typography";
 import type { PostAuthor } from "#/types";
 
 interface BlueskyPostHeaderProps {
@@ -24,9 +24,7 @@ export const BlueskyPostHeader = ({ author }: BlueskyPostHeaderProps) => {
         source={{ uri: author.avatar }}
         style={{ width: 40, height: 40, borderRadius: 20 }}
       />
-      <UiText bold size="lg">
-        {displayName}
-      </UiText>
+      <Typography type="heading">{displayName}</Typography>
     </View>
   );
 };

--- a/src/components/posts/bsky/PostText.tsx
+++ b/src/components/posts/bsky/PostText.tsx
@@ -2,7 +2,7 @@ import { type AppBskyFeedDefs, RichText } from "@atproto/api";
 import { useRouter } from "expo-router";
 import { Hyperlink } from "react-native-hyperlink";
 
-import UiText from "#/components/ui/UiText";
+import Typography from "#/components/ui/Typography";
 import Colors from "#/constants/Colors";
 import { onLinkPress } from "#/helpers/Linking";
 import { normalizeFacets } from "#/helpers/utils/posts";
@@ -54,9 +54,7 @@ export const PostText = ({ feedViewPost, uri }: PostTextProps) => {
       linkText={(url) => linkTextToUrlMap[url]}
       onPress={(url: HttpsUrl) => onLinkPress(url, router, uri)}
     >
-      <UiText size="lg" style={{ lineHeight: 24 }}>
-        {decodedText}
-      </UiText>
+      <Typography type="body">{decodedText}</Typography>
     </Hyperlink>
   );
 };

--- a/src/components/posts/insta/InstaPostCard.tsx
+++ b/src/components/posts/insta/InstaPostCard.tsx
@@ -7,6 +7,7 @@ import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
 import {
+  CARD_CONTENT_GAP,
   POST_PADDING_HORIZONTAL,
   globalStyles,
 } from "#/constants/GlobalStyles";
@@ -63,7 +64,7 @@ const InstaPostCard = (properties: InstaPostProperties) => {
   }, [inView, loaded, registered, computedPermalink]);
 
   return (
-    <View>
+    <View style={{ gap: CARD_CONTENT_GAP }}>
       <InstaPostImage
         photos={photos}
         width={width}
@@ -80,7 +81,7 @@ const InstaPostCard = (properties: InstaPostProperties) => {
         hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
         style={{
           paddingHorizontal: POST_PADDING_HORIZONTAL,
-          paddingVertical: 10,
+          paddingBottom: 10,
           opacity: 1,
         }}
       >

--- a/src/components/posts/insta/InstaPostDetail.tsx
+++ b/src/components/posts/insta/InstaPostDetail.tsx
@@ -4,7 +4,7 @@ import { View, useWindowDimensions } from "react-native";
 import { Hyperlink } from "react-native-hyperlink";
 
 import InstaPostImage from "#/components/posts/insta/InstaPostImage";
-import UiText from "#/components/ui/UiText";
+import Typography from "#/components/ui/Typography";
 import Config from "#/constants/Config";
 import { CARD_CONTENT_GAP } from "#/constants/GlobalStyles";
 import { Achievements } from "#/helpers/Achievements";
@@ -54,12 +54,12 @@ const InstaPostDetail = (properties: InstaPostProperties) => {
         onLongPress={handleLongPress}
       />
       <Hyperlink linkStyle={{ color: corporate }} onPress={handleLinkPress}>
-        <UiText
-          size="lg"
-          style={{ paddingHorizontal: 10, paddingBottom: 50, lineHeight: 24 }}
+        <Typography
+          type="body"
+          style={{ paddingHorizontal: 10, paddingBottom: 50 }}
         >
           {caption}
-        </UiText>
+        </Typography>
       </Hyperlink>
     </View>
   );

--- a/src/components/posts/insta/InstaPostDetail.tsx
+++ b/src/components/posts/insta/InstaPostDetail.tsx
@@ -6,6 +6,7 @@ import { Hyperlink } from "react-native-hyperlink";
 import InstaPostImage from "#/components/posts/insta/InstaPostImage";
 import UiText from "#/components/ui/UiText";
 import Config from "#/constants/Config";
+import { CARD_CONTENT_GAP } from "#/constants/GlobalStyles";
 import { Achievements } from "#/helpers/Achievements";
 import { onLinkPress } from "#/helpers/Linking";
 import { onShare } from "#/helpers/Sharing";
@@ -43,7 +44,7 @@ const InstaPostDetail = (properties: InstaPostProperties) => {
   }, []);
 
   return (
-    <View>
+    <View style={{ gap: CARD_CONTENT_GAP }}>
       <InstaPostImage
         photos={photos}
         width={width}

--- a/src/components/posts/insta/InstaPostImage.tsx
+++ b/src/components/posts/insta/InstaPostImage.tsx
@@ -52,7 +52,7 @@ const Dot = ({
           width: 5,
           backgroundColor: color,
           marginHorizontal: 3,
-          marginVertical: 10,
+          marginTop: 10,
           borderRadius: 5,
         },
         style,

--- a/src/components/ui/Typography.tsx
+++ b/src/components/ui/Typography.tsx
@@ -1,6 +1,10 @@
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
-import { type TextVariant, textVariants } from "#/constants/TextVariants";
+import {
+  type TextVariant,
+  type TextVariantSpec,
+  textVariants,
+} from "#/constants/TextVariants";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
 type TypographyProperties = React.ComponentProps<typeof UiText> & {
@@ -15,9 +19,10 @@ type TypographyProperties = React.ComponentProps<typeof UiText> & {
 /**
  * Semantic text component. Prefer this over `UiText` for anything with a role
  * (titles, meta lines): `<Typography type="title">` instead of hand-tuning
- * `size` / `bold` / `color` per screen. It resolves the role into concrete
- * `UiText` props; `size`, `bold` and an explicit `color` in `style` still
- * override the role for one-offs.
+ * `size` / `bold` / `color` / `lineHeight` / alignment per screen. It resolves
+ * the role into concrete `UiText` props and defaults to left alignment; `size`,
+ * `bold` and an explicit `color`/`textAlign` in `style` still override the role
+ * for one-offs. Layout (padding, margins) stays with the caller.
  */
 const Typography = ({
   type,
@@ -27,7 +32,7 @@ const Typography = ({
   ...properties
 }: TypographyProperties) => {
   const colorScheme = useAppColorScheme();
-  const preset = textVariants[type];
+  const preset: TextVariantSpec = textVariants[type];
   const toneColor =
     preset.tone === "muted" ? Colors[colorScheme].textMuted : undefined;
 
@@ -35,7 +40,12 @@ const Typography = ({
     <UiText
       size={size ?? preset.size}
       bold={bold ?? preset.bold}
-      style={toneColor ? [{ color: toneColor }, style] : style}
+      style={[
+        { textAlign: "left" },
+        toneColor ? { color: toneColor } : null,
+        preset.lineHeight ? { lineHeight: preset.lineHeight } : null,
+        style,
+      ]}
       {...properties}
     />
   );

--- a/src/components/ui/Typography.tsx
+++ b/src/components/ui/Typography.tsx
@@ -1,0 +1,26 @@
+import UiText from "#/components/ui/UiText";
+import type { TextVariant } from "#/constants/TextVariants";
+
+type TypographyProperties = Omit<
+  React.ComponentProps<typeof UiText>,
+  "variant"
+> & {
+  /**
+   * Semantic role of this text (see {@link textVariants}). Sets size, weight
+   * and color tone at once so the same kind of text — a screen title, a
+   * date/duration/author meta line — looks identical wherever it appears.
+   */
+  type: TextVariant;
+};
+
+/**
+ * Semantic text component. Prefer this over `UiText` for anything with a role
+ * (titles, meta lines): `<Typography type="title">` instead of
+ * hand-tuning `size` / `bold` / `color` per screen. `size`, `bold` and an
+ * explicit `color` in `style` still override the variant for one-offs.
+ */
+const Typography = ({ type, ...properties }: TypographyProperties) => (
+  <UiText variant={type} {...properties} />
+);
+
+export default Typography;

--- a/src/components/ui/Typography.tsx
+++ b/src/components/ui/Typography.tsx
@@ -1,3 +1,5 @@
+import type { ComponentProps } from "react";
+
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
 import {
@@ -7,7 +9,7 @@ import {
 } from "#/constants/TextVariants";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
-type TypographyProperties = React.ComponentProps<typeof UiText> & {
+type TypographyProperties = ComponentProps<typeof UiText> & {
   /**
    * Semantic role of this text (see {@link textVariants}). Sets size, weight
    * and color tone at once so the same kind of text — a screen title, a

--- a/src/components/ui/Typography.tsx
+++ b/src/components/ui/Typography.tsx
@@ -1,10 +1,9 @@
 import UiText from "#/components/ui/UiText";
-import type { TextVariant } from "#/constants/TextVariants";
+import Colors from "#/constants/Colors";
+import { type TextVariant, textVariants } from "#/constants/TextVariants";
+import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
-type TypographyProperties = Omit<
-  React.ComponentProps<typeof UiText>,
-  "variant"
-> & {
+type TypographyProperties = React.ComponentProps<typeof UiText> & {
   /**
    * Semantic role of this text (see {@link textVariants}). Sets size, weight
    * and color tone at once so the same kind of text — a screen title, a
@@ -15,12 +14,31 @@ type TypographyProperties = Omit<
 
 /**
  * Semantic text component. Prefer this over `UiText` for anything with a role
- * (titles, meta lines): `<Typography type="title">` instead of
- * hand-tuning `size` / `bold` / `color` per screen. `size`, `bold` and an
- * explicit `color` in `style` still override the variant for one-offs.
+ * (titles, meta lines): `<Typography type="title">` instead of hand-tuning
+ * `size` / `bold` / `color` per screen. It resolves the role into concrete
+ * `UiText` props; `size`, `bold` and an explicit `color` in `style` still
+ * override the role for one-offs.
  */
-const Typography = ({ type, ...properties }: TypographyProperties) => (
-  <UiText variant={type} {...properties} />
-);
+const Typography = ({
+  type,
+  size,
+  bold,
+  style,
+  ...properties
+}: TypographyProperties) => {
+  const colorScheme = useAppColorScheme();
+  const preset = textVariants[type];
+  const toneColor =
+    preset.tone === "muted" ? Colors[colorScheme].textMuted : undefined;
+
+  return (
+    <UiText
+      size={size ?? preset.size}
+      bold={bold ?? preset.bold}
+      style={toneColor ? [{ color: toneColor }, style] : style}
+      {...properties}
+    />
+  );
+};
 
 export default Typography;

--- a/src/components/ui/UiCollapsable.tsx
+++ b/src/components/ui/UiCollapsable.tsx
@@ -4,8 +4,8 @@ import type { ColorValue } from "react-native";
 import { Animated, StyleSheet, View } from "react-native";
 
 import { ChevronIcon } from "#/components/Icons";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
-import UiText from "#/components/ui/UiText";
 import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
@@ -63,9 +63,7 @@ const UiCollapsable = ({
       >
         <View style={styles.title}>
           {icon}
-          <UiText bold size="lg">
-            {title}
-          </UiText>
+          <Typography type="heading">{title}</Typography>
         </View>
         <ChevronIcon
           direction={open ? "up" : "down"}

--- a/src/components/ui/UiLink.tsx
+++ b/src/components/ui/UiLink.tsx
@@ -5,8 +5,8 @@ import type { ReactElement } from "react";
 import { View } from "react-native";
 
 import { ExternalLinkIcon } from "#/components/Icons";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
-import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
 import { globalStyles } from "#/constants/GlobalStyles";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
@@ -50,9 +50,7 @@ const UiLink = (properties: UiLinkProperties) => {
       ]}
     >
       {properties.icon && <View style={{ width: 24 }}>{properties.icon}</View>}
-      <UiText bold size="lg">
-        {properties.text}
-      </UiText>
+      <Typography type="heading">{properties.text}</Typography>
       <ExternalLinkIcon
         color={Colors[colorScheme].textMuted}
         style={{ marginLeft: "auto" }}

--- a/src/components/ui/UiText.tsx
+++ b/src/components/ui/UiText.tsx
@@ -3,17 +3,10 @@ import { Text } from "react-native";
 
 import Colors from "#/constants/Colors";
 import { type FontSizeToken, fontSizes } from "#/constants/FontSizes";
-import { type TextVariant, textVariants } from "#/constants/TextVariants";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
 type TextProperties = TextProps & {
   key?: string;
-  /**
-   * Semantic role of this text (see {@link textVariants}). Sets size, weight
-   * and color at once so the same kind of text looks identical across screens.
-   * `size` / `bold` / a `color` in `style` override it.
-   */
-  variant?: TextVariant;
   /**
    * Font size from the shared scale (see {@link fontSizes}). Prefer this over a
    * raw `fontSize` in `style` so text stays on the typographic scale. An
@@ -24,26 +17,25 @@ type TextProperties = TextProps & {
   bold?: boolean;
 };
 
+/**
+ * Low-level styled text primitive: applies the theme text color, a font-scale
+ * size and the regular/bold family. For text with a semantic role (titles,
+ * meta lines) prefer {@link Typography}, which layers those roles on top.
+ */
 const UiText = (properties: TextProperties) => {
-  const { style, variant, size, bold, ...otherProperties } = properties;
+  const { style, size, bold, ...otherProperties } = properties;
   const colorScheme = useAppColorScheme();
-  const palette = Colors[colorScheme];
-
-  const preset = variant ? textVariants[variant] : undefined;
-  const effectiveSize = size ?? preset?.size;
-  const effectiveBold = bold ?? preset?.bold ?? false;
-  const tone = preset?.tone ?? "default";
-  const color = tone === "muted" ? palette.textMuted : palette.text;
+  const color = Colors[colorScheme].text;
 
   return (
     <Text
       style={[
         { color },
         {
-          fontFamily: effectiveBold ? "SourceSansProBold" : "SourceSansPro",
+          fontFamily: bold ? "SourceSansProBold" : "SourceSansPro",
           includeFontPadding: false,
         },
-        effectiveSize ? { fontSize: fontSizes[effectiveSize] } : null,
+        size ? { fontSize: fontSizes[size] } : null,
         style,
       ]}
       {...otherProperties}

--- a/src/components/ui/UiText.tsx
+++ b/src/components/ui/UiText.tsx
@@ -3,10 +3,17 @@ import { Text } from "react-native";
 
 import Colors from "#/constants/Colors";
 import { type FontSizeToken, fontSizes } from "#/constants/FontSizes";
+import { type TextVariant, textVariants } from "#/constants/TextVariants";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
 type TextProperties = TextProps & {
   key?: string;
+  /**
+   * Semantic role of this text (see {@link textVariants}). Sets size, weight
+   * and color at once so the same kind of text looks identical across screens.
+   * `size` / `bold` / a `color` in `style` override it.
+   */
+  variant?: TextVariant;
   /**
    * Font size from the shared scale (see {@link fontSizes}). Prefer this over a
    * raw `fontSize` in `style` so text stays on the typographic scale. An
@@ -18,19 +25,25 @@ type TextProperties = TextProps & {
 };
 
 const UiText = (properties: TextProperties) => {
-  const { style, size, bold, ...otherProperties } = properties;
+  const { style, variant, size, bold, ...otherProperties } = properties;
   const colorScheme = useAppColorScheme();
-  const color = Colors[colorScheme].text;
+  const palette = Colors[colorScheme];
+
+  const preset = variant ? textVariants[variant] : undefined;
+  const effectiveSize = size ?? preset?.size;
+  const effectiveBold = bold ?? preset?.bold ?? false;
+  const tone = preset?.tone ?? "default";
+  const color = tone === "muted" ? palette.textMuted : palette.text;
 
   return (
     <Text
       style={[
         { color },
         {
-          fontFamily: bold ? "SourceSansProBold" : "SourceSansPro",
+          fontFamily: effectiveBold ? "SourceSansProBold" : "SourceSansPro",
           includeFontPadding: false,
         },
-        size ? { fontSize: fontSizes[size] } : null,
+        effectiveSize ? { fontSize: fontSizes[effectiveSize] } : null,
         style,
       ]}
       {...otherProperties}

--- a/src/components/views/ContactCard.tsx
+++ b/src/components/views/ContactCard.tsx
@@ -3,6 +3,7 @@ import { View } from "react-native";
 
 import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
+import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
 import { globalStyles } from "#/constants/GlobalStyles";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
@@ -62,7 +63,7 @@ const ContactCard = ({
         style={{
           alignItems: "center",
           backgroundColor: accent,
-          borderRadius: 40,
+          borderRadius: radii.full,
           justifyContent: "center",
           paddingVertical: 10,
           width: 160,

--- a/src/components/views/Support.tsx
+++ b/src/components/views/Support.tsx
@@ -4,6 +4,7 @@ import { View } from "react-native";
 import Modal from "react-native-modal";
 
 import { CloseIcon, HeartIcon } from "#/components/Icons";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
@@ -62,9 +63,9 @@ const Support = ({ article_link }: SupportProperties) => {
         onPress={banktransfer}
         style={{ padding: 10 }}
       >
-        <UiText bold size="lg" style={{ color: corporate }}>
+        <Typography type="heading" style={{ color: corporate }}>
           Dauerauftrag
-        </UiText>
+        </Typography>
       </UiPressable>
       <UiText size="base" style={{ textAlign: "center" }}>
         direkt bei der Bank einrichten.

--- a/src/constants/FontSizes.ts
+++ b/src/constants/FontSizes.ts
@@ -27,3 +27,10 @@ export const fontSizes = {
 } as const;
 
 export type FontSizeToken = keyof typeof fontSizes;
+
+/**
+ * Line height for readable body copy — article body, social-post fulltext.
+ * The article body is the reference; keep other long-form content in sync
+ * with it via this constant (and the `body` text variant).
+ */
+export const CONTENT_LINE_HEIGHT = 27;

--- a/src/constants/FontSizes.ts
+++ b/src/constants/FontSizes.ts
@@ -34,3 +34,19 @@ export type FontSizeToken = keyof typeof fontSizes;
  * with it via this constant (and the `body` text variant).
  */
 export const CONTENT_LINE_HEIGHT = 27;
+
+/**
+ * Recommended line heights per font size for optimal text readability.
+ * Use these for multi-line text that doesn't fit a semantic `Typography` role
+ * (e.g. social-post metadata, changelog notes, announcement text).
+ *
+ * Formula: size × 1.35–1.4 for comfortable linespacing without looking loose.
+ */
+export const LINE_HEIGHTS = {
+  xs: 16, // 12 × 1.33
+  sm: 19, // 14 × 1.36
+  base: 22, // 16 × 1.38
+  lg: 24, // 18 × 1.33
+  xl: 27, // 20 × 1.35
+  xxl: 32, // 24 × 1.33
+} as const;

--- a/src/constants/FontSizes.ts
+++ b/src/constants/FontSizes.ts
@@ -40,7 +40,7 @@ export const CONTENT_LINE_HEIGHT = 27;
  * Use these for multi-line text that doesn't fit a semantic `Typography` role
  * (e.g. social-post metadata, changelog notes, announcement text).
  *
- * Formula: size × 1.35–1.4 for comfortable linespacing without looking loose.
+ * Formula: size × ~1.33–1.4 for comfortable linespacing without looking loose.
  */
 export const LINE_HEIGHTS = {
   xs: 16, // 12 × 1.33

--- a/src/constants/GlobalStyles.ts
+++ b/src/constants/GlobalStyles.ts
@@ -14,9 +14,11 @@ export const CONTENT_HORIZONTAL_PADDING = 10;
 export const POST_PADDING_HORIZONTAL = 30;
 export const CARD_PADDING = 20;
 
-// Vertical gap between a feed card's title and its meta line (author/date/
-// duration). Shared so the article and podcast cards space them identically.
-export const CARD_TITLE_META_GAP = 10;
+// Vertical gap between a feed post's stacked content blocks — image, title,
+// meta line (author/date/duration), caption. Shared so every post type spaces
+// its content identically (and independent of variable elements like the
+// Instagram image-carousel dots).
+export const CARD_CONTENT_GAP = 10;
 
 // Height/width ratio of WordPress's default featured-image crop (e.g. 1200x615),
 // used as the fallback aspect ratio for post thumbnails whose real image

--- a/src/constants/GlobalStyles.ts
+++ b/src/constants/GlobalStyles.ts
@@ -1,5 +1,6 @@
 import { StyleSheet } from "react-native";
 
+import { radii } from "#/constants/BorderRadius";
 import { fontSizes } from "#/constants/FontSizes";
 
 export const SOURCE_SANS_FONTS = [
@@ -47,7 +48,7 @@ export const globalStyles = StyleSheet.create({
     width: "100%",
   },
   input: {
-    borderRadius: 40,
+    borderRadius: radii.full,
     minHeight: 40,
     paddingHorizontal: 25,
   },

--- a/src/constants/GlobalStyles.ts
+++ b/src/constants/GlobalStyles.ts
@@ -1,7 +1,7 @@
 import { StyleSheet } from "react-native";
 
 import { radii } from "#/constants/BorderRadius";
-import { fontSizes } from "#/constants/FontSizes";
+import { LINE_HEIGHTS, fontSizes } from "#/constants/FontSizes";
 
 export const SOURCE_SANS_FONTS = [
   "SourceSansPro",
@@ -74,6 +74,6 @@ export const globalStyles = StyleSheet.create({
   pillLabel: {
     fontFamily: "SourceSansProBold",
     fontSize: fontSizes.sm,
-    lineHeight: 19,
+    lineHeight: LINE_HEIGHTS.sm,
   },
 });

--- a/src/constants/GlobalStyles.ts
+++ b/src/constants/GlobalStyles.ts
@@ -14,6 +14,10 @@ export const CONTENT_HORIZONTAL_PADDING = 10;
 export const POST_PADDING_HORIZONTAL = 30;
 export const CARD_PADDING = 20;
 
+// Vertical gap between a feed card's title and its meta line (author/date/
+// duration). Shared so the article and podcast cards space them identically.
+export const CARD_TITLE_META_GAP = 10;
+
 // Height/width ratio of WordPress's default featured-image crop (e.g. 1200x615),
 // used as the fallback aspect ratio for post thumbnails whose real image
 // dimensions aren't known ahead of layout.

--- a/src/constants/TextVariants.ts
+++ b/src/constants/TextVariants.ts
@@ -1,4 +1,8 @@
-import { CONTENT_LINE_HEIGHT, type FontSizeToken } from "#/constants/FontSizes";
+import {
+  CONTENT_LINE_HEIGHT,
+  type FontSizeToken,
+  LINE_HEIGHTS,
+} from "#/constants/FontSizes";
 
 /** Shape of one entry in {@link textVariants}. */
 export type TextVariantSpec = {
@@ -25,7 +29,12 @@ export const textVariants = {
   /** Headline of a detail screen (article, podcast episode …). */
   title: { size: "xxl", bold: true, tone: "default" },
   /** Headline of a feed card. */
-  cardTitle: { size: "xl", bold: true, tone: "default", lineHeight: 26 },
+  cardTitle: {
+    size: "xl",
+    bold: true,
+    tone: "default",
+    lineHeight: LINE_HEIGHTS.xl,
+  },
   /**
    * Prominent bold label a step below a title: section headings, form-field
    * labels, social-post author names, link labels.

--- a/src/constants/TextVariants.ts
+++ b/src/constants/TextVariants.ts
@@ -1,0 +1,31 @@
+import type { FontSizeToken } from "#/constants/FontSizes";
+
+/**
+ * Semantic text roles, keyed by the {@link Typography} `type` prop.
+ *
+ * A variant bundles the three things that make a piece of text "the same kind
+ * of text" everywhere: size, weight and color tone. Prefer `<Typography
+ * type="title">` over repeating `size` + `fontFamily: "SourceSansProBold"` +
+ * `color: textMuted` per screen, so e.g. an article detail header and a podcast
+ * detail header can't drift apart again.
+ *
+ * `size` / `bold` / an explicit `color` in `style` still override the variant
+ * for genuine one-offs.
+ */
+export const textVariants = {
+  /** Headline of a detail screen (article, podcast episode …). */
+  title: { size: "xxl", bold: true, tone: "default" },
+  /** Headline of a feed card. */
+  cardTitle: { size: "xl", bold: true, tone: "default" },
+  /** Info line under a title: author, date, duration, reading time. */
+  meta: { size: "sm", bold: false, tone: "muted" },
+} as const satisfies Record<
+  string,
+  {
+    size: FontSizeToken;
+    bold: boolean;
+    tone: "default" | "muted";
+  }
+>;
+
+export type TextVariant = keyof typeof textVariants;

--- a/src/constants/TextVariants.ts
+++ b/src/constants/TextVariants.ts
@@ -1,4 +1,4 @@
-import type { FontSizeToken } from "#/constants/FontSizes";
+import { CONTENT_LINE_HEIGHT, type FontSizeToken } from "#/constants/FontSizes";
 
 /** Shape of one entry in {@link textVariants}. */
 export type TextVariantSpec = {
@@ -33,6 +33,17 @@ export const textVariants = {
   heading: { size: "lg", bold: true, tone: "default" },
   /** Info line under a title: author, date, duration, reading time. */
   meta: { size: "sm", bold: false, tone: "muted" },
+  /**
+   * Readable body copy: social-post fulltext and the like. Mirrors the article
+   * body (see {@link CONTENT_LINE_HEIGHT}) so long-form text reads the same
+   * everywhere.
+   */
+  body: {
+    size: "lg",
+    bold: false,
+    tone: "default",
+    lineHeight: CONTENT_LINE_HEIGHT,
+  },
 } as const satisfies Record<string, TextVariantSpec>;
 
 export type TextVariant = keyof typeof textVariants;

--- a/src/constants/TextVariants.ts
+++ b/src/constants/TextVariants.ts
@@ -26,6 +26,11 @@ export const textVariants = {
   title: { size: "xxl", bold: true, tone: "default" },
   /** Headline of a feed card. */
   cardTitle: { size: "xl", bold: true, tone: "default", lineHeight: 26 },
+  /**
+   * Prominent bold label a step below a title: section headings, form-field
+   * labels, social-post author names, link labels.
+   */
+  heading: { size: "lg", bold: true, tone: "default" },
   /** Info line under a title: author, date, duration, reading time. */
   meta: { size: "sm", bold: false, tone: "muted" },
 } as const satisfies Record<string, TextVariantSpec>;

--- a/src/constants/TextVariants.ts
+++ b/src/constants/TextVariants.ts
@@ -1,13 +1,22 @@
 import type { FontSizeToken } from "#/constants/FontSizes";
 
+/** Shape of one entry in {@link textVariants}. */
+export type TextVariantSpec = {
+  size: FontSizeToken;
+  bold: boolean;
+  tone: "default" | "muted";
+  /** Optional line height, for roles whose size wants explicit leading. */
+  lineHeight?: number;
+};
+
 /**
  * Semantic text roles, keyed by the {@link Typography} `type` prop.
  *
- * A variant bundles the three things that make a piece of text "the same kind
- * of text" everywhere: size, weight and color tone. Prefer `<Typography
- * type="title">` over repeating `size` + `fontFamily: "SourceSansProBold"` +
- * `color: textMuted` per screen, so e.g. an article detail header and a podcast
- * detail header can't drift apart again.
+ * A variant bundles what makes a piece of text "the same kind of text"
+ * everywhere: size, weight, color tone and (where it matters) line height.
+ * Prefer `<Typography type="title">` over repeating `size` +
+ * `fontFamily: "SourceSansProBold"` + `color: textMuted` per screen, so e.g.
+ * an article detail header and a podcast detail header can't drift apart again.
  *
  * `size` / `bold` / an explicit `color` in `style` still override the variant
  * for genuine one-offs.
@@ -16,16 +25,9 @@ export const textVariants = {
   /** Headline of a detail screen (article, podcast episode …). */
   title: { size: "xxl", bold: true, tone: "default" },
   /** Headline of a feed card. */
-  cardTitle: { size: "xl", bold: true, tone: "default" },
+  cardTitle: { size: "xl", bold: true, tone: "default", lineHeight: 26 },
   /** Info line under a title: author, date, duration, reading time. */
   meta: { size: "sm", bold: false, tone: "muted" },
-} as const satisfies Record<
-  string,
-  {
-    size: FontSizeToken;
-    bold: boolean;
-    tone: "default" | "muted";
-  }
->;
+} as const satisfies Record<string, TextVariantSpec>;
 
 export type TextVariant = keyof typeof textVariants;

--- a/src/screens/ActionTab/components/RegionMap.tsx
+++ b/src/screens/ActionTab/components/RegionMap.tsx
@@ -102,10 +102,7 @@ const RegionMap = () => {
           flex: 1,
         }}
       >
-        <UiText
-          size="xl"
-          style={[globalStyles.whiteText, { fontFamily: "SourceSansProBold" }]}
-        >
+        <UiText size="xl" bold style={globalStyles.whiteText}>
           Bundesländer Ranking
         </UiText>
         <UiSpace size={10} />

--- a/src/screens/ActionTab/components/statistics/StatisticsPanel.tsx
+++ b/src/screens/ActionTab/components/statistics/StatisticsPanel.tsx
@@ -61,10 +61,8 @@ const StatisticsPanel = ({
         <StatisticsIcon name={icon} size={32} color="white" />
         <UiText
           size="xl"
-          style={[
-            globalStyles.whiteText,
-            { fontFamily: "SourceSansProBold", marginLeft: 10 },
-          ]}
+          bold
+          style={[globalStyles.whiteText, { marginLeft: 10 }]}
         >
           {title}
         </UiText>

--- a/src/screens/Home/components/article/Body.tsx
+++ b/src/screens/Home/components/article/Body.tsx
@@ -13,6 +13,7 @@ import RenderHtml, { defaultHTMLElementModels } from "react-native-render-html";
 
 import Colors from "#/constants/Colors";
 import Config from "#/constants/Config";
+import { CONTENT_LINE_HEIGHT } from "#/constants/FontSizes";
 import { SOURCE_SANS_FONTS } from "#/constants/GlobalStyles";
 import Statistics from "#/helpers/Statistics";
 import SourcesStore from "#/helpers/Stores/SourcesStore";
@@ -164,7 +165,7 @@ const Body = (properties: BodyProperties) => {
       domVisitors={{ onElement }}
       baseStyle={{
         fontFamily: "SourceSansPro",
-        lineHeight: 27,
+        lineHeight: CONTENT_LINE_HEIGHT,
         maxWidth: maxWidth,
         color: Colors[colorScheme].text,
       }}

--- a/src/screens/Home/components/article/Header.tsx
+++ b/src/screens/Home/components/article/Header.tsx
@@ -143,19 +143,12 @@ const Header = (properties: HeaderProperties) => {
         <ImageCreditBadge credit={article.imageCredit} position="bottomRight" />
       </View>
       <UiSpace size={30} />
-      <Typography
-        type="title"
-        style={{
-          paddingHorizontal: 20,
-          textAlign: "left",
-        }}
-      >
+      <Typography type="title" style={{ paddingHorizontal: 20 }}>
         {article_title}
       </Typography>
       <Typography
         type="meta"
         style={{
-          textAlign: "left",
           paddingVertical: 10,
           paddingHorizontal: 20,
         }}
@@ -241,11 +234,7 @@ const Header = (properties: HeaderProperties) => {
             <UiSpace size={20} />
             <Typography
               type="title"
-              style={{
-                color: Colors.dark.text,
-                paddingHorizontal: 20,
-                textAlign: "left",
-              }}
+              style={{ color: Colors.dark.text, paddingHorizontal: 20 }}
             >
               {article_title}
             </Typography>
@@ -254,11 +243,7 @@ const Header = (properties: HeaderProperties) => {
                 pins the light-on-dark colors instead of following the theme. */}
             <Typography
               type="meta"
-              style={{
-                color: Colors.dark.textMuted,
-                paddingHorizontal: 20,
-                textAlign: "left",
-              }}
+              style={{ color: Colors.dark.textMuted, paddingHorizontal: 20 }}
             >
               {article.authors?.length ? (
                 <>

--- a/src/screens/Home/components/article/Header.tsx
+++ b/src/screens/Home/components/article/Header.tsx
@@ -15,6 +15,7 @@ import ViewShot, { type ViewShotRef } from "react-native-view-shot";
 
 import AudioPlayer from "#/components/audio/AudioPlayer";
 import ImageCreditBadge from "#/components/posts/ImageCreditBadge";
+import Typography from "#/components/ui/Typography";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
@@ -142,18 +143,17 @@ const Header = (properties: HeaderProperties) => {
         <ImageCreditBadge credit={article.imageCredit} position="bottomRight" />
       </View>
       <UiSpace size={30} />
-      <UiText
-        size="xxl"
+      <Typography
+        type="title"
         style={{
           paddingHorizontal: 20,
           textAlign: "left",
-          fontFamily: "SourceSansProBold",
         }}
       >
         {article_title}
-      </UiText>
-      <UiText
-        size="lg"
+      </Typography>
+      <Typography
+        type="meta"
         style={{
           textAlign: "left",
           paddingVertical: 10,
@@ -189,7 +189,7 @@ const Header = (properties: HeaderProperties) => {
               : "";
           })[0]
         }
-      </UiText>
+      </Typography>
       <ArticleStats
         article_link={article_link}
         reading_time={article.reading_time}
@@ -239,22 +239,23 @@ const Header = (properties: HeaderProperties) => {
               onLoad={() => setImageLoaded(true)}
             />
             <UiSpace size={20} />
-            <UiText
-              size="xxl"
+            <Typography
+              type="title"
               style={{
                 color: Colors.dark.text,
                 paddingHorizontal: 20,
                 textAlign: "left",
-                fontFamily: "SourceSansProBold",
               }}
             >
               {article_title}
-            </UiText>
+            </Typography>
             <UiSpace size={20} />
-            <UiText
-              size="lg"
+            {/* The share card is always rendered on the dark background, so it
+                pins the light-on-dark colors instead of following the theme. */}
+            <Typography
+              type="meta"
               style={{
-                color: Colors.dark.text,
+                color: Colors.dark.textMuted,
                 paddingHorizontal: 20,
                 textAlign: "left",
               }}
@@ -285,7 +286,7 @@ const Header = (properties: HeaderProperties) => {
                     : "";
                 })[0]
               }
-            </UiText>
+            </Typography>
           </View>
         </ViewShot>
       </Modal>

--- a/src/screens/Home/components/article/Recommended.tsx
+++ b/src/screens/Home/components/article/Recommended.tsx
@@ -46,9 +46,9 @@ const Recommended = (properties: RecommendedProperties) => {
       {matches.length > 0 && (
         <UiText
           size="xl"
+          bold
           style={{
             padding: 10,
-            fontFamily: "SourceSansProBold",
           }}
         >
           Passend dazu:

--- a/src/screens/PersonalTab/components/MySources.tsx
+++ b/src/screens/PersonalTab/components/MySources.tsx
@@ -7,6 +7,7 @@ import Swipeable, {
 
 import { DeleteIcon, LinkIcon } from "#/components/Icons";
 import RightAction from "#/components/actions/RightAction";
+import Typography from "#/components/ui/Typography";
 import UiCard from "#/components/ui/UiCard";
 import UiEmptyState from "#/components/ui/UiEmptyState";
 import UiPressable from "#/components/ui/UiPressable";
@@ -80,11 +81,7 @@ const MySources = () => {
         return (
           <UiCard key={group.slug} style={{ padding: 0 }}>
             <View style={{ padding: 30, gap: 10 }}>
-              {title && (
-                <UiText bold size="lg">
-                  {title}
-                </UiText>
-              )}
+              {title && <Typography type="heading">{title}</Typography>}
               {group.entries.map((entry) => (
                 <Swipeable
                   key={entry.href}

--- a/src/screens/Search/components/AISearch.tsx
+++ b/src/screens/Search/components/AISearch.tsx
@@ -52,13 +52,7 @@ const AISearch = ({
           onPress={() => onLinkPress(item.url, router)}
           text={item.text}
           subtitle={
-            <UiText
-              size="base"
-              style={{
-                fontFamily: "SourceSansProBold",
-                color: textColor,
-              }}
-            >
+            <UiText size="base" bold style={{ color: textColor }}>
               {hostname ?? item.url}
             </UiText>
           }

--- a/src/screens/Search/components/SearchHeader.tsx
+++ b/src/screens/Search/components/SearchHeader.tsx
@@ -8,7 +8,6 @@ import UiHeaderGradient from "#/components/ui/UiHeaderGradient";
 import UiPressable from "#/components/ui/UiPressable";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
-import { fontSizes } from "#/constants/FontSizes";
 import { INPUT_FONT_SIZE, globalStyles } from "#/constants/GlobalStyles";
 import { toast } from "#/helpers/toast";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
@@ -72,10 +71,10 @@ const SearchHeader = ({
         ]}
       >
         <UiText
+          bold
+          size="xxl"
           style={{
             paddingTop: 20,
-            fontFamily: "SourceSansProBold",
-            fontSize: fontSizes.xxl,
             color: corporate,
             flex: 1,
             textAlign: "center",

--- a/src/screens/Search/components/SearchResultItem.tsx
+++ b/src/screens/Search/components/SearchResultItem.tsx
@@ -8,6 +8,7 @@ import Typography from "#/components/ui/Typography";
 import UiCard from "#/components/ui/UiCard";
 import UiPressable from "#/components/ui/UiPressable";
 import Colors from "#/constants/Colors";
+import { CONTENT_LINE_HEIGHT } from "#/constants/FontSizes";
 import {
   CARD_PADDING,
   CONTENT_HORIZONTAL_PADDING,
@@ -47,7 +48,7 @@ const SearchResultItem = ({
   const baseStyle = useMemo(
     () => ({
       fontFamily: "SourceSansPro",
-      lineHeight: 24,
+      lineHeight: CONTENT_LINE_HEIGHT,
       color: textColor,
     }),
     [textColor],

--- a/src/screens/Search/components/SearchResultItem.tsx
+++ b/src/screens/Search/components/SearchResultItem.tsx
@@ -4,9 +4,9 @@ import { useMemo } from "react";
 import { View, useWindowDimensions } from "react-native";
 import RenderHtml from "react-native-render-html";
 
+import Typography from "#/components/ui/Typography";
 import UiCard from "#/components/ui/UiCard";
 import UiPressable from "#/components/ui/UiPressable";
-import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
 import {
   CARD_PADDING,
@@ -55,20 +55,18 @@ const SearchResultItem = ({
 
   const content = (
     <UiCard>
-      {title ? (
-        <UiText bold size="lg" style={{ marginBottom: 10 }}>
-          {decode(title)}
-        </UiText>
-      ) : null}
+      <View style={{ gap: 10 }}>
+        {title ? <Typography type="heading">{decode(title)}</Typography> : null}
 
-      <RenderHtml
-        source={{ html: text }}
-        tagsStyles={styles}
-        ignoredDomTags={IGNORED_DOM_TAGS}
-        systemFonts={SOURCE_SANS_FONTS}
-        contentWidth={contentWidth}
-        baseStyle={baseStyle}
-      />
+        <RenderHtml
+          source={{ html: text }}
+          tagsStyles={styles}
+          ignoredDomTags={IGNORED_DOM_TAGS}
+          systemFonts={SOURCE_SANS_FONTS}
+          contentWidth={contentWidth}
+          baseStyle={baseStyle}
+        />
+      </View>
 
       {subtitle}
     </UiCard>

--- a/src/screens/Settings/components/licenses/LicenseListItem.tsx
+++ b/src/screens/Settings/components/licenses/LicenseListItem.tsx
@@ -89,7 +89,7 @@ const LicensesListItem = (
           <Link style={[styles.text, { color: textColor }]} url={licenseUrl}>
             {licenses}
           </Link>
-          <UiText size="base" style={[styles.name, { color: textColor }]}>
+          <UiText size="base" bold style={[styles.name, { color: textColor }]}>
             {packageVersion}
           </UiText>
         </View>
@@ -150,7 +150,6 @@ const getStyles = (cardBackground: string) =>
       marginLeft: 8,
     },
     name: {
-      fontFamily: "SourceSansProBold",
       flexShrink: 1, // ensure the title can shrink instead of overflowing
     },
     text: {


### PR DESCRIPTION
## What & why

Text styling across the app was hand-rolled per screen: the same "kind" of text (a screen title, a card title, a meta line, a section heading, body copy) was expressed as an ad-hoc `size` + `fontFamily` + `color` + `lineHeight` + `textAlign` tuple, copied around and slowly drifting apart. The article and podcast screens had visibly diverged (different title sizes, different meta colors).

This introduces a semantic **`Typography`** component backed by a small table of named roles, and consolidates all hand-rolled styling onto scales and constants:

```tsx
<Typography type="title">…</Typography>       // detail-screen headline
<Typography type="cardTitle">…</Typography>   // feed-card headline
<Typography type="heading">…</Typography>     // section / field / author label
<Typography type="body">…</Typography>        // reading copy
<Typography type="meta">…</Typography>        // author · date · duration
```

Plus centralized scales for **every text style dimension**:
- **sizes** via `fontSizes` (xs–xxl)
- **weight** via `UiText`'s `bold` prop (not `fontFamily: "SourceSansProBold"`)
- **colors/tones** via `Typography` (not inline `style={{ color: textMuted }}`)
- **line heights** via `LINE_HEIGHTS` (xs–xxl) and `CONTENT_LINE_HEIGHT` (27)
- **radii** via `radii.full` for pills/capsules (not magic `40`)
- **layout** via flex `gap` (not individual margins)

## How it's layered

1. **`src/constants/FontSizes.ts`** — `fontSizes` scale + `LINE_HEIGHTS` per size + `CONTENT_LINE_HEIGHT` (article body baseline, 27).
2. **`src/constants/BorderRadius.ts`** — `radii` scale (xs–xxl) + `radii.full` for flexible-size pills.
3. **`src/constants/TextVariants.ts`** — the semantic `Typography` roles. Each bundles `size` + `bold` + color `tone` (+ optional `lineHeight`):

   | `type` | size | weight | color | line height |
   |---|---|---|---|---|
   | `title` | `xxl` | bold | default | — |
   | `cardTitle` | `xl` | bold | default | `LINE_HEIGHTS.xl` (27) |
   | `heading` | `lg` | bold | default | — |
   | `body` | `lg` | regular | default | `CONTENT_LINE_HEIGHT` (27) |
   | `meta` | `sm` | regular | muted | — |

4. **`src/components/ui/UiText.tsx`** — stays a dumb styled primitive (size/bold/color/style). No knowledge of roles.
5. **`src/components/ui/Typography.tsx`** — owns the semantic layer end-to-end: resolves `type` into concrete `UiText` props for the active color scheme, applies line height, defaults to left alignment. `size` / `bold` / an explicit `color` or `textAlign` in `style` still override the role for one-offs.

## Migrated

- **Detail screens** — article header (on-screen + Instagram share card) and podcast episode screen: `title` + `meta`, and the podcast description → `body`.
- **Feed cards** — `ArticlePost` / `PodcastPost`: `cardTitle` + `meta`.
- **Section/label headings** — 13 `<UiText bold size="lg">` sites → `heading`.
- **Body copy** — social-post fulltext (Mastodon fulltext + thread answers, Bluesky card/detail/`PostText`, Instagram caption, podcast description) → `body`.
- **Line heights** — all hand-rolled values (`19`, `22`, `24`, `26`) → `LINE_HEIGHTS[size]` or `CONTENT_LINE_HEIGHT`.
- **Bold weight** — all inline `fontFamily: "SourceSansProBold"` → `bold` prop (8 components).
- **Pills/capsules** — all magic "big radius" values (`40`, `20`) → `radii.full` (3 components + `globalStyles.input`).

## Layout cleanups (flex gap over margins)

- Feed cards space title↔meta with a shared `CARD_CONTENT_GAP` flex gap instead of `UiSpace`/margins; the same gap fixes the cramped image↔text spacing on **single-image Instagram posts**.
- Contact-form field labels and search-result title use a `gap` wrapper instead of `marginBottom`.
- Dropped `ArticlePost`'s `titleStyle` / `authorDateStyle` objects entirely.

## Intended visual changes (worth a look)

- Podcast **card** title grows `lg → xl` to match the article card; its title no longer truncates at two lines.
- Card **meta** lines and the article-detail subtitle move to `meta` (`sm`, muted).
- **Body copy** line height unifies to 27 (social posts were 24); the podcast description grows `base → lg`.
- **Card titles** (article + podcast) and **ClaimPost titles** now have consistent line height (27) for multi-line overflow.
- The image-less podcast card no longer prints a "Podcast" text label.
- All **pills and capsules** (category buttons, input fields, buttons) use `radii.full` so they stay fully rounded regardless of size or padding changes.

## Tests

`Typography` / `UiText` unit tests cover role resolution, tone, line height, and override precedence. `pnpm check:ts`, eslint/prettier, and the full suite (134 suites / ~1014 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
