### PR TITLE
Dedupe podcast episodes re-uploaded to YouTube in home feed

### DIFF
--- a/__tests__/helpers/fetchers/FetcherUtilities.test.tsx
+++ b/__tests__/helpers/fetchers/FetcherUtilities.test.tsx
@@ -182,6 +182,61 @@ describe("FetcherUtils", () => {
     });
   });
 
+  describe("removeYouTubePodcastDuplicates", () => {
+    const podcastPost = {
+      id: "podcast-1",
+      datetime: "2021-01-01T00:00:00Z",
+      contentType: "podcast",
+      data: { title: "Folge 25: Danger Dan – die Heizhammer-Lüge" },
+    } as unknown as Post<unknown>;
+
+    const matchingYouTubePost = {
+      id: "yt-1",
+      datetime: "2021-01-01T01:00:00Z",
+      data: {
+        snippet: {
+          title: "Podcast Folge 25: Danger Dan - die Heizhammer-Lüge",
+        },
+      },
+    } as unknown as Post<unknown>;
+
+    const unrelatedYouTubePost = {
+      id: "yt-2",
+      datetime: "2021-01-02T00:00:00Z",
+      data: { snippet: { title: "Ein ganz anderes Video" } },
+    } as unknown as Post<unknown>;
+
+    it("drops a YouTube post whose title matches a podcast episode (case/dash/prefix-insensitive)", () => {
+      const result = FetcherUtilities.removeYouTubePodcastDuplicates([
+        podcastPost,
+        matchingYouTubePost,
+        unrelatedYouTubePost,
+      ]);
+      expect(result).toEqual([podcastPost, unrelatedYouTubePost]);
+    });
+
+    it("keeps the YouTube post untouched when no podcast post is present", () => {
+      const result = FetcherUtilities.removeYouTubePodcastDuplicates([
+        matchingYouTubePost,
+        unrelatedYouTubePost,
+      ]);
+      expect(result).toEqual([matchingYouTubePost, unrelatedYouTubePost]);
+    });
+
+    it("leaves non-YouTube-shaped posts untouched", () => {
+      const wpPost = {
+        id: "wp-1",
+        datetime: "2021-01-01T02:00:00Z",
+        data: { title: "Some article" },
+      } as unknown as Post<unknown>;
+      const result = FetcherUtilities.removeYouTubePodcastDuplicates([
+        podcastPost,
+        wpPost,
+      ]);
+      expect(result).toEqual([podcastPost, wpPost]);
+    });
+  });
+
   describe("fetchAndProcessPosts", () => {
     const p1 = {
       id: "1",

--- a/src/screens/Home/fetchers/FetcherUtilities.ts
+++ b/src/screens/Home/fetchers/FetcherUtilities.ts
@@ -1,4 +1,23 @@
-import type { Post, SafeFetchFunction } from "#/types";
+import type {
+  PodcastEpisodeProperties,
+  Post,
+  SafeFetchFunction,
+  YouTubePostProperties,
+} from "#/types";
+import { FAV_TYPE_PODCAST } from "#/types";
+
+// The channel re-uploads podcast episodes to YouTube titled "Podcast <episode title>",
+// so a normalized-title match reliably identifies the YouTube upload as a duplicate
+// of the podcast episode (verified against live feeds: podigee "Folge 25: ..." vs
+// YouTube "Podcast Folge 25: ...").
+const PODCAST_TITLE_PREFIX = /^podcast\s+/i;
+const normalizeEpisodeTitle = (title: string): string =>
+  title
+    .toLowerCase()
+    .replace(PODCAST_TITLE_PREFIX, "")
+    .replaceAll(/[‐-―]/g, "-")
+    .replaceAll(/\s+/g, " ")
+    .trim();
 
 const FetcherUtilities = {
   isAbortError(error: unknown): boolean {
@@ -69,6 +88,30 @@ const FetcherUtilities = {
     });
   },
 
+  /**
+   * Drops YouTube posts that are re-uploads of a podcast episode already present
+   * in the same batch (title match, see normalizeEpisodeTitle). If the podcast
+   * feed is disabled for the user, no podcast posts are present here and the
+   * YouTube post is left untouched, so it still appears in the feed.
+   */
+  removeYouTubePodcastDuplicates(_posts: Post<unknown>[]): Post<unknown>[] {
+    const podcastTitles = new Set(
+      _posts
+        .filter((post) => post.contentType === FAV_TYPE_PODCAST)
+        .map((post) =>
+          normalizeEpisodeTitle((post.data as PodcastEpisodeProperties).title),
+        ),
+    );
+    if (podcastTitles.size === 0) return _posts;
+
+    return _posts.filter((post) => {
+      const ytTitle = (post.data as Partial<YouTubePostProperties>)?.snippet
+        ?.title;
+      if (typeof ytTitle !== "string") return true;
+      return !podcastTitles.has(normalizeEpisodeTitle(ytTitle));
+    });
+  },
+
   async fetchAndProcessPosts(
     fetchers: {
       fetcher: (
@@ -116,7 +159,12 @@ const FetcherUtilities = {
         );
       }
 
-      return FetcherUtilities.removeDuplicates([...allPosts, ...oldPosts]).sort(
+      allPosts = FetcherUtilities.removeYouTubePodcastDuplicates([
+        ...allPosts,
+        ...oldPosts,
+      ]);
+
+      return FetcherUtilities.removeDuplicates(allPosts).sort(
         options.prioSort
           ? FetcherUtilities.sortByPriority
           : FetcherUtilities.sortByDatetime,


### PR DESCRIPTION
## Summary
- Podcast episodes get re-uploaded to YouTube (titled `"Podcast <episode title>"`), so both the `podcast` and `yt` fetchers were surfacing the same episode as two separate home-feed entries.
- `FetcherUtilities.removeDuplicates` only dedupes by `post.id`, and podcast episode GUIDs / YouTube video IDs never overlap, so no existing dedup step caught this.
- Adds `removeYouTubePodcastDuplicates`, called before the id-based dedup in `fetchAndProcessPosts`. It normalizes titles (case, whitespace, dash variants, strips the `"Podcast "` prefix) and drops the YouTube post when a matching podcast post is present in the same batch.
- Verified the title pattern against the live feeds (podigee RSS vs. the YouTube channel RSS) — e.g. `"Folge 25: Danger Dan, die Heizhammer-Lüge entlarvt..."` vs. `"Podcast Folge 25: Danger Dan, die Heizhammer-Lüge entlarvt..."`.
- If podcast content is disabled for the user, no podcast post ever reaches this step, so the YouTube upload is left untouched and still appears — this was requested behavior, not incidental.

## Test plan
- [x] `pnpm check:ts` — clean
- [x] `pnpm lint:fix` — 0 errors (pre-existing unrelated warnings only)
- [x] `pnpm check` (type check + spell check) — clean
- [x] `pnpm test` — 135 suites / 1041 tests passing, including new coverage for `removeYouTubePodcastDuplicates` (match/no-podcast-present/non-YouTube-shaped-post cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)