### PR TITLE
chore: add icon-prefixed job names across workflows

### DIFF
--- a/.github/workflows/check-test-and-lint.yml
+++ b/.github/workflows/check-test-and-lint.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-test-and-lint:
+    name: 🧪 Check, Test and Lint
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   deploy:
+    name: 🚀 Deploy Web to Bunny
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   expo-preview:
+    name: 🚀 Expo Preview
     # Dependabot-triggered runs can't read Actions secrets, so EXPO_TOKEN is empty,
     # the EAS setup step is skipped, and `eas --version` fails. A per-PR QR preview
     # isn't useful for a dependency bump anyway, so skip the job for Dependabot.

--- a/.github/workflows/expo-release-beta.yml
+++ b/.github/workflows/expo-release-beta.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test-and-lint:
+    name: 🧪 Test and Lint
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-slim
     steps:
@@ -27,6 +28,7 @@ jobs:
         uses: ./.github/actions/test-and-lint
 
   build-and-release-stores:
+    name: 🚀 Build and Release to Stores
     needs: test-and-lint
     runs-on: ubuntu-slim
     steps:
@@ -47,6 +49,7 @@ jobs:
         run: APP=volksverpetzer eas build --profile internal --platform ios --clear-cache --non-interactive --auto-submit --no-wait
 
   build-and-release-apk:
+    name: 🎂 Build and Release APK
     needs: build-and-release-stores
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/expo-release-mimikama.yml
+++ b/.github/workflows/expo-release-mimikama.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test-and-lint:
+    name: 🧪 Test and Lint
     runs-on: ubuntu-slim
     steps:
       - name: ⬇️ Checkout repo
@@ -23,6 +24,7 @@ jobs:
         uses: ./.github/actions/test-and-lint
 
   release-prepare:
+    name: 📄 Prepare Release
     needs: test-and-lint
     runs-on: ubuntu-slim
     outputs:
@@ -46,13 +48,13 @@ jobs:
             --onlyDirectDependencies \
             --onlyProdDependencies
 
-      - name: Build license data.tsx
+      - name: 📄 Build license data.tsx
         run: |
           echo "export default " > src/screens/Settings/components/licenses/data.tsx
           cat src/screens/Settings/components/licenses/licenseData.json >> src/screens/Settings/components/licenses/data.tsx
           echo ";" >> src/screens/Settings/components/licenses/data.tsx
 
-      - name: Pushing license data changes
+      - name: 🫸 Push license data changes
         run: |
           git config --local user.name "github-actions"
           git config --local user.email "actions@github.com"
@@ -64,11 +66,12 @@ jobs:
             git push --force-with-lease
           fi
 
-      - name: Get prepared commit SHA
+      - name: 🔗 Get prepared commit SHA
         id: get_sha
         run: echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_STATE
 
   release-build:
+    name: 🚀 Release Build
     needs: release-prepare
     runs-on: ubuntu-slim
     strategy:

--- a/.github/workflows/expo-release.yml
+++ b/.github/workflows/expo-release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test-and-lint:
+    name: 🧪 Test and Lint
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-slim
     steps:
@@ -26,6 +27,7 @@ jobs:
         uses: ./.github/actions/test-and-lint
 
   build-and-release-stores:
+    name: 🚀 Build and Release to Stores
     needs: test-and-lint
     runs-on: ubuntu-slim
     steps:
@@ -46,6 +48,7 @@ jobs:
         run: APP=volksverpetzer eas build --platform ios --clear-cache --non-interactive --auto-submit --no-wait
 
   build-and-release-apk:
+    name: 🎂 Build and Release APK
     needs: build-and-release-stores
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   update-licenses:
+    name: 📄 Update License Data
     runs-on: ubuntu-slim
     steps:
       - name: ⬇️ Checkout repo


### PR DESCRIPTION
## Summary
- Add an icon-prefixed `name:` to every job across all workflows (steps already had this; jobs didn't), so the Actions run summary is consistent at both levels — this repo is the style reference for the other vvp_* repos.
- Fill in a couple of step names in `expo-release-mimikama.yml` that were missing icons.

No workflow logic changed — only `name:` fields.

Part of a repo-wide pass to align GitHub Actions workflows across vvp_* repos.

## Test plan
- [x] All workflow YAML files parse successfully (`yaml.safe_load`)
- [ ] CI run on this branch (check-test-and-lint.yml, expo-preview.yml) passes