### PR TITLE
ci: push store metadata to Google Play and App Store on release

### DIFF
--- a/.github/workflows/expo-release.yml
+++ b/.github/workflows/expo-release.yml
@@ -48,6 +48,7 @@ jobs:
         run: APP=volksverpetzer eas build --platform ios --clear-cache --non-interactive --auto-submit --no-wait
 
   push-play-metadata:
+    name: 📝 Push Google Play Metadata
     needs: build-and-release-stores
     runs-on: ubuntu-latest
     timeout-minutes: 180
@@ -85,6 +86,7 @@ jobs:
           PLAY_JSON_KEY_FILE: ${{ runner.temp }}/play-key.json
 
   push-appstore-metadata:
+    name: 📝 Push App Store Metadata
     needs: build-and-release-stores
     runs-on: ubuntu-latest
     timeout-minutes: 180

--- a/.github/workflows/expo-release.yml
+++ b/.github/workflows/expo-release.yml
@@ -47,6 +47,71 @@ jobs:
       - name: 🚀 EAS Build - ios
         run: APP=volksverpetzer eas build --platform ios --clear-cache --non-interactive --auto-submit --no-wait
 
+  push-play-metadata:
+    needs: build-and-release-stores
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v7
+
+      - name: 🏗 Setup environment
+        uses: ./.github/actions/setup-node-pnpm-expo
+        with:
+          install-deps: "false"
+          setup-expo-token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: ⏳ Wait for EAS android build
+        id: android-build
+        run: node scripts/wait-for-eas-build.mjs --platform android --commit ${{ github.sha }}
+
+      - name: 🛠 Prepare Play metadata
+        run: node scripts/prepare-play-metadata.mjs --play-version-code ${{ steps.android-build.outputs.build-version }}
+
+      - name: 💎 Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: 🔑 Write Play service account key
+        run: printf '%s' "$PLAY_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/play-key.json"
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+
+      - name: 🚀 Push metadata to Google Play
+        run: bundle exec fastlane android push_metadata version_code:${{ steps.android-build.outputs.build-version }}
+        env:
+          PLAY_JSON_KEY_FILE: ${{ runner.temp }}/play-key.json
+
+  push-appstore-metadata:
+    needs: build-and-release-stores
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v7
+
+      - name: 🏗 Setup environment
+        uses: ./.github/actions/setup-node-pnpm-expo
+        with:
+          install-deps: "false"
+          setup-expo-token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: ⏳ Wait for EAS ios build
+        run: node scripts/wait-for-eas-build.mjs --platform ios --commit ${{ github.sha }}
+
+      # auto-submit runs asynchronously after the build — give it time to
+      # deliver the build so the release notes land on the new version
+      - name: ⏳ Wait for auto-submit
+        run: sleep 300
+
+      - name: 🛠 Generate store.config.json
+        run: node scripts/prepare-store-config.mjs
+
+      - name: 🚀 Push metadata to App Store
+        run: APP=volksverpetzer eas metadata:push --profile production --non-interactive
+
   build-and-release-apk:
     name: 🎂 Build and Release APK
     needs: build-and-release-stores

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ coverage/
 /android
 /Volksverpetzer.app
 /Mimikama.app
+# store metadata push (generated in CI)
+/build/
+/store.config.json
+/vendor/bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,366 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.8)
+    abbrev (0.1.2)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    artifactory (3.0.17)
+    atomos (0.1.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1281.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.130.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.229.0)
+      aws-sdk-core (~> 3, >= 3.254.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    babosa (1.0.4)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    claide (1.1.0)
+    colored (1.2)
+    colored2 (3.1.2)
+    commander (4.6.0)
+      highline (~> 2.0.0)
+    csv (3.3.6)
+    declarative (0.0.20)
+    digest-crc (0.7.0)
+      rake (>= 12.0.0, < 14.0.0)
+    domain_name (0.6.20240107)
+    dotenv (2.8.1)
+    emoji_regex (3.2.3)
+    erb (6.0.7)
+    excon (1.7.0)
+      logger
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-cookie_jar (0.0.8)
+      faraday (>= 0.8.0)
+      http-cookie (>= 1.0.0)
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
+    fastimage (2.4.1)
+    fastlane (2.238.0)
+      CFPropertyList (>= 2.3, < 5.0.0)
+      abbrev (~> 0.1)
+      addressable (>= 2.9.0, < 3.0.0)
+      artifactory (~> 3.0)
+      aws-sdk-s3 (~> 1.197)
+      babosa (>= 1.0.3, < 2.0.0)
+      base64 (~> 0.2)
+      benchmark (>= 0.1.0)
+      bundler (>= 2.4.0, < 5.0.0)
+      colored (~> 1.2)
+      commander (~> 4.6)
+      csv (~> 3.3)
+      dotenv (>= 2.1.1, < 3.0.0)
+      emoji_regex (>= 0.1, < 4.0)
+      excon (>= 0.71.0, < 2.0.0)
+      faraday (~> 2.7)
+      faraday-cookie_jar (~> 0.0.8)
+      faraday-follow_redirects (~> 0.3)
+      faraday-multipart (~> 1.0)
+      faraday-retry (~> 2.0)
+      fastimage (>= 2.1.0, < 3.0.0)
+      fastlane-sirp (>= 1.1.0)
+      gh_inspector (>= 1.1.2, < 2.0.0)
+      google-apis-androidpublisher_v3 (~> 0.3)
+      google-apis-playcustomapp_v1 (~> 0.1)
+      google-cloud-env (>= 1.6.0, < 2.3.0)
+      google-cloud-storage (~> 1.31)
+      highline (~> 2.0)
+      http-cookie (~> 1.0.5)
+      irb (>= 1.8)
+      json (< 3.0.0)
+      jwt (>= 2.10.3, < 4)
+      logger (>= 1.6, < 2.0)
+      mini_magick (>= 4.9.4, < 5.0.0)
+      multi_json (~> 1.12)
+      multipart-post (>= 2.0.0, < 3.0.0)
+      mutex_m (~> 0.3)
+      naturally (~> 2.2)
+      nkf (~> 0.2)
+      optparse (>= 0.1.1, < 1.0.0)
+      ostruct (>= 0.1.0)
+      plist (>= 3.1.0, < 4.0.0)
+      rubyzip (>= 2.0.0, < 3.0.0)
+      security (= 0.1.5)
+      simctl (~> 1.6.3)
+      terminal-notifier (>= 2.0.0, < 3.0.0)
+      terminal-table (~> 4)
+      tty-screen (>= 0.6.3, < 1.0.0)
+      tty-spinner (>= 0.8.0, < 1.0.0)
+      word_wrap (~> 1.0.0)
+      xcodeproj (>= 1.13.0, < 2.0.0)
+      xcpretty (~> 0.4.1)
+      xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-sirp (1.1.0)
+    gh_inspector (1.1.3)
+    google-apis-androidpublisher_v3 (0.106.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-core (1.2.5)
+      addressable (~> 2.9)
+      faraday (~> 2.13)
+      faraday-follow_redirects (~> 0.3)
+      googleauth (~> 1.14)
+      mini_mime (~> 1.1)
+      multi_json (~> 1.11)
+      representable (~> 3.0)
+      retriable (>= 3.1, < 5.0)
+    google-apis-iamcredentials_v1 (0.28.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-playcustomapp_v1 (0.18.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-storage_v1 (0.66.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-cloud-core (1.9.0)
+      google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-env (2.2.2)
+      base64 (~> 0.2)
+      faraday (>= 1.0, < 3.a)
+    google-cloud-errors (1.7.0)
+    google-cloud-storage (1.62.0)
+      addressable (~> 2.8)
+      digest-crc (~> 0.4)
+      google-apis-core (>= 0.18, < 2)
+      google-apis-iamcredentials_v1 (~> 0.18)
+      google-apis-storage_v1 (>= 0.42)
+      google-cloud-core (~> 1.6)
+      googleauth (~> 1.9)
+      mini_mime (~> 1.0)
+    google-logging-utils (0.2.0)
+    googleauth (1.17.3)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      jwt (>= 1.4, < 4.0)
+      os (>= 0.9, < 2.0)
+      pstore (~> 0.1)
+      signet (>= 0.16, < 2.a)
+    highline (2.0.3)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
+    io-console (0.9.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jmespath (1.6.2)
+    json (2.21.2)
+    jwt (3.2.0)
+      base64
+    logger (1.7.0)
+    mini_magick (4.13.2)
+    mini_mime (1.1.5)
+    multi_json (1.21.1)
+    multipart-post (2.4.1)
+    mutex_m (0.3.0)
+    nanaimo (0.4.0)
+    naturally (2.3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    nkf (0.3.0)
+    optparse (0.8.1)
+    os (1.1.4)
+    ostruct (0.6.3)
+    plist (3.7.2)
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    pstore (0.2.1)
+    public_suffix (7.0.5)
+    rake (13.4.2)
+    rbs (4.1.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    reline (0.7.0)
+      io-console (~> 0.5)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    retriable (4.2.0)
+    rexml (3.4.4)
+    rouge (3.28.0)
+    rubyzip (2.4.1)
+    security (0.1.5)
+    signet (0.22.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 4.0)
+    simctl (1.6.10)
+      CFPropertyList
+      naturally
+    terminal-notifier (2.0.0)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    trailblazer-option (0.1.2)
+    tsort (0.2.0)
+    tty-cursor (0.7.1)
+    tty-screen (0.8.2)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
+    uber (0.1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    word_wrap (1.0.0)
+    xcodeproj (1.28.1)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      base64
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.4.0)
+      nkf
+      rexml (>= 3.3.6, < 4.0)
+    xcpretty (0.4.1)
+      rouge (~> 3.28.0)
+    xcpretty-travis-formatter (1.0.1)
+      xcpretty (~> 0.2, >= 0.0.7)
+
+PLATFORMS
+  arm64-darwin
+  arm64-darwin-25
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  fastlane
+
+CHECKSUMS
+  CFPropertyList (3.0.8) sha256=2c99d0d980536d3d7ab252f7bd59ac8be50fbdd1ff487c98c949bb66bb114261
+  abbrev (0.1.2) sha256=ad1b4eaaaed4cb722d5684d63949e4bde1d34f2a95e20db93aecfe7cbac74242
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
+  atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
+  aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
+  aws-partitions (1.1281.0) sha256=97fcc7d6a068ab790a1efcd8c6587c08fb108b4bed7ff1409cb47e0d642782ec
+  aws-sdk-core (3.254.1) sha256=518089e32134c3478cd4ec63d07fb966546a45e9e4cbf5f80d2cf16d5699d29b
+  aws-sdk-kms (1.130.0) sha256=a2e83662ca31b77a2a19c9aa2f40a98165a67270c18c718fe1c70d0cbd7cd749
+  aws-sdk-s3 (1.229.0) sha256=7dd11a111875b3505d2ec0a0a383a6aab6c1badb3d4e94e7fbb958a24451f596
+  aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
+  babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  claide (1.1.0) sha256=6d3c5c089dde904d96aa30e73306d0d4bd444b1accb9b3125ce14a3c0183f82e
+  colored (1.2) sha256=9d82b47ac589ce7f6cab64b1f194a2009e9fd00c326a5357321f44afab2c1d2c
+  colored2 (3.1.2) sha256=b13c2bd7eeae2cf7356a62501d398e72fde78780bd26aec6a979578293c28b4a
+  commander (4.6.0) sha256=7d1ddc3fccae60cc906b4131b916107e2ef0108858f485fdda30610c0f2913d9
+  csv (3.3.6) sha256=aba61e7e507a66f03d45cb1f3c4b6359861c3504038b422962875dce099e4456
+  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
+  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
+  domain_name (0.6.20240107) sha256=5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933
+  dotenv (2.8.1) sha256=c5944793349ae03c432e1780a2ca929d60b88c7d14d52d630db0508c3a8a17d8
+  emoji_regex (3.2.3) sha256=ecd8be856b7691406c6bf3bb3a5e55d6ed683ffab98b4aa531bb90e1ddcc564b
+  erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
+  excon (1.7.0) sha256=b8deec2bf978123b7e4b13a103ffec61557c6feaba34706dbc1ce4a94dec33e0
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
+  faraday-cookie_jar (0.0.8) sha256=0140605823f8cc63c7028fccee486aaed8e54835c360cffc1f7c8c07c4299dbb
+  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
+  faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
+  faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
+  fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
+  fastlane (2.238.0) sha256=78e9252df2224c7e427012638e41051edfa29b133a40fda883fd2f1c13a77b98
+  fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
+  gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
+  google-apis-androidpublisher_v3 (0.106.0) sha256=b90b5312b70f8f731def88f24a2b8fb791fe1b979a7c2c14a905cb6cae19cf3f
+  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
+  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
+  google-apis-playcustomapp_v1 (0.18.0) sha256=44b277b9dee4a59ac5e9d98be1485edc5e382d2f9d73c79ae8908a455786a254
+  google-apis-storage_v1 (0.66.0) sha256=fdf6d65d3fc77e7046b3494333a818ece9e2afd763bb161e1a7a9e70cf198351
+  google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
+  google-cloud-env (2.2.2) sha256=94bed40e05a67e9468ce1cb38389fba9a90aa8fc62fc9e173204c1dca59e21e7
+  google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
+  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
+  google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
+  googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
+  highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
+  http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
+  io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  nanaimo (0.4.0) sha256=faf069551bab17f15169c1f74a1c73c220657e71b6e900919897a10d991d0723
+  naturally (2.3.0) sha256=459923cf76c2e6613048301742363200c3c7e4904c324097d54a67401e179e01
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
+  optparse (0.8.1) sha256=42bea10d53907ccff4f080a69991441d611fbf8733b60ed1ce9ee365ce03bd1a
+  os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+  plist (3.7.2) sha256=d37a4527cc1116064393df4b40e1dbbc94c65fa9ca2eec52edf9a13616718a42
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
+  reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
+  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
+  retriable (4.2.0) sha256=90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (3.28.0) sha256=0d6de482c7624000d92697772ab14e48dca35629f8ddf3f4b21c99183fd70e20
+  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
+  security (0.1.5) sha256=3a977a0eca7706e804c96db0dd9619e0a94969fe3aac9680fcfc2bf9b8a833b7
+  signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
+  simctl (1.6.10) sha256=b99077f4d13ad81eace9f86bf5ba4df1b0b893a4d1b368bd3ed59b5b27f9236b
+  terminal-notifier (2.0.0) sha256=7a0d2b2212ab9835c07f4b2e22a94cff64149dba1eed203c04835f7991078cea
+  terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
+  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tty-cursor (0.7.1) sha256=79534185e6a777888d88628b14b6a1fdf5154a603f285f80b1753e1908e0bf48
+  tty-screen (0.8.2) sha256=c090652115beae764336c28802d633f204fb84da93c6a968aa5d8e319e819b50
+  tty-spinner (0.9.3) sha256=0e036f047b4ffb61f2aa45f5a770ec00b4d04130531558a94bfc5b192b570542
+  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  word_wrap (1.0.0) sha256=f556d4224c812e371000f12a6ee8102e0daa724a314c3f246afaad76d82accc7
+  xcodeproj (1.28.1) sha256=6f12670f00739d9817ca27ac89d6ef01cc86050e22a0bc08a3131487e5b5cddc
+  xcpretty (0.4.1) sha256=b14c50e721f6589ee3d6f5353e2c2cfcd8541fa1ea16d6c602807dd7327f3892
+  xcpretty-travis-formatter (1.0.1) sha256=aacc332f17cb7b2cba222994e2adc74223db88724fe76341483ad3098e232f93
+
+BUNDLED WITH
+  4.0.16

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+json_key_file(ENV["PLAY_JSON_KEY_FILE"])
+package_name("de.volksverpetzer.app")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,33 @@
+default_platform(:android)
+
+platform :android do
+  desc "Push listing texts and release notes from build/play-metadata to Google Play"
+  desc "Options: version_code (EAS versionCode of the submitted build), track (default: beta)"
+  lane :push_metadata do |options|
+    version_code = options[:version_code].to_i
+    UI.user_error!("Pass version_code:<EAS versionCode>") if version_code <= 0
+    track = options[:track] || "beta"
+
+    # EAS auto-submit runs asynchronously after the build finishes — wait for
+    # the new versionCode to appear on the track before attaching release notes.
+    on_track = false
+    20.times do |attempt|
+      on_track = google_play_track_version_codes(track: track).include?(version_code)
+      break if on_track
+
+      UI.message("versionCode #{version_code} not on '#{track}' yet, retrying in 60s (#{attempt + 1}/20)")
+      sleep(60)
+    end
+    UI.user_error!("versionCode #{version_code} never appeared on track '#{track}'") unless on_track
+
+    upload_to_play_store(
+      track: track,
+      # fastlane resolves relative paths from this fastlane/ dir, not the repo root
+      metadata_path: File.expand_path("../build/play-metadata/android", __dir__),
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_screenshots: true,
+      skip_upload_images: true,
+    )
+  end
+end

--- a/scripts/prepare-play-metadata.mjs
+++ b/scripts/prepare-play-metadata.mjs
@@ -1,0 +1,61 @@
+/**
+ * Prepares a copy of fastlane/metadata for `fastlane supply` (Google Play).
+ *
+ * The changelog files are named after the package.json versionCode, but the
+ * APK that EAS submits to Google Play carries an EAS-managed versionCode
+ * (appVersionSource: "remote" + autoIncrement). Supply matches changelog
+ * files to the versionCodes on the Play track, so the current release notes
+ * are renamed to the EAS versionCode. All other changelogs and the images
+ * are dropped from the copy (screenshots/images are managed in the Play
+ * Console, not from this repo).
+ *
+ * Usage: node scripts/prepare-play-metadata.mjs --play-version-code <code>
+ * Output: build/play-metadata/android
+ */
+import { cpSync, readFileSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const argIndex = process.argv.indexOf("--play-version-code");
+const playVersionCode =
+  argIndex === -1 ? NaN : Number.parseInt(process.argv[argIndex + 1], 10);
+
+if (!Number.isInteger(playVersionCode) || playVersionCode <= 0) {
+  console.error(
+    "Usage: node scripts/prepare-play-metadata.mjs --play-version-code <code>",
+  );
+  process.exit(1);
+}
+
+const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+const { versionCode } = pkg;
+
+const source = resolve(root, "fastlane/metadata/android");
+const target = resolve(root, "build/play-metadata/android");
+
+rmSync(target, { recursive: true, force: true });
+cpSync(source, target, { recursive: true });
+
+for (const locale of readdirSync(target)) {
+  rmSync(resolve(target, locale, "images"), { recursive: true, force: true });
+
+  const changelogDir = resolve(target, locale, "changelogs");
+  for (const file of readdirSync(changelogDir)) {
+    if (file === `${versionCode}.txt`) {
+      renameSync(
+        resolve(changelogDir, file),
+        resolve(changelogDir, `${playVersionCode}.txt`),
+      );
+      console.log(
+        `✓ ${locale}: ${file} → ${playVersionCode}.txt (EAS versionCode)`,
+      );
+    } else {
+      rmSync(resolve(changelogDir, file));
+    }
+  }
+}
+
+console.log(`✓ Play metadata prepared at build/play-metadata/android`);

--- a/scripts/prepare-play-metadata.mjs
+++ b/scripts/prepare-play-metadata.mjs
@@ -12,7 +12,14 @@
  * Usage: node scripts/prepare-play-metadata.mjs --play-version-code <code>
  * Output: build/play-metadata/android
  */
-import { cpSync, readFileSync, readdirSync, renameSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -43,6 +50,16 @@ for (const locale of readdirSync(target)) {
   rmSync(resolve(target, locale, "images"), { recursive: true, force: true });
 
   const changelogDir = resolve(target, locale, "changelogs");
+  if (!existsSync(resolve(changelogDir, `${versionCode}.txt`))) {
+    console.error(
+      `✗ No changelog found at fastlane/metadata/android/${locale}/changelogs/${versionCode}.txt`,
+    );
+    console.error(
+      "  Create this file with release notes (pnpm prepare:changelog), then re-run this script.",
+    );
+    process.exit(1);
+  }
+
   for (const file of readdirSync(changelogDir)) {
     if (file === `${versionCode}.txt`) {
       renameSync(

--- a/scripts/prepare-store-config.mjs
+++ b/scripts/prepare-store-config.mjs
@@ -1,0 +1,48 @@
+/**
+ * Generates store.config.json for `eas metadata:push` (App Store) from the
+ * fastlane changelog of the current package.json versionCode.
+ *
+ * Only releaseNotes are pushed on purpose — the App Store listing texts
+ * (title, description, keywords) are managed in App Store Connect and differ
+ * from the Google Play texts kept in this repo.
+ *
+ * Usage: node scripts/prepare-store-config.mjs
+ * Output: store.config.json (git-ignored, generated per release in CI)
+ */
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+const { versionCode } = pkg;
+
+const info = {};
+
+for (const locale of ["de-DE", "en-US"]) {
+  const changelogPath = resolve(
+    root,
+    `fastlane/metadata/android/${locale}/changelogs/${versionCode}.txt`,
+  );
+  if (!existsSync(changelogPath)) {
+    console.error(
+      `✗ No changelog found at fastlane/metadata/android/${locale}/changelogs/${versionCode}.txt`,
+    );
+    process.exit(1);
+  }
+  info[locale] = { releaseNotes: readFileSync(changelogPath, "utf8").trim() };
+}
+
+const config = {
+  configVersion: 0,
+  apple: { info },
+};
+
+writeFileSync(
+  resolve(root, "store.config.json"),
+  `${JSON.stringify(config, null, 2)}\n`,
+  "utf8",
+);
+console.log(`✓ Generated store.config.json with release notes ${versionCode}`);

--- a/scripts/wait-for-eas-build.mjs
+++ b/scripts/wait-for-eas-build.mjs
@@ -1,0 +1,76 @@
+/**
+ * Waits for the EAS build of the given platform and git commit to finish,
+ * then exposes its versionCode/buildNumber as a GitHub Actions output.
+ *
+ * Usage: node scripts/wait-for-eas-build.mjs --platform android|ios --commit <sha>
+ *
+ * Outputs (via $GITHUB_OUTPUT, also printed to stdout):
+ *   build-version — appBuildVersion of the finished build (Android versionCode / iOS buildNumber)
+ */
+import { execSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const POLL_INTERVAL_MS = 2 * 60 * 1000;
+const TIMEOUT_MS = 120 * 60 * 1000;
+
+const arg = (name) => {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+
+const platform = arg("platform");
+const commit = arg("commit");
+
+if (!["android", "ios"].includes(platform) || !commit) {
+  console.error(
+    "Usage: node scripts/wait-for-eas-build.mjs --platform android|ios --commit <sha>",
+  );
+  process.exit(1);
+}
+
+const listBuilds = () =>
+  JSON.parse(
+    execSync(
+      `eas build:list --platform ${platform} --limit 10 --json --non-interactive`,
+      { encoding: "utf8" },
+    ),
+  );
+
+const deadline = Date.now() + TIMEOUT_MS;
+
+for (;;) {
+  const build = listBuilds().find((b) => b.gitCommitHash === commit);
+
+  if (build?.status === "FINISHED") {
+    console.log(
+      `✓ ${platform} build ${build.id} finished (build version ${build.appBuildVersion})`,
+    );
+    if (process.env.GITHUB_OUTPUT) {
+      appendFileSync(
+        process.env.GITHUB_OUTPUT,
+        `build-version=${build.appBuildVersion}\n`,
+      );
+    }
+    process.exit(0);
+  }
+
+  if (["ERRORED", "CANCELED"].includes(build?.status)) {
+    console.error(`✗ ${platform} build ${build.id} ended as ${build.status}`);
+    process.exit(1);
+  }
+
+  if (Date.now() > deadline) {
+    console.error(
+      `✗ Timed out waiting for the ${platform} build of commit ${commit}`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    build
+      ? `… ${platform} build is ${build.status}, polling again in 2 min`
+      : `… no ${platform} build for commit ${commit} yet, polling again in 2 min`,
+  );
+  await sleep(POLL_INTERVAL_MS);
+}

--- a/scripts/wait-for-eas-build.mjs
+++ b/scripts/wait-for-eas-build.mjs
@@ -32,7 +32,7 @@ if (!["android", "ios"].includes(platform) || !commit) {
 const listBuilds = () =>
   JSON.parse(
     execSync(
-      `eas build:list --platform ${platform} --limit 10 --json --non-interactive`,
+      `eas build:list --platform ${platform} --limit 50 --json --non-interactive`,
       { encoding: "utf8" },
     ),
   );


### PR DESCRIPTION
## Problem

The release workflow only submits binaries via EAS auto-submit. `fastlane/metadata/` was never pushed to Google Play — EAS Submit doesn't read it, EAS Metadata only supports the App Store, and nothing invoked `fastlane supply`. Release notes and listing texts therefore never showed up in the Play Console.

There's also a versionCode mismatch: changelog files are named after the `package.json` versionCode, but the submitted build carries an EAS-managed versionCode (`appVersionSource: "remote"` + `autoIncrement`), so even a manual `fastlane supply` would silently skip them.

## Changes

Two new jobs in the release workflow, both gated on the existing tag-only chain:

**📝 Push Google Play Metadata**
1. `scripts/wait-for-eas-build.mjs` polls EAS until the Android build for the tagged commit finishes and captures the EAS-assigned versionCode
2. `scripts/prepare-play-metadata.mjs` stages a copy of `fastlane/metadata` with the current changelog renamed to that versionCode (old changelogs and images are dropped — screenshots stay managed in the Play Console)
3. The new `push_metadata` fastlane lane waits for auto-submit to land the build on the `beta` track, then runs `upload_to_play_store` with listing texts + release notes only (no binary, no screenshots/images)

**📝 Push App Store Metadata**
1. Waits for the iOS build, plus a grace period for auto-submit
2. `scripts/prepare-store-config.mjs` generates `store.config.json` containing only the de-DE/en-US release notes (App Store listing texts stay managed in App Store Connect — the repo texts are the Play/F-Droid ones)
3. `eas metadata:push` sends them via EAS Metadata

Supporting files: `Gemfile`/`Gemfile.lock` (fastlane, x86_64-linux platform included for CI), `fastlane/Appfile` + `Fastfile`, `.gitignore` entries for generated output.

## Required setup

⚠️ Add a `PLAY_SERVICE_ACCOUNT_JSON` GitHub Actions secret containing a Google Play service-account key (same kind of key EAS uses for auto-submit; EAS stores its copy server-side, so the workflow needs its own). The App Store job needs no new secret — `eas metadata:push` reuses the ASC API key stored on EAS.

## Notes

- The Play job **does** push `title.txt` / `short_description.txt` / `full_description.txt` to the Play listing. If the live listing differs from the repo files, update the repo files before the next release tag.
- The mimikama release workflow is untouched; the same pattern can be applied there in a follow-up.
- Scripts were dry-run locally; the end-to-end path runs on the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)