### PR TITLE
Adopt shared elevation tokens from @volksverpetzer/design-tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "exclude": []
     }
   },
-  "packageManager": "pnpm@11.21.0",
+  "packageManager": "pnpm@11.22.0",
   "engines": {
     "node": "24.x"
   },
@@ -63,7 +63,7 @@
     "@react-native-vector-icons/octicons": "21.1.2",
     "@rive-app/react-native": "0.4.19",
     "@stripe/stripe-react-native": "0.64.0",
-    "@volksverpetzer/design-tokens": "0.3.0",
+    "@volksverpetzer/design-tokens": "0.4.0",
     "buffer": "6.0.3",
     "domhandler": "6.0.1",
     "domutils": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: 0.64.0
         version: 0.64.0(expo@57.0.13)(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/jest-preset@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@volksverpetzer/design-tokens':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.4.0
+        version: 0.4.0
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -2373,8 +2373,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@volksverpetzer/design-tokens@0.3.0':
-    resolution: {integrity: sha512-Y9mEXSdmwV/he7q616I6IZVHsXoTmt2uCHAKRauEN6Z6qy6D8RrHzZ5vJDC151dxiHRt7eAe2J6FEywBaBgGwA==}
+  '@volksverpetzer/design-tokens@0.4.0':
+    resolution: {integrity: sha512-tG5d9HJEM8vdHHprEphGRS/rzhxVV1EG7UKhjX9m/VBjlCJ3XjahGbwoht95DUAAEL9JNx+h1q1+xihMCMDgbA==}
 
   '@xmldom/xmldom@0.8.14':
     resolution: {integrity: sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==}
@@ -9300,7 +9300,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@volksverpetzer/design-tokens@0.3.0': {}
+  '@volksverpetzer/design-tokens@0.4.0': {}
 
   '@xmldom/xmldom@0.8.14': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ minimumReleaseAgeExclude:
   - "@expo/prebuild-config@57.0.12"
   - "@expo/router-server@57.0.6"
   - "@expo/ui@57.0.11"
-  - "@volksverpetzer/design-tokens@0.3.0"
+  - "@volksverpetzer/design-tokens@0.4.0"
   - babel-preset-expo@57.0.7
   - expo-asset@57.0.11
   - expo-build-properties@57.0.11

--- a/src/components/buttons/BackToTopButton.tsx
+++ b/src/components/buttons/BackToTopButton.tsx
@@ -4,6 +4,7 @@ import Animated, { FadeInDown, FadeOutDown } from "react-native-reanimated";
 import { ChevronIcon } from "#/components/Icons";
 import UiPressable from "#/components/ui/UiPressable";
 import Colors from "#/constants/Colors";
+import { elevation } from "#/constants/Elevation";
 import { iconSizes } from "#/constants/IconSizes";
 import { useAppColorScheme } from "#/hooks/useAppColorScheme";
 
@@ -55,7 +56,7 @@ const styles = StyleSheet.create({
   button: {
     alignItems: "center",
     borderRadius: 24,
-    elevation: 4,
+    elevation: elevation.sm.android,
     height: 48,
     justifyContent: "center",
     overflow: "hidden",
@@ -64,7 +65,7 @@ const styles = StyleSheet.create({
   container: {
     borderRadius: 24,
     bottom: 20,
-    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.25)",
+    boxShadow: elevation.sm.boxShadow,
     position: "absolute",
     right: 20,
   },

--- a/src/components/posts/ArticlePost.tsx
+++ b/src/components/posts/ArticlePost.tsx
@@ -13,6 +13,7 @@ import UiText from "#/components/ui/UiText";
 import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
 import Config from "#/constants/Config";
+import { elevation } from "#/constants/Elevation";
 import {
   CARD_CONTENT_GAP,
   DEFAULT_IMAGE_ASPECT_RATIO,
@@ -170,11 +171,11 @@ const ArticlePost = (properties: ArticlePostScreenProperties) => {
     if (!elevated) return;
     const isDark = colorScheme === "dark";
     const shadowRgb = isDark ? "255, 255, 255" : "0, 0, 0";
-    const shadowOpacity = isDark ? 0.12 : 0.2;
+    const shadowOpacity = isDark ? 0.12 : elevation.xs.opacity;
     return {
       borderRadius: radii.lg,
-      boxShadow: `0px 1px 1.41px rgba(${shadowRgb}, ${shadowOpacity})`,
-      elevation: 2,
+      boxShadow: `0px ${elevation.xs.offsetY}px ${elevation.xs.blur}px rgba(${shadowRgb}, ${shadowOpacity})`,
+      elevation: elevation.xs.android,
     };
   }, [elevated, colorScheme]);
   const imageStyle = useMemo(

--- a/src/constants/Elevation.ts
+++ b/src/constants/Elevation.ts
@@ -1,0 +1,14 @@
+/**
+ * Central elevation/shadow scale for the app — sourced from `@volksverpetzer/design-tokens`,
+ * the shared token package also consumed by vvp_link_shortener and
+ * vvp_divi5_extensions. Edit the scale there (packages/tokens/tokens/elevation.json),
+ * not here.
+ *
+ * Color is always neutral black. A brand-colored shadow (e.g. a pink CTA
+ * glow) is a local, one-off design choice, not part of this scale — keep
+ * those hand-written at the call site.
+ */
+export {
+  elevation,
+  type ElevationToken,
+} from "@volksverpetzer/design-tokens/rn/shared";


### PR DESCRIPTION
## Summary

- Bumps `@volksverpetzer/design-tokens` to 0.4.0, which adds an `elevation` scale (Android `elevation` paired with an equivalent iOS/web `boxShadow` per step).
- Adds `src/constants/Elevation.ts` as a thin re-export shim, following the same pattern already established for `Spacing.ts`/`IconSizes.ts`/`BorderRadius.ts`/`FontSizes.ts`.
- Replaces the two hand-rolled shadow/elevation values in the codebase with the shared tokens:
  - `BackToTopButton.tsx`'s floating button (`elevation: 4` / `boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.25)"` → `elevation.sm`)
  - `ArticlePost.tsx`'s elevated card shadow (`elevation: 2` / hand-built `boxShadow` string → `elevation.xs`)

Brand-colored shadows (e.g. a one-off CTA glow) stay hand-written at the call site — only neutral-black elevation/shadow values are covered by the scale, matching the doc comment on `Elevation.ts`.

## Test plan

- [x] `pnpm lint:fix` — clean (only pre-existing `require()` warnings in test files)
- [x] `pnpm check` — type check + spell check clean
- [x] `pnpm test -- BackToTopButton ArticlePost` — both suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)