### PR TITLE
perf: replace magic-number height math with RN aspectRatio

### DIFF
--- a/__tests__/components/posts/RedditPost.test.tsx
+++ b/__tests__/components/posts/RedditPost.test.tsx
@@ -112,4 +112,16 @@ describe("RedditPost", () => {
       .find((p: any) => p.children === "Test Reddit Post");
     expect(titleCallProps?.size).toBe("lg");
   });
+
+  it("does not crash when preview.images is an empty array", async () => {
+    await expect(
+      render(
+        <RedditPost
+          {...baseProps}
+          is_reddit_media_domain
+          preview={{ images: [], enabled: false }}
+        />,
+      ),
+    ).resolves.toBeTruthy();
+  });
 });

--- a/__tests__/components/posts/insta/InstaPostImage.test.tsx
+++ b/__tests__/components/posts/insta/InstaPostImage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from "@jest/globals";
-import { render } from "@testing-library/react-native";
+import { act, render } from "@testing-library/react-native";
 
 import InstaPostImage from "#/components/posts/insta/InstaPostImage";
 import { spacing } from "#/constants/Spacing";
@@ -87,5 +87,34 @@ describe("InstaPostImage", () => {
     const dotsRow = findDotsRow(toJSON());
     expect(dotsRow).toBeDefined();
     expect(flatten(dotsRow.props.style).gap).toBe(spacing.sm);
+  });
+
+  const findImageNode = (node: any): any => {
+    if (!node) return undefined;
+    if (typeof node.props?.onLoad === "function") return node;
+    for (const child of node.children ?? []) {
+      if (typeof child !== "object") continue;
+      const found = findImageNode(child);
+      if (found) return found;
+    }
+    return undefined;
+  };
+
+  it("keeps the fallback ratio when onLoad reports a zero-width image, instead of an invalid aspectRatio", async () => {
+    const { toJSON } = await render(
+      <InstaPostImage {...baseProps} photos={["a.jpg"]} inView />,
+    );
+
+    const before = flatten(findImageNode(toJSON()).props.style);
+    expect(Number.isFinite(before.aspectRatio)).toBe(true);
+
+    act(() => {
+      findImageNode(toJSON()).props.onLoad({
+        nativeEvent: { source: { width: 0, height: 400 } },
+      });
+    });
+
+    const after = flatten(findImageNode(toJSON()).props.style);
+    expect(after.aspectRatio).toBe(before.aspectRatio);
   });
 });

--- a/__tests__/screens/Home/components/article/renderer/ImageRenderer.test.tsx
+++ b/__tests__/screens/Home/components/article/renderer/ImageRenderer.test.tsx
@@ -77,8 +77,25 @@ describe("ImageRenderer", () => {
     await render(<ImageRenderer {...baseRenderProps} />);
     const [firstProps] = Image.mock.calls[0];
     expect(firstProps.onLoad).toBeDefined();
-    act(() => {
+    await act(async () => {
       firstProps.onLoad({ source: { width: 800, height: 400 } });
+      await Promise.resolve();
     });
+  });
+
+  it("keeps the fallback ratio when onLoad reports a zero-width image, instead of an invalid aspectRatio", async () => {
+    const { Image } = jest.requireMock("expo-image");
+    await render(<ImageRenderer {...baseRenderProps} />);
+    const [initialProps] = Image.mock.calls[0];
+    const initialAspectRatio = initialProps.style.aspectRatio;
+    expect(Number.isFinite(initialAspectRatio)).toBe(true);
+
+    await act(async () => {
+      initialProps.onLoad({ source: { width: 0, height: 400 } });
+      await Promise.resolve();
+    });
+
+    const [lastCallProps] = Image.mock.calls.at(-1);
+    expect(lastCallProps.style.aspectRatio).toBe(initialAspectRatio);
   });
 });

--- a/src/components/posts/RedditPost.tsx
+++ b/src/components/posts/RedditPost.tsx
@@ -1,6 +1,5 @@
 import { Image } from "expo-image";
 import { useRouter } from "expo-router";
-import { useState } from "react";
 import { View } from "react-native";
 
 import Typography from "#/components/ui/Typography";
@@ -42,7 +41,6 @@ interface RedditProperties {
  * Renders Reddit Post with data from Reddit API (RedditProps)
  */
 const RedditPost = (properties: RedditProperties) => {
-  const [dims, setDims] = useState({ width: 0, height: 0 });
   const router = useRouter();
   const img_dim = properties.preview?.images[0].source ?? {
     width: 100,
@@ -63,11 +61,6 @@ const RedditPost = (properties: RedditProperties) => {
     );
   };
   const date = datebeautify();
-
-  const onLayout = (event) => {
-    const { height, width } = event.nativeEvent.layout;
-    setDims({ width: width, height: height });
-  };
 
   const onShare = async () => {
     try {
@@ -94,14 +87,13 @@ const RedditPost = (properties: RedditProperties) => {
           })
         }
         onLongPress={onShare}
-        onLayout={onLayout}
       >
         <View>
           <Image
             style={{
               left: 0,
-              width: dims.width,
-              height: Math.round(height_relation * dims.width),
+              width: "100%",
+              aspectRatio: 1 / height_relation,
             }}
             source={{ uri: imageUri }}
           />

--- a/src/components/posts/RedditPost.tsx
+++ b/src/components/posts/RedditPost.tsx
@@ -42,13 +42,14 @@ interface RedditProperties {
  */
 const RedditPost = (properties: RedditProperties) => {
   const router = useRouter();
-  const img_dim = properties.preview?.images[0].source ?? {
+  const img_dim = properties.preview?.images[0]?.source ?? {
     width: 100,
     height: 100,
   };
-  const height_relation = properties.is_reddit_media_domain
-    ? img_dim.height / img_dim.width
-    : DEFAULT_IMAGE_ASPECT_RATIO;
+  const height_relation =
+    properties.is_reddit_media_domain && img_dim.width > 0
+      ? img_dim.height / img_dim.width
+      : DEFAULT_IMAGE_ASPECT_RATIO;
   const size = properties.title.length > 100 ? 16 : 18;
   const author =
     properties.crosspost_parent_list?.[0]?.author ?? properties.author;

--- a/src/components/posts/insta/InstaPostImage.tsx
+++ b/src/components/posts/insta/InstaPostImage.tsx
@@ -80,7 +80,13 @@ const InstaPostImage = ({
     (event: ImageLoadEventData) => {
       if (loaded) return;
       const { width: w, height: h } = event.source;
-      setRatio(Math.round((h / w) * 100) / 100);
+      const nextRatio = Math.round((h / w) * 100) / 100;
+      // Malformed image metadata (e.g. width 0) would otherwise produce an
+      // Infinity/NaN aspectRatio and break layout — keep the existing
+      // fallback ratio instead.
+      if (Number.isFinite(nextRatio) && nextRatio > 0) {
+        setRatio(nextRatio);
+      }
       setLoaded(true);
       onFirstLoad?.();
     },

--- a/src/components/posts/insta/InstaPostImage.tsx
+++ b/src/components/posts/insta/InstaPostImage.tsx
@@ -111,7 +111,7 @@ const InstaPostImage = ({
   );
 
   const imageStyle = useMemo(
-    () => ({ width, height: width * ratio }),
+    () => ({ width, aspectRatio: 1 / ratio }),
     [width, ratio],
   );
 

--- a/src/screens/Home/components/article/Header.tsx
+++ b/src/screens/Home/components/article/Header.tsx
@@ -228,7 +228,7 @@ const Header = (properties: HeaderProperties) => {
           <View
             style={{
               width: width,
-              height: (16 / 9) * width,
+              aspectRatio: 16 / 9,
               backgroundColor: Colors.dark.background,
               paddingTop: ((width * 16) / 9) * 0.2,
               gap: spacing.xl,

--- a/src/screens/Home/components/article/Header.tsx
+++ b/src/screens/Home/components/article/Header.tsx
@@ -228,7 +228,7 @@ const Header = (properties: HeaderProperties) => {
           <View
             style={{
               width: width,
-              aspectRatio: 16 / 9,
+              aspectRatio: 9 / 16,
               backgroundColor: Colors.dark.background,
               paddingTop: ((width * 16) / 9) * 0.2,
               gap: spacing.xl,

--- a/src/screens/Home/components/article/Header.tsx
+++ b/src/screens/Home/components/article/Header.tsx
@@ -21,7 +21,10 @@ import UiSpace from "#/components/ui/UiSpace";
 import UiText from "#/components/ui/UiText";
 import Colors from "#/constants/Colors";
 import Config from "#/constants/Config";
-import { CONTENT_HORIZONTAL_PADDING } from "#/constants/GlobalStyles";
+import {
+  CONTENT_HORIZONTAL_PADDING,
+  DEFAULT_IMAGE_ASPECT_RATIO,
+} from "#/constants/GlobalStyles";
 import { spacing } from "#/constants/Spacing";
 import { outBoundLinkPress } from "#/helpers/Linking";
 import { onShare } from "#/helpers/Sharing";
@@ -57,7 +60,9 @@ const Header = (properties: HeaderProperties) => {
   const [imageLoaded2, setImageLoaded2] = useState(false);
   const [urlCopied, setUrlCopied] = useState(false);
   const { width } = useWindowDimensions();
-  const [height, setHeight] = useState(Math.round(0.5125 * width));
+  const [height, setHeight] = useState(
+    Math.round(DEFAULT_IMAGE_ASPECT_RATIO * width),
+  );
   // Reference to the ViewShot component for image capture
   const reference = useRef<ViewShotRef>(null);
   const router = useRouter();
@@ -122,7 +127,7 @@ const Header = (properties: HeaderProperties) => {
 
   const onLayout = (event: LayoutChangeEvent) => {
     const { width } = event.nativeEvent.layout;
-    setHeight(Math.round(0.5125 * width));
+    setHeight(Math.round(DEFAULT_IMAGE_ASPECT_RATIO * width));
   };
 
   return (
@@ -250,7 +255,7 @@ const Header = (properties: HeaderProperties) => {
               style={{
                 left: 0,
                 width: width,
-                height: Math.round(0.5125 * width),
+                height: Math.round(DEFAULT_IMAGE_ASPECT_RATIO * width),
               }}
               source={{ uri: article_image }}
               onLoad={() => setImageLoaded(true)}

--- a/src/screens/Home/components/article/Header.tsx
+++ b/src/screens/Home/components/article/Header.tsx
@@ -3,7 +3,6 @@ import { Image } from "expo-image";
 import type { Href } from "expo-router";
 import { useRouter } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { LayoutChangeEvent } from "react-native";
 import {
   AppState,
   Modal,
@@ -60,9 +59,6 @@ const Header = (properties: HeaderProperties) => {
   const [imageLoaded2, setImageLoaded2] = useState(false);
   const [urlCopied, setUrlCopied] = useState(false);
   const { width } = useWindowDimensions();
-  const [height, setHeight] = useState(
-    Math.round(DEFAULT_IMAGE_ASPECT_RATIO * width),
-  );
   // Reference to the ViewShot component for image capture
   const reference = useRef<ViewShotRef>(null);
   const router = useRouter();
@@ -125,11 +121,6 @@ const Header = (properties: HeaderProperties) => {
     };
   }, [article_link, copyToClipboard, urlCopied]);
 
-  const onLayout = (event: LayoutChangeEvent) => {
-    const { width } = event.nativeEvent.layout;
-    setHeight(Math.round(DEFAULT_IMAGE_ASPECT_RATIO * width));
-  };
-
   return (
     <>
       {/* Pull the hero image edge-to-edge: the article ScrollView pads its
@@ -144,10 +135,13 @@ const Header = (properties: HeaderProperties) => {
         <UiPressable
           accessibilityRole="button"
           onLongPress={() => setVisible(true)}
-          onLayout={onLayout}
         >
           <Image
-            style={{ margin: "auto", height, width: "100%" }}
+            style={{
+              margin: "auto",
+              width: "100%",
+              aspectRatio: 1 / DEFAULT_IMAGE_ASPECT_RATIO,
+            }}
             source={{ uri: article_image }}
             placeholder={LoadingImage}
           />
@@ -255,7 +249,7 @@ const Header = (properties: HeaderProperties) => {
               style={{
                 left: 0,
                 width: width,
-                height: Math.round(DEFAULT_IMAGE_ASPECT_RATIO * width),
+                aspectRatio: 1 / DEFAULT_IMAGE_ASPECT_RATIO,
               }}
               source={{ uri: article_image }}
               onLoad={() => setImageLoaded(true)}

--- a/src/screens/Home/components/article/renderer/ImageRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/ImageRenderer.tsx
@@ -57,7 +57,7 @@ const ImageRenderer = ({ url, ...properties }: ImageRendererProperties) => {
         <Image
           onLoad={onLoad}
           source={{ uri }}
-          style={{ width, height: width * ratio, backgroundColor }}
+          style={{ width, aspectRatio: 1 / ratio, backgroundColor }}
         />
       </UiPressable>
       <ImageCreditBadge credit={credit} position="bottomRight" />

--- a/src/screens/Home/components/article/renderer/ImageRenderer.tsx
+++ b/src/screens/Home/components/article/renderer/ImageRenderer.tsx
@@ -43,7 +43,12 @@ const ImageRenderer = ({ url, ...properties }: ImageRendererProperties) => {
     setIsLoaded(true);
     const { width, height } = event.source;
     const _ratio = Math.round((height / width) * 100) / 100;
-    if (ratio !== _ratio) setRatio(_ratio);
+    // Malformed image metadata (e.g. width 0) would otherwise produce an
+    // Infinity/NaN aspectRatio and break layout — keep the existing
+    // fallback ratio instead.
+    if (Number.isFinite(_ratio) && _ratio > 0 && ratio !== _ratio) {
+      setRatio(_ratio);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary

- **#30 aus dem Tech-Debt-Audit**: `Header.tsx` verwendete den rohen Wert `0.5125` an drei Stellen. Durch die bereits existierende benannte Konstante `DEFAULT_IMAGE_ASPECT_RATIO` aus `src/constants/GlobalStyles.ts` ersetzt (dieselbe Konstante nutzen bereits `RedditPost.tsx`, `ArticlePost.tsx` und `PodcastPost.tsx`).
- **Weiterer Schritt**: Statt Bildhöhen per JS zu berechnen (`useState` + `onLayout`/`onLoad` + `height: ratio * width`), nutzen alle betroffenen Stellen jetzt React Natives deklaratives `aspectRatio`-Style (Yoga-Layout-Engine), analog zum bereits bestehenden Pattern in `PodcastPost.tsx`:
  - **`Header.tsx`**: Hero-Bild und ViewShot-Capture-Card-Bild — `height`-State + `onLayout`-Handler komplett entfernt
  - **`RedditPost.tsx`**: `dims`-State + `onLayout`-Handler komplett entfernt (existierte nur, um die Container-Breite für die Höhenberechnung zu kennen)
  - **`ImageRenderer.tsx`**: `height: width * ratio` → `aspectRatio: 1 / ratio`
  - **`InstaPostImage.tsx`**: `height: width * ratio` → `aspectRatio: 1 / ratio`
  - **`Header.tsx`** (ViewShot-Card-Hintergrund): `height: (16/9) * width` → `aspectRatio: 9/16` (Kehrwert, da die ursprüngliche Formel `height/width = 16/9` beschreibt — eine Portrait-Box — und RN's `aspectRatio` `width/height` ist)

## Was ein Reviewer wissen sollte

- `DEFAULT_IMAGE_ASPECT_RATIO` ist als **height/width**-Verhältnis dokumentiert (0.5125 = 615/1200). RN's `aspectRatio`-Style ist dagegen **width/height** (wie CSS `aspect-ratio`) — daher überall der Kehrwert
- In `ImageRenderer.tsx` und `InstaPostImage.tsx` bleibt der `ratio`-State bestehen, da das tatsächliche Seitenverhältnis erst beim Laden des Bildes bekannt ist (`onLoad`) — hier wurde nur die Höhenberechnung vereinfacht, kein State eliminiert
- In `Header.tsx` und `RedditPost.tsx` konnte der komplette Höhen-State + `onLayout`-Handler entfernt werden, da die Breite bereits anderweitig bekannt ist (Fensterbreite bzw. `width: "100%"`)
- **On-Device getestet (Android)**: Der Instagram-Story-Share zeigte zunächst ein stark gestauchtes Bild — die ViewShot-Card war ursprünglich fälschlich mit `aspectRatio: 16/9` (statt korrektem Kehrwert `9/16`) umgesetzt. Gefixt in [e077165](https://github.com/Volksverpetzer/vvp_app/commit/e077165c) (siehe PR-Kommentar für Details). Alle anderen aspectRatio-Konvertierungen folgen dem gleichen, bereits in `PodcastPost.tsx` etablierten Muster und sind davon nicht betroffen.

## Test plan

- [x] Artikel-Header: Bild wird mit korrektem Seitenverhältnis angezeigt
- [x] Long-Press auf Hero-Bild → Instagram-Story-Share erzeugt korrekt proportioniertes Capture-Bild (Bug gefunden und gefixt, siehe oben)
- [ ] Reddit-Posts im Feed: Bilder werden korrekt proportioniert angezeigt
- [ ] Artikel-Inline-Bilder: korrektes Seitenverhältnis nach dem Laden
- [ ] Instagram-Posts im Feed: korrektes Seitenverhältnis, Karussell-Bilder passen sich an

🤖 Generated with [Claude Code](https://claude.com/claude-code)