### PR TITLE
fix: write prepared commit SHA to GITHUB_OUTPUT, not GITHUB_STATE

### DIFF
--- a/.github/workflows/expo-release-mimikama.yml
+++ b/.github/workflows/expo-release-mimikama.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Get prepared commit SHA
         id: get_sha
-        run: echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_STATE
+        run: echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   release-build:
     needs: release-prepare

--- a/.github/workflows/expo-release-mimikama.yml
+++ b/.github/workflows/expo-release-mimikama.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Get prepared commit SHA
         id: get_sha
-        run: echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   release-build:
     needs: release-prepare


### PR DESCRIPTION
## Summary
- `expo-release-mimikama.yml`'s `release-prepare` job declares `outputs.commit: \${{ steps.get_sha.outputs.commit_sha }}`, but the step that sets `commit_sha` wrote to `$GITHUB_STATE` instead of `$GITHUB_OUTPUT`. `$GITHUB_STATE` is for `actions/toolkit` save-state between a main/post step in the *same* action, not for exposing step outputs to other jobs — so `commit_sha` was always empty.
- Downstream, `release-build`'s checkout step uses `ref: \${{ needs.release-prepare.outputs.commit || github.sha }}`, so this silently fell back to `github.sha` — the commit *before* the license-data bump commit that `release-prepare` just pushed — instead of the commit that actually includes the fresh license data.
- Fix: write to `$GITHUB_OUTPUT` instead.

## Test plan
- [x] Workflow YAML parses successfully
- [ ] Next push to `main-mimikama` confirms `release-build` checks out the license-bump commit (not the parent), e.g. by checking the SHA in the build logs