### PR TITLE
Show an article-style preview card for unresolvable embedded articles

### DIFF
--- a/__tests__/IframeRenderer.test.tsx
+++ b/__tests__/IframeRenderer.test.tsx
@@ -1019,4 +1019,31 @@ describe("IframeRenderer wp-embedded-content fallback", () => {
 
     expect(onLinkPress).toHaveBeenCalledWith(expect.anything(), pageUrl);
   });
+
+  it("shows the default error card instead of the preview for a transient failure, not just a missing slug", async () => {
+    // A network/server error is not the same as "no post for this slug" —
+    // the embedded article might well exist, so this shouldn't render the
+    // Open Graph fallback (which would present possibly-stale/wrong content
+    // as if it were the real thing) or otherwise mask the failure.
+    mockGetPost.mockRejectedValue(new Error("network error"));
+    const onLinkPress = jest.fn();
+    const renderProps = {} as unknown as CustomRendererProps<TBlock>;
+
+    const { findByText, queryByText } = await render(
+      <IframeRenderer
+        renderProps={renderProps}
+        width={360}
+        maxWidth={700}
+        onLinkPress={onLinkPress}
+      />,
+    );
+
+    expect(
+      await findByText(
+        "Beitrag konnte nicht geladen werden. Bitte später erneut versuchen.",
+      ),
+    ).toBeTruthy();
+    expect(mockFetchOpenGraphPreview).not.toHaveBeenCalled();
+    expect(queryByText("Landtagswahl Sachsen Anhalt")).toBeNull();
+  });
 });

--- a/__tests__/IframeRenderer.test.tsx
+++ b/__tests__/IframeRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from "@testing-library/react-native";
+import { act, fireEvent, render } from "@testing-library/react-native";
 import * as Linking from "expo-linking";
 import { Dimensions } from "react-native";
 import type { CustomRendererProps, TBlock } from "react-native-render-html";
@@ -14,15 +14,36 @@ jest.mock("#/constants/Config", () => ({
   },
 }));
 
-// Mock expo-linking parse used in the component
+// Mock expo-linking parse used in the component. `path` mirrors the real
+// expo-linking behavior of omitting the leading slash (extractSlug below
+// relies on that: path.split("/")[1] is the slug for a "/category/slug/..."
+// permalink).
 jest.mock("expo-linking", () => ({
   parse: (url: string) => {
     try {
       const parsed = new URL(url);
-      return { hostname: parsed.hostname, path: parsed.pathname };
+      return {
+        hostname: parsed.hostname,
+        path: parsed.pathname.replace(/^\/+/, ""),
+      };
     } catch {
       return {};
     }
+  },
+}));
+
+// Mock WordPressAPI.getPost so the wp-embedded-content fallback-card tests
+// can simulate a slug LoadArticlePost can't resolve (deleted/renamed, or a
+// non-"post" content type such as a WordPress "project" page).
+const mockGetPost = jest.fn();
+jest.mock("#/helpers/network/WordPressAPI", () => ({
+  __esModule: true,
+  default: {
+    getPost: (...args: unknown[]) => mockGetPost(...args),
+    create: jest.fn(() => ({
+      getPost: (...args: unknown[]) => mockGetPost(...args),
+    })),
+    convertLoadProps: jest.fn((data) => data),
   },
 }));
 
@@ -916,5 +937,47 @@ describe("IframeRenderer non-video height cap", () => {
       ? style.find((s: any) => s && typeof s.height === "number")?.height
       : style?.height;
     expect(height).toBe(maxHeight);
+  });
+});
+
+describe("IframeRenderer wp-embedded-content fallback", () => {
+  beforeEach(() => {
+    mockUseHtmlIframeProps.mockClear();
+    mockUseAppColorScheme.mockClear();
+    mockUseAppColorScheme.mockReturnValue(ColorScheme.light);
+    mockGetPost.mockClear();
+  });
+
+  it("links out to the real page instead of showing an error card when the embedded slug can't be loaded as a post", async () => {
+    // e.g. a WordPress "project" page linked via "Sonst schau auch hier
+    // vorbei:" — its REST endpoint isn't public, so getPost never resolves it.
+    mockGetPost.mockResolvedValue(null);
+    mockUseHtmlIframeProps.mockReturnValue({
+      htmlAttribs: {
+        src: "https://www.volksverpetzer.de/project/landtagswahl-sachsen-anhalt/embed/#?secret=abc",
+        class: "wp-embedded-content",
+      },
+    } as unknown as ReturnType<typeof mockUseHtmlIframeProps>);
+    const onLinkPress = jest.fn();
+    const renderProps = {} as unknown as CustomRendererProps<TBlock>;
+
+    const { findByText } = await render(
+      <IframeRenderer
+        renderProps={renderProps}
+        width={360}
+        maxWidth={700}
+        onLinkPress={onLinkPress}
+      />,
+    );
+
+    const card = await findByText("Landtagswahl Sachsen Anhalt");
+    await act(async () => {
+      fireEvent.press(card);
+    });
+
+    expect(onLinkPress).toHaveBeenCalledWith(
+      expect.anything(),
+      "https://www.volksverpetzer.de/project/landtagswahl-sachsen-anhalt/",
+    );
   });
 });

--- a/__tests__/IframeRenderer.test.tsx
+++ b/__tests__/IframeRenderer.test.tsx
@@ -47,6 +47,15 @@ jest.mock("#/helpers/network/WordPressAPI", () => ({
   },
 }));
 
+// Mock the Open Graph preview fetch used by LoadOpenGraphCard (the fallback
+// card for a wp-embedded-content embed LoadArticlePost couldn't resolve) so
+// its network call doesn't need a real fetch client in this test.
+const mockFetchOpenGraphPreview = jest.fn();
+jest.mock("#/helpers/utils/openGraph", () => ({
+  fetchOpenGraphPreview: (...args: unknown[]) =>
+    mockFetchOpenGraphPreview(...args),
+}));
+
 // Mock the html iframe hook to return predictable htmlAttribs
 const mockUseHtmlIframeProps = jest.fn(() => ({
   htmlAttribs: { src: "https://example.com/embed" },
@@ -941,23 +950,31 @@ describe("IframeRenderer non-video height cap", () => {
 });
 
 describe("IframeRenderer wp-embedded-content fallback", () => {
+  const embedSource =
+    "https://www.volksverpetzer.de/project/landtagswahl-sachsen-anhalt/embed/#?secret=abc";
+  const pageUrl =
+    "https://www.volksverpetzer.de/project/landtagswahl-sachsen-anhalt/";
+
   beforeEach(() => {
     mockUseHtmlIframeProps.mockClear();
     mockUseAppColorScheme.mockClear();
     mockUseAppColorScheme.mockReturnValue(ColorScheme.light);
     mockGetPost.mockClear();
-  });
-
-  it("links out to the real page instead of showing an error card when the embedded slug can't be loaded as a post", async () => {
+    mockFetchOpenGraphPreview.mockClear();
+    mockUseHtmlIframeProps.mockReturnValue({
+      htmlAttribs: { src: embedSource, class: "wp-embedded-content" },
+    } as unknown as ReturnType<typeof mockUseHtmlIframeProps>);
     // e.g. a WordPress "project" page linked via "Sonst schau auch hier
     // vorbei:" — its REST endpoint isn't public, so getPost never resolves it.
     mockGetPost.mockResolvedValue(null);
-    mockUseHtmlIframeProps.mockReturnValue({
-      htmlAttribs: {
-        src: "https://www.volksverpetzer.de/project/landtagswahl-sachsen-anhalt/embed/#?secret=abc",
-        class: "wp-embedded-content",
-      },
-    } as unknown as ReturnType<typeof mockUseHtmlIframeProps>);
+  });
+
+  it("shows an Open Graph preview card and links out to the real page", async () => {
+    mockFetchOpenGraphPreview.mockResolvedValue({
+      title: "Sachsen-Anhalt: Landtagswahl 2026",
+      description: "Warum sich Wählen lohnt.",
+      image: "https://www.volksverpetzer.de/preview.jpg",
+    });
     const onLinkPress = jest.fn();
     const renderProps = {} as unknown as CustomRendererProps<TBlock>;
 
@@ -970,14 +987,36 @@ describe("IframeRenderer wp-embedded-content fallback", () => {
       />,
     );
 
-    const card = await findByText("Landtagswahl Sachsen Anhalt");
-    await act(async () => {
-      fireEvent.press(card);
-    });
-
-    expect(onLinkPress).toHaveBeenCalledWith(
+    expect(mockFetchOpenGraphPreview).toHaveBeenCalledWith(
+      pageUrl,
       expect.anything(),
-      "https://www.volksverpetzer.de/project/landtagswahl-sachsen-anhalt/",
     );
+
+    const title = await findByText("Sachsen-Anhalt: Landtagswahl 2026");
+    expect(await findByText("Warum sich Wählen lohnt.")).toBeTruthy();
+
+    fireEvent.press(title);
+
+    expect(onLinkPress).toHaveBeenCalledWith(expect.anything(), pageUrl);
+  });
+
+  it("falls back to a humanized slug title when no Open Graph preview is available", async () => {
+    mockFetchOpenGraphPreview.mockResolvedValue(null);
+    const onLinkPress = jest.fn();
+    const renderProps = {} as unknown as CustomRendererProps<TBlock>;
+
+    const { findByText } = await render(
+      <IframeRenderer
+        renderProps={renderProps}
+        width={360}
+        maxWidth={700}
+        onLinkPress={onLinkPress}
+      />,
+    );
+
+    const title = await findByText("Landtagswahl Sachsen Anhalt");
+    fireEvent.press(title);
+
+    expect(onLinkPress).toHaveBeenCalledWith(expect.anything(), pageUrl);
   });
 });

--- a/__tests__/components/loader/LoadOpenGraphCard.test.tsx
+++ b/__tests__/components/loader/LoadOpenGraphCard.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+
+import LoadOpenGraphCard from "#/components/loader/LoadOpenGraphCard";
+import { fetchOpenGraphPreview } from "#/helpers/utils/openGraph";
+import type { HttpsUrl } from "#/types";
+
+jest.mock("#/helpers/utils/openGraph", () => ({
+  fetchOpenGraphPreview: jest.fn(),
+}));
+
+const mockFetchOpenGraphPreview = fetchOpenGraphPreview as jest.Mock;
+
+const URL = "https://www.volksverpetzer.de/project/foo/" as HttpsUrl;
+
+describe("LoadOpenGraphCard", () => {
+  beforeEach(() => {
+    mockFetchOpenGraphPreview.mockReset();
+  });
+
+  it("shows the fetched preview once it resolves", async () => {
+    mockFetchOpenGraphPreview.mockResolvedValue({
+      title: "A real title",
+      description: "A real description",
+    });
+
+    const { findByText } = await render(
+      <LoadOpenGraphCard
+        url={URL}
+        fallbackTitle="Fallback"
+        onPress={jest.fn()}
+      />,
+    );
+
+    expect(await findByText("A real title")).toBeTruthy();
+  });
+
+  it("falls back to fallbackTitle and clears the spinner instead of hanging forever when the fetch rejects", async () => {
+    mockFetchOpenGraphPreview.mockRejectedValue(new Error("boom"));
+    const onPress = jest.fn();
+
+    const { findByText } = await render(
+      <LoadOpenGraphCard
+        url={URL}
+        fallbackTitle="Fallback"
+        onPress={onPress}
+      />,
+    );
+
+    // Before the fix, isLoading never flipped to false on rejection, so
+    // this would time out waiting for a spinner-only tree forever.
+    const title = await findByText("Fallback");
+    fireEvent.press(title);
+
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  it("falls back to fallbackTitle when the resolved preview has no title", async () => {
+    mockFetchOpenGraphPreview.mockResolvedValue(null);
+
+    const { findByText } = await render(
+      <LoadOpenGraphCard
+        url={URL}
+        fallbackTitle="Fallback"
+        onPress={jest.fn()}
+      />,
+    );
+
+    expect(await findByText("Fallback")).toBeTruthy();
+  });
+});

--- a/__tests__/helpers/utils/openGraph.test.ts
+++ b/__tests__/helpers/utils/openGraph.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { fetchOpenGraphPreview } from "#/helpers/utils/openGraph";
+
+const mockGet = jest.fn() as jest.MockedFunction<
+  (...args: unknown[]) => Promise<string>
+>;
+jest.mock("#/helpers/utils/networking", () => ({
+  get: (...args: unknown[]) => mockGet(...args),
+}));
+
+jest.mock("#/helpers/network/WordPressAPI", () => ({
+  __esModule: true,
+  default: { client: {} },
+}));
+
+const PAGE_URL = "https://www.volksverpetzer.de/project/foo/" as const;
+
+describe("fetchOpenGraphPreview", () => {
+  beforeEach(() => {
+    mockGet.mockClear();
+  });
+
+  it("extracts title, description and image regardless of attribute order", async () => {
+    mockGet.mockResolvedValue(`
+      <html><head>
+        <meta property="og:title" content="Sachsen-Anhalt: Landtagswahl 2026" />
+        <meta content="Warum sich Wählen lohnt." property="og:description" />
+        <meta property="og:image" content="https://example.com/preview.jpg" />
+      </head></html>
+    `);
+
+    const preview = await fetchOpenGraphPreview(PAGE_URL);
+
+    expect(preview).toEqual({
+      title: "Sachsen-Anhalt: Landtagswahl 2026",
+      description: "Warum sich Wählen lohnt.",
+      image: "https://example.com/preview.jpg",
+    });
+  });
+
+  it("decodes HTML entities in the extracted values", async () => {
+    mockGet.mockResolvedValue(
+      `<meta property="og:title" content="Fakten &amp; Fiktion &quot;Test&quot;" />`,
+    );
+
+    const preview = await fetchOpenGraphPreview(PAGE_URL);
+
+    expect(preview?.title).toBe('Fakten & Fiktion "Test"');
+  });
+
+  it("returns null when there's no og:title, even if other tags are present", async () => {
+    mockGet.mockResolvedValue(
+      `<meta property="og:description" content="No title here" />`,
+    );
+
+    expect(await fetchOpenGraphPreview(PAGE_URL)).toBeNull();
+  });
+
+  it("omits description/image when only og:title is present", async () => {
+    mockGet.mockResolvedValue(
+      `<meta property="og:title" content="Just a title" />`,
+    );
+
+    expect(await fetchOpenGraphPreview(PAGE_URL)).toEqual({
+      title: "Just a title",
+      description: undefined,
+      image: undefined,
+    });
+  });
+
+  it("returns null instead of throwing when the fetch fails", async () => {
+    mockGet.mockRejectedValue(new Error("network error"));
+
+    await expect(fetchOpenGraphPreview(PAGE_URL)).resolves.toBeNull();
+  });
+
+  it("passes the url and abort signal through to the fetch layer", async () => {
+    mockGet.mockResolvedValue(`<meta property="og:title" content="Title" />`);
+    const controller = new AbortController();
+
+    await fetchOpenGraphPreview(PAGE_URL, controller.signal);
+
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.anything(),
+      PAGE_URL,
+      expect.objectContaining({
+        responseType: "text",
+        signal: controller.signal,
+      }),
+    );
+  });
+});

--- a/src/components/loader/LoadArticlePost.tsx
+++ b/src/components/loader/LoadArticlePost.tsx
@@ -6,6 +6,21 @@ import ArticlePost from "#/components/posts/ArticlePost";
 import WordPressAPI from "#/helpers/network/WordPressAPI";
 import type { ArticleProperties, HttpsUrl } from "#/types";
 
+/**
+ * Thrown when `WordPressAPI.getPost` resolves without a post for the given
+ * slug — as opposed to a network/server failure, which throws whatever error
+ * the fetch layer produced. Callers that want to tell the two apart (e.g. to
+ * only show a "not found" fallback for a genuinely missing slug, not mask a
+ * transient outage as one) can check `error instanceof ArticleNotFoundError`
+ * in `renderError`.
+ */
+export class ArticleNotFoundError extends Error {
+  constructor(slug: string) {
+    super(`Article not found for slug: ${slug}`);
+    this.name = "ArticleNotFoundError";
+  }
+}
+
 export type LoadProperties = {
   slug: string;
   /**
@@ -20,8 +35,9 @@ export type LoadProperties = {
    * Overrides the default "couldn't load" error card, e.g. to render nothing
    * when a caller would rather silently drop a broken entry (such as a stale
    * recommendation) than show an error in a list of otherwise-fine items.
+   * Return `null` to render nothing.
    */
-  renderError?: (error: unknown) => ReactElement;
+  renderError?: (error: unknown) => ReactElement | null;
 };
 
 // Reuse one API client per secondary base URL so rendering many embedded
@@ -52,9 +68,7 @@ const LoadArticlePost = (properties: LoadProperties) => {
         : WordPressAPI.getPost;
       return getPost(articleSlug).then((data) => {
         if (!data) {
-          return Promise.reject(
-            new Error(`Article not found for slug: ${articleSlug}`),
-          );
+          return Promise.reject(new ArticleNotFoundError(articleSlug));
         }
 
         return WordPressAPI.convertLoadProps(data);

--- a/src/components/loader/LoadArticlePost.tsx
+++ b/src/components/loader/LoadArticlePost.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from "react";
 import { useCallback } from "react";
 
 import Loader from "#/components/loader/Loader";
@@ -15,6 +16,12 @@ export type LoadProperties = {
   baseUrl?: HttpsUrl;
   inView?: boolean;
   elevated?: boolean;
+  /**
+   * Overrides the default "couldn't load" error card, e.g. to render nothing
+   * when a caller would rather silently drop a broken entry (such as a stale
+   * recommendation) than show an error in a list of otherwise-fine items.
+   */
+  renderError?: (error: unknown) => ReactElement;
 };
 
 // Reuse one API client per secondary base URL so rendering many embedded
@@ -36,7 +43,7 @@ const secondaryApiFor = (baseUrl: HttpsUrl) => {
  * This component takes an article slug, pulls WordPress API and then Renders an Article Post with the Response
  */
 const LoadArticlePost = (properties: LoadProperties) => {
-  const { slug, baseUrl, inView = true, elevated } = properties;
+  const { slug, baseUrl, inView = true, elevated, renderError } = properties;
 
   const loadArticle = useCallback(
     (articleSlug: string) => {
@@ -68,6 +75,7 @@ const LoadArticlePost = (properties: LoadProperties) => {
       keyValue={slug}
       load={loadArticle}
       render={renderArticle}
+      renderError={renderError}
       loadingText="Lade Artikel..."
     />
   );

--- a/src/components/loader/LoadOpenGraphCard.tsx
+++ b/src/components/loader/LoadOpenGraphCard.tsx
@@ -2,6 +2,7 @@ import { Image } from "expo-image";
 import { useEffect, useMemo, useState } from "react";
 import { View } from "react-native";
 
+import Typography from "#/components/ui/Typography";
 import UiCard from "#/components/ui/UiCard";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpinner from "#/components/ui/UiSpinner";
@@ -9,6 +10,10 @@ import UiText from "#/components/ui/UiText";
 import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
 import { elevation } from "#/constants/Elevation";
+import {
+  CARD_CONTENT_GAP,
+  POST_PADDING_HORIZONTAL,
+} from "#/constants/GlobalStyles";
 import { spacing } from "#/constants/Spacing";
 import type { OpenGraphPreview } from "#/helpers/utils/openGraph";
 import { fetchOpenGraphPreview } from "#/helpers/utils/openGraph";
@@ -93,16 +98,18 @@ const LoadOpenGraphCard = ({
               contentFit="cover"
             />
           )}
-          <View style={{ gap: spacing.xs, padding: spacing.md }}>
-            <UiText bold numberOfLines={2}>
+          <View
+            style={{
+              gap: CARD_CONTENT_GAP,
+              paddingHorizontal: POST_PADDING_HORIZONTAL,
+              paddingVertical: spacing.md,
+            }}
+          >
+            <Typography type="cardTitle" numberOfLines={2}>
               {preview?.title ?? fallbackTitle}
-            </UiText>
+            </Typography>
             {preview?.description && (
-              <UiText
-                size="sm"
-                numberOfLines={2}
-                style={{ color: Colors[colorScheme].textMuted }}
-              >
+              <UiText size="base" numberOfLines={2}>
                 {preview.description}
               </UiText>
             )}

--- a/src/components/loader/LoadOpenGraphCard.tsx
+++ b/src/components/loader/LoadOpenGraphCard.tsx
@@ -1,0 +1,112 @@
+import { Image } from "expo-image";
+import { useEffect, useState } from "react";
+import { View } from "react-native";
+
+import { ExternalLinkIcon } from "#/components/Icons";
+import UiCard from "#/components/ui/UiCard";
+import UiPressable from "#/components/ui/UiPressable";
+import UiSpinner from "#/components/ui/UiSpinner";
+import UiText from "#/components/ui/UiText";
+import Colors from "#/constants/Colors";
+import { spacing } from "#/constants/Spacing";
+import type { OpenGraphPreview } from "#/helpers/utils/openGraph";
+import { fetchOpenGraphPreview } from "#/helpers/utils/openGraph";
+import { useAppColorScheme } from "#/hooks/useAppColorScheme";
+import type { HttpsUrl } from "#/types";
+
+export interface LoadOpenGraphCardProperties {
+  url: HttpsUrl;
+  /** Shown while the preview is loading and if it comes back without a title. */
+  fallbackTitle: string;
+  onPress: (event: unknown) => void;
+}
+
+/**
+ * A small link-out card for `url`, previewed via its Open Graph
+ * title/description/image. Used where the real content can't be loaded
+ * natively as an article (e.g. a WordPress "project" page, whose REST
+ * endpoint isn't public) but is otherwise a normal public page worth
+ * showing a proper preview for, not a bare error.
+ */
+const LoadOpenGraphCard = ({
+  url,
+  fallbackTitle,
+  onPress,
+}: LoadOpenGraphCardProperties) => {
+  const colorScheme = useAppColorScheme();
+  const [preview, setPreview] = useState<OpenGraphPreview | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    const controller = new AbortController();
+    setIsLoading(true);
+    fetchOpenGraphPreview(url, controller.signal).then((result) => {
+      if (!isMounted) return;
+      setPreview(result);
+      setIsLoading(false);
+    });
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [url]);
+
+  if (isLoading) {
+    return (
+      <View
+        style={{
+          marginHorizontal: spacing.md,
+          minHeight: 100,
+          justifyContent: "center",
+        }}
+      >
+        <UiSpinner />
+      </View>
+    );
+  }
+
+  return (
+    <UiPressable
+      accessibilityRole="link"
+      onPress={onPress}
+      style={{ marginHorizontal: spacing.md }}
+    >
+      <UiCard style={{ padding: 0, overflow: "hidden" }}>
+        {preview?.image && (
+          <Image
+            source={{ uri: preview.image }}
+            style={{ width: "100%", aspectRatio: 1200 / 630 }}
+            contentFit="cover"
+          />
+        )}
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.md,
+            padding: spacing.md,
+          }}
+        >
+          <View style={{ flex: 1, gap: spacing.xs }}>
+            <UiText bold numberOfLines={2}>
+              {preview?.title ?? fallbackTitle}
+            </UiText>
+            {preview?.description && (
+              <UiText
+                size="sm"
+                numberOfLines={2}
+                style={{ color: Colors[colorScheme].textMuted }}
+              >
+                {preview.description}
+              </UiText>
+            )}
+          </View>
+          <ExternalLinkIcon color={Colors[colorScheme].textMuted} />
+        </View>
+      </UiCard>
+    </UiPressable>
+  );
+};
+
+export default LoadOpenGraphCard;

--- a/src/components/loader/LoadOpenGraphCard.tsx
+++ b/src/components/loader/LoadOpenGraphCard.tsx
@@ -1,13 +1,14 @@
 import { Image } from "expo-image";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { View } from "react-native";
 
-import { ExternalLinkIcon } from "#/components/Icons";
 import UiCard from "#/components/ui/UiCard";
 import UiPressable from "#/components/ui/UiPressable";
 import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
+import { radii } from "#/constants/BorderRadius";
 import Colors from "#/constants/Colors";
+import { elevation } from "#/constants/Elevation";
 import { spacing } from "#/constants/Spacing";
 import type { OpenGraphPreview } from "#/helpers/utils/openGraph";
 import { fetchOpenGraphPreview } from "#/helpers/utils/openGraph";
@@ -36,6 +37,19 @@ const LoadOpenGraphCard = ({
   const colorScheme = useAppColorScheme();
   const [preview, setPreview] = useState<OpenGraphPreview | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  // Matches ArticlePost's `elevated` card look, so an embed preview reads as
+  // the same kind of card as a resolved article embed right above/below it.
+  const shadowWrapperStyle = useMemo(() => {
+    const isDark = colorScheme === "dark";
+    const shadowRgb = isDark ? "255, 255, 255" : "0, 0, 0";
+    const shadowOpacity = isDark ? 0.12 : elevation.xs.opacity;
+    return {
+      borderRadius: radii.lg,
+      boxShadow: `0px ${elevation.xs.offsetY}px ${elevation.xs.blur}px rgba(${shadowRgb}, ${shadowOpacity})`,
+      elevation: elevation.xs.android,
+    };
+  }, [colorScheme]);
 
   useEffect(() => {
     let isMounted = true;
@@ -67,28 +81,25 @@ const LoadOpenGraphCard = ({
   }
 
   return (
-    <UiPressable
-      accessibilityRole="link"
-      onPress={onPress}
-      style={{ marginHorizontal: spacing.md }}
-    >
-      <UiCard style={{ padding: 0, overflow: "hidden" }}>
-        {preview?.image && (
-          <Image
-            source={{ uri: preview.image }}
-            style={{ width: "100%", aspectRatio: 1200 / 630 }}
-            contentFit="cover"
-          />
-        )}
-        <View
+    <View style={[{ marginHorizontal: spacing.md }, shadowWrapperStyle]}>
+      <UiPressable accessibilityRole="link" onPress={onPress}>
+        <UiCard
           style={{
-            flexDirection: "row",
-            alignItems: "center",
-            gap: spacing.md,
-            padding: spacing.md,
+            padding: 0,
+            overflow: "hidden",
+            borderRadius: radii.lg,
+            borderWidth: 1,
+            borderColor: Colors[colorScheme].surface,
           }}
         >
-          <View style={{ flex: 1, gap: spacing.xs }}>
+          {preview?.image && (
+            <Image
+              source={{ uri: preview.image }}
+              style={{ width: "100%", aspectRatio: 1200 / 630 }}
+              contentFit="cover"
+            />
+          )}
+          <View style={{ gap: spacing.xs, padding: spacing.md }}>
             <UiText bold numberOfLines={2}>
               {preview?.title ?? fallbackTitle}
             </UiText>
@@ -102,10 +113,9 @@ const LoadOpenGraphCard = ({
               </UiText>
             )}
           </View>
-          <ExternalLinkIcon color={Colors[colorScheme].textMuted} />
-        </View>
-      </UiCard>
-    </UiPressable>
+        </UiCard>
+      </UiPressable>
+    </View>
   );
 };
 

--- a/src/components/loader/LoadOpenGraphCard.tsx
+++ b/src/components/loader/LoadOpenGraphCard.tsx
@@ -22,7 +22,7 @@ import type { HttpsUrl } from "#/types";
 
 export interface LoadOpenGraphCardProperties {
   url: HttpsUrl;
-  /** Shown while the preview is loading and if it comes back without a title. */
+  /** Shown as the card's title if the fetched preview comes back without an og:title. */
   fallbackTitle: string;
   onPress: (event: unknown) => void;
 }

--- a/src/components/loader/LoadOpenGraphCard.tsx
+++ b/src/components/loader/LoadOpenGraphCard.tsx
@@ -60,11 +60,24 @@ const LoadOpenGraphCard = ({
     let isMounted = true;
     const controller = new AbortController();
     setIsLoading(true);
-    fetchOpenGraphPreview(url, controller.signal).then((result) => {
-      if (!isMounted) return;
-      setPreview(result);
-      setIsLoading(false);
-    });
+    fetchOpenGraphPreview(url, controller.signal)
+      .then((result) => {
+        if (!isMounted) return;
+        setPreview(result);
+      })
+      .catch((error) => {
+        // fetchOpenGraphPreview already swallows its own failures into
+        // `null`, but don't let an unexpected rejection (a mocked
+        // implementation in tests, a future change to that contract) leave
+        // this stuck on the spinner forever — fall back to fallbackTitle
+        // the same as a resolved-but-empty preview.
+        if (!isMounted) return;
+        console.warn(error);
+        setPreview(null);
+      })
+      .finally(() => {
+        if (isMounted) setIsLoading(false);
+      });
     return () => {
       isMounted = false;
       controller.abort();

--- a/src/components/loader/LoadOpenGraphCard.tsx
+++ b/src/components/loader/LoadOpenGraphCard.tsx
@@ -68,20 +68,14 @@ const LoadOpenGraphCard = ({
 
   if (isLoading) {
     return (
-      <View
-        style={{
-          marginHorizontal: spacing.md,
-          minHeight: 100,
-          justifyContent: "center",
-        }}
-      >
+      <View style={{ minHeight: 100, justifyContent: "center" }}>
         <UiSpinner />
       </View>
     );
   }
 
   return (
-    <View style={[{ marginHorizontal: spacing.md }, shadowWrapperStyle]}>
+    <View style={shadowWrapperStyle}>
       <UiPressable accessibilityRole="link" onPress={onPress}>
         <UiCard
           style={{

--- a/src/components/loader/Loader.tsx
+++ b/src/components/loader/Loader.tsx
@@ -29,6 +29,13 @@ const Loader = <TData,>({
   const [data, setData] = useState<TData>();
   const [error, setError] = useState<unknown>();
   const [isLoading, setLoading] = useState(true);
+  // Depend on presence, not identity: callers often pass a fresh inline
+  // renderError function each render (e.g. IframeRenderer's fallback card),
+  // and only whether one exists at all matters for the console.warn/error
+  // choice below — keying the effect on the boolean instead of the function
+  // itself avoids reloading on every render while still staying correct if a
+  // caller toggles renderError on/off between renders.
+  const hasRenderError = Boolean(renderError);
 
   useEffect(() => {
     let isMounted = true;
@@ -57,7 +64,7 @@ const Loader = <TData,>({
         // A caller that supplies its own renderError has UI for this failure
         // (e.g. a link-out card for a stale embed) — that's an expected,
         // handled case, not something that belongs in the error console.
-        if (renderError) {
+        if (hasRenderError) {
           console.warn(_error);
         } else {
           console.error(_error);
@@ -72,13 +79,7 @@ const Loader = <TData,>({
     return () => {
       isMounted = false;
     };
-    // renderError is deliberately excluded: callers often pass a fresh inline
-    // function each render (e.g. IframeRenderer's fallback card), and it's
-    // only used for the console.warn/error choice inside the reject handler
-    // above — including it would re-trigger the load on every render instead
-    // of just on a real keyValue/load change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [keyValue, load, onLoaded]);
+  }, [keyValue, load, onLoaded, hasRenderError]);
 
   if (isLoading) {
     return (

--- a/src/components/loader/Loader.tsx
+++ b/src/components/loader/Loader.tsx
@@ -10,7 +10,8 @@ type LoaderProps<TData> = {
   keyValue: string;
   load: (keyValue: string) => Promise<TData>;
   render: (data: TData) => ReactElement;
-  renderError?: (error: unknown) => ReactElement;
+  /** Return `null` to render nothing for a handled failure. */
+  renderError?: (error: unknown) => ReactElement | null;
   onLoaded?: (data: TData) => void;
   loadingText?: string;
   spinnerProps?: ActivityIndicatorProps;

--- a/src/components/loader/Loader.tsx
+++ b/src/components/loader/Loader.tsx
@@ -53,7 +53,14 @@ const Loader = <TData,>({
         if (isMounted) {
           setError(_error);
         }
-        console.error(_error);
+        // A caller that supplies its own renderError has UI for this failure
+        // (e.g. a link-out card for a stale embed) — that's an expected,
+        // handled case, not something that belongs in the error console.
+        if (renderError) {
+          console.warn(_error);
+        } else {
+          console.error(_error);
+        }
       })
       .finally(() => {
         if (isMounted) {
@@ -64,6 +71,12 @@ const Loader = <TData,>({
     return () => {
       isMounted = false;
     };
+    // renderError is deliberately excluded: callers often pass a fresh inline
+    // function each render (e.g. IframeRenderer's fallback card), and it's
+    // only used for the console.warn/error choice inside the reject handler
+    // above — including it would re-trigger the load on every render instead
+    // of just on a real keyValue/load change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [keyValue, load, onLoaded]);
 
   if (isLoading) {

--- a/src/helpers/utils/openGraph.ts
+++ b/src/helpers/utils/openGraph.ts
@@ -1,0 +1,52 @@
+import { decode } from "html-entities";
+
+import WordPressAPI from "#/helpers/network/WordPressAPI";
+import { get } from "#/helpers/utils/networking";
+import type { HttpsUrl } from "#/types";
+
+export interface OpenGraphPreview {
+  title: string;
+  description?: string;
+  image?: string;
+}
+
+const extractMetaContent = (
+  html: string,
+  property: string,
+): string | undefined => {
+  // Isolate the whole <meta> tag first so attribute order (content before or
+  // after property) doesn't matter, then pull `content` out of just that tag.
+  const tag = html.match(
+    new RegExp(`<meta[^>]*property=["']og:${property}["'][^>]*>`, "i"),
+  )?.[0];
+  const content = tag?.match(/content=["']([^"']*)["']/i)?.[1];
+  return content ? decode(content) : undefined;
+};
+
+/**
+ * Fetches `url`'s HTML and extracts its Open Graph title/description/image.
+ * Used as a preview for pages that are public but that LoadArticlePost can't
+ * fetch through the WordPress REST API — e.g. a "project" custom-post-type
+ * page, whose REST route requires authentication even though the page itself
+ * doesn't.
+ */
+export const fetchOpenGraphPreview = async (
+  url: HttpsUrl,
+  signal?: AbortSignal,
+): Promise<OpenGraphPreview | null> => {
+  try {
+    const html = await get<string>(WordPressAPI.client, url, {
+      responseType: "text",
+      signal,
+    });
+    const title = extractMetaContent(html, "title");
+    if (!title) return null;
+    return {
+      title,
+      description: extractMetaContent(html, "description"),
+      image: extractMetaContent(html, "image"),
+    };
+  } catch {
+    return null;
+  }
+};

--- a/src/screens/Home/components/article/Recommended.tsx
+++ b/src/screens/Home/components/article/Recommended.tsx
@@ -63,7 +63,17 @@ const Recommended = (properties: RecommendedProperties) => {
           const url = new URL(match.url);
           const path = url.pathname;
           const slug = path.replace(/\/+$/, "").split("/").pop();
-          return <LoadArticlePost key={String(index)} slug={slug} elevated />;
+          return (
+            <LoadArticlePost
+              key={String(index)}
+              slug={slug}
+              elevated
+              // A recommendation can point at a slug that's since been
+              // renamed or deleted on WordPress; drop it silently instead of
+              // showing an error card among otherwise-fine recommendations.
+              renderError={() => <></>}
+            />
+          );
         })}
       </View>
     </>

--- a/src/screens/Home/components/article/Recommended.tsx
+++ b/src/screens/Home/components/article/Recommended.tsx
@@ -63,17 +63,7 @@ const Recommended = (properties: RecommendedProperties) => {
           const url = new URL(match.url);
           const path = url.pathname;
           const slug = path.replace(/\/+$/, "").split("/").pop();
-          return (
-            <LoadArticlePost
-              key={String(index)}
-              slug={slug}
-              elevated
-              // A recommendation can point at a slug that's since been
-              // renamed or deleted on WordPress; drop it silently instead of
-              // showing an error card among otherwise-fine recommendations.
-              renderError={() => <></>}
-            />
-          );
+          return <LoadArticlePost key={String(index)} slug={slug} elevated />;
         })}
       </View>
     </>

--- a/src/screens/Home/components/article/renderer/IframeRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/IframeRenderer.tsx
@@ -355,7 +355,15 @@ const IframeRenderer = ({
         }}
       >
         <View style={{ margin: spacing.md }}>
-          <LoadArticlePost slug={slug} baseUrl={secondaryWp?.handle} elevated />
+          <LoadArticlePost
+            slug={slug}
+            baseUrl={secondaryWp?.handle}
+            elevated
+            // The embedded article can have been renamed or deleted since
+            // this article's body was written; drop it silently rather than
+            // showing a broken "couldn't load" card inline in the content.
+            renderError={() => <></>}
+          />
         </View>
       </View>
     );

--- a/src/screens/Home/components/article/renderer/IframeRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/IframeRenderer.tsx
@@ -9,7 +9,9 @@ import type {
   WebViewMessageEvent,
 } from "react-native-webview/lib/WebViewTypes";
 
-import LoadArticlePost from "#/components/loader/LoadArticlePost";
+import LoadArticlePost, {
+  ArticleNotFoundError,
+} from "#/components/loader/LoadArticlePost";
 import LoadOpenGraphCard from "#/components/loader/LoadOpenGraphCard";
 import UiErrorCard from "#/components/ui/UiErrorCard";
 import UiSpinner from "#/components/ui/UiSpinner";
@@ -186,7 +188,7 @@ const EmbedFallbackCard = ({
   onLinkPress,
 }: EmbedFallbackCardProperties) => {
   const pageUrl = embedSourceToPageUrl(source);
-  if (!pageUrl) return <></>;
+  if (!pageUrl) return null;
 
   return (
     <LoadOpenGraphCard
@@ -423,18 +425,25 @@ const IframeRenderer = ({
             slug={slug}
             baseUrl={secondaryWp?.handle}
             elevated
-            // The embed can point at a slug that's been renamed/deleted, or
-            // at content LoadArticlePost was never going to be able to fetch
-            // as a post (e.g. a "project" custom-post-type page). Either way,
-            // link out to the real page instead of showing a bare
-            // "couldn't load" card inline in the article.
-            renderError={() => (
-              <EmbedFallbackCard
-                slug={slug}
-                source={source ?? ""}
-                onLinkPress={onLinkPress}
-              />
-            )}
+            // Only fall back to the preview card for a genuinely missing
+            // slug (renamed/deleted, or content of a type other than "post"
+            // such as a "project" page) — not for a transient network/server
+            // error, where the article might well exist and the default
+            // error card's "try again later" is the more honest message.
+            renderError={(error) =>
+              error instanceof ArticleNotFoundError ? (
+                <EmbedFallbackCard
+                  slug={slug}
+                  source={source ?? ""}
+                  onLinkPress={onLinkPress}
+                />
+              ) : (
+                <UiErrorCard
+                  style={{ marginHorizontal: spacing.md }}
+                  text="Beitrag konnte nicht geladen werden. Bitte später erneut versuchen."
+                />
+              )
+            }
           />
         </View>
       </View>

--- a/src/screens/Home/components/article/renderer/IframeRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/IframeRenderer.tsx
@@ -9,8 +9,11 @@ import type {
   WebViewMessageEvent,
 } from "react-native-webview/lib/WebViewTypes";
 
+import { ExternalLinkIcon } from "#/components/Icons";
 import LoadArticlePost from "#/components/loader/LoadArticlePost";
+import UiCard from "#/components/ui/UiCard";
 import UiErrorCard from "#/components/ui/UiErrorCard";
+import UiPressable from "#/components/ui/UiPressable";
 import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
 import { radii } from "#/constants/BorderRadius";
@@ -131,6 +134,79 @@ const extractSlug = (source: string): string => {
     console.error("Error extracting slug:", error, "from src:", source);
     return "";
   }
+};
+
+/**
+ * Derives the canonical (non-embed) page URL from a wp-embedded-content
+ * iframe's src, e.g. ".../project/foo/embed/#?secret=xyz" becomes
+ * ".../project/foo/". Used to link out to content LoadArticlePost can't
+ * fetch as a regular post (e.g. a "project" custom-post-type page, whose
+ * REST endpoint isn't public).
+ */
+const embedSourceToPageUrl = (source: string): HttpsUrl | null => {
+  try {
+    const url = new URL(source);
+    url.hash = "";
+    url.search = "";
+    url.pathname = url.pathname.replace(/\/embed\/?$/, "/");
+    const page = url.toString();
+    return isHttpsUrl(page) ? page : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Turns a slug like "landtagswahl-sachsen-anhalt" into "Landtagswahl Sachsen
+ * Anhalt". Used as the fallback card's title when the real post title isn't
+ * available — WordPress's own embed HTML carries it in a sibling
+ * <blockquote><a>, but ElementHandlers strips that stub before this renderer
+ * ever sees it, leaving only the bare <iframe>.
+ */
+const humanizeSlug = (slug: string): string =>
+  slug
+    .split("-")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+interface EmbedFallbackCardProperties {
+  slug: string;
+  source: string;
+  onLinkPress: (event: unknown, href: HttpsUrl) => void;
+}
+
+/**
+ * Shown in place of an embedded article when LoadArticlePost can't fetch it
+ * as a post (deleted/renamed slug, or content of a type other than "post",
+ * e.g. a WordPress "project" page). Links out to the real page instead of
+ * silently disappearing or showing a bare "couldn't load" error.
+ */
+const EmbedFallbackCard = ({
+  slug,
+  source,
+  onLinkPress,
+}: EmbedFallbackCardProperties) => {
+  const colorScheme = useAppColorScheme();
+  const pageUrl = embedSourceToPageUrl(source);
+  if (!pageUrl) return <></>;
+
+  return (
+    <UiPressable
+      accessibilityRole="link"
+      onPress={(event) => onLinkPress(event, pageUrl)}
+      style={{ marginHorizontal: spacing.md }}
+    >
+      <UiCard
+        style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}
+      >
+        <UiText style={{ flex: 1 }} bold>
+          {humanizeSlug(slug)}
+        </UiText>
+        <ExternalLinkIcon color={Colors[colorScheme].textMuted} />
+      </UiCard>
+    </UiPressable>
+  );
 };
 
 /**
@@ -359,10 +435,18 @@ const IframeRenderer = ({
             slug={slug}
             baseUrl={secondaryWp?.handle}
             elevated
-            // The embedded article can have been renamed or deleted since
-            // this article's body was written; drop it silently rather than
-            // showing a broken "couldn't load" card inline in the content.
-            renderError={() => <></>}
+            // The embed can point at a slug that's been renamed/deleted, or
+            // at content LoadArticlePost was never going to be able to fetch
+            // as a post (e.g. a "project" custom-post-type page). Either way,
+            // link out to the real page instead of showing a bare
+            // "couldn't load" card inline in the article.
+            renderError={() => (
+              <EmbedFallbackCard
+                slug={slug}
+                source={source ?? ""}
+                onLinkPress={onLinkPress}
+              />
+            )}
           />
         </View>
       </View>

--- a/src/screens/Home/components/article/renderer/IframeRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/IframeRenderer.tsx
@@ -9,11 +9,9 @@ import type {
   WebViewMessageEvent,
 } from "react-native-webview/lib/WebViewTypes";
 
-import { ExternalLinkIcon } from "#/components/Icons";
 import LoadArticlePost from "#/components/loader/LoadArticlePost";
-import UiCard from "#/components/ui/UiCard";
+import LoadOpenGraphCard from "#/components/loader/LoadOpenGraphCard";
 import UiErrorCard from "#/components/ui/UiErrorCard";
-import UiPressable from "#/components/ui/UiPressable";
 import UiSpinner from "#/components/ui/UiSpinner";
 import UiText from "#/components/ui/UiText";
 import { radii } from "#/constants/BorderRadius";
@@ -158,10 +156,8 @@ const embedSourceToPageUrl = (source: string): HttpsUrl | null => {
 
 /**
  * Turns a slug like "landtagswahl-sachsen-anhalt" into "Landtagswahl Sachsen
- * Anhalt". Used as the fallback card's title when the real post title isn't
- * available — WordPress's own embed HTML carries it in a sibling
- * <blockquote><a>, but ElementHandlers strips that stub before this renderer
- * ever sees it, leaving only the bare <iframe>.
+ * Anhalt", for LoadOpenGraphCard's fallback title while its preview fetch is
+ * in flight (or if that fetch can't find an og:title either).
  */
 const humanizeSlug = (slug: string): string =>
   slug
@@ -179,33 +175,25 @@ interface EmbedFallbackCardProperties {
 /**
  * Shown in place of an embedded article when LoadArticlePost can't fetch it
  * as a post (deleted/renamed slug, or content of a type other than "post",
- * e.g. a WordPress "project" page). Links out to the real page instead of
- * silently disappearing or showing a bare "couldn't load" error.
+ * e.g. a WordPress "project" page). Rather than a bare "couldn't load"
+ * error, this previews the real page the same way an ArticlePost previews a
+ * regular post — title, image, excerpt — sourced from that page's own Open
+ * Graph tags, since its REST data isn't reachable.
  */
 const EmbedFallbackCard = ({
   slug,
   source,
   onLinkPress,
 }: EmbedFallbackCardProperties) => {
-  const colorScheme = useAppColorScheme();
   const pageUrl = embedSourceToPageUrl(source);
   if (!pageUrl) return <></>;
 
   return (
-    <UiPressable
-      accessibilityRole="link"
+    <LoadOpenGraphCard
+      url={pageUrl}
+      fallbackTitle={humanizeSlug(slug)}
       onPress={(event) => onLinkPress(event, pageUrl)}
-      style={{ marginHorizontal: spacing.md }}
-    >
-      <UiCard
-        style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}
-      >
-        <UiText style={{ flex: 1 }} bold>
-          {humanizeSlug(slug)}
-        </UiText>
-        <ExternalLinkIcon color={Colors[colorScheme].textMuted} />
-      </UiCard>
-    </UiPressable>
+    />
   );
 };
 

--- a/src/screens/Home/components/article/renderer/IframeRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/IframeRenderer.tsx
@@ -158,8 +158,9 @@ const embedSourceToPageUrl = (source: string): HttpsUrl | null => {
 
 /**
  * Turns a slug like "landtagswahl-sachsen-anhalt" into "Landtagswahl Sachsen
- * Anhalt", for LoadOpenGraphCard's fallback title while its preview fetch is
- * in flight (or if that fetch can't find an og:title either).
+ * Anhalt", used as LoadOpenGraphCard's fallback title if its preview fetch
+ * resolves without an og:title. (Not shown during loading — that state is
+ * spinner-only.)
  */
 const humanizeSlug = (slug: string): string =>
   slug


### PR DESCRIPTION
## Summary
- Fixes `ERROR [Error: Article not found for slug: ...]` seen when opening [analyse/5-antraege-afd-sachsen-anhalt](https://volksverpetzer.de/analyse/5-antraege-afd-sachsen-anhalt/) — its "Sonst schau auch hier vorbei:" embed points at `/project/landtagswahl-sachsen-anhalt/`, a WordPress "project" custom-post-type page whose REST endpoint requires auth, so `LoadArticlePost` could never resolve it as a regular post.
- The inline embed case (an editor-placed "related article" link inside the article body) now gets a proper preview instead of a dead-end error: a new `LoadOpenGraphCard` fetches the target page's own HTML and reads its Open Graph title/description/image (the same metadata WordPress puts on every public page for link previews) to render a real preview card — image, title, excerpt — matching `ArticlePost`'s elevated-card look (shadow, border, `cardTitle` typography) instead of a bare "couldn't load" error.
- `Loader` now logs at `console.warn` instead of `console.error` whenever the caller supplies its own `renderError` (i.e. has a handled UI path for the failure), quieting the noisy `ERROR` log for this now-gracefully-handled case.
- `Recommended.tsx` ("Passend dazu" AI suggestions) is unchanged from before this PR — still shows the default error card for an unresolvable slug.

## Why
The broken embed wasn't actually a deleted/renamed article — it's content of a different WordPress post type (`project`) that `LoadArticlePost` was never going to resolve via `/wp-json/wp/v2/posts`. Rather than hide that content or show a dead-end error inline in an article, fetching its public Open Graph metadata lets us render a proper preview and link out to it, consistent with how the rest of the article treats embedded articles.

## Test plan
- [x] `pnpm check:ts`
- [x] `pnpm lint` (0 errors, only pre-existing warnings)
- [x] `pnpm test` — full suite (149 suites / 1114 tests) passes
- [x] Added/updated `__tests__/IframeRenderer.test.tsx` coverage for the new fallback card (Open Graph preview success + fallback-title path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)