### PR TITLE
feat: add top-level ErrorBoundary

### DIFF
--- a/__tests__/components/ErrorBoundary.test.tsx
+++ b/__tests__/components/ErrorBoundary.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import { Text } from "react-native";
+
+import ErrorBoundary from "#/components/ErrorBoundary";
+
+jest.mock("#/components/ui/UiErrorCard", () => {
+  const { Text: MockText } = jest.requireActual("react-native");
+  return function MockErrorCard({ text }: { text?: string }) {
+    return <MockText>{`error:${text}`}</MockText>;
+  };
+});
+
+const Bomb = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) throw new Error("boom");
+  return <Text>ok</Text>;
+};
+
+describe("ErrorBoundary", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders children when there is no error", async () => {
+    const { getByText } = await render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(getByText("ok")).toBeTruthy();
+  });
+
+  it("renders fallback UI when a child throws during render", async () => {
+    const { getByText } = await render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(
+      getByText("error:Etwas ist schiefgelaufen. Bitte versuche es erneut."),
+    ).toBeTruthy();
+  });
+
+  it("resets and re-renders children after pressing the retry button", async () => {
+    const { getByText, rerender } = await render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    // Fix the underlying condition, then retry — the boundary should
+    // re-attempt rendering children instead of staying stuck on the fallback.
+    rerender(
+      <ErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    await fireEvent.press(getByText("Erneut versuchen"));
+
+    expect(getByText("ok")).toBeTruthy();
+  });
+});

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -20,6 +20,7 @@ import {
 import type { ToastConfig } from "react-native-toast-message";
 import Toast from "react-native-toast-message";
 
+import ErrorBoundary from "#/components/ErrorBoundary";
 import ChangelogModal from "#/components/popups/ChangelogModal";
 import StripeWrapper from "#/components/providers/StripeWrapper";
 import UiSpinner from "#/components/ui/UiSpinner";
@@ -150,39 +151,41 @@ const RootLayout = () => {
           <BadgeProvider>
             <AudioProvider>
               <AppFrame>
-                <Stack
-                  screenOptions={{
-                    headerShown: false,
-                    gestureEnabled: true,
-                  }}
-                >
-                  <Stack.Screen name="(tabs)" options={{ title: "Home" }} />
-                  <Stack.Screen
-                    name="[category]/[slug]"
-                    options={{ title: "Artikel" }}
-                  />
-                  <Stack.Screen
-                    name="insta/[post_id]"
-                    options={{ title: "Artikel" }}
-                  />
-                  <Stack.Screen
-                    name="podcast/[id]"
-                    options={{ title: "Podcast" }}
-                  />
-                  <Stack.Screen name="search" options={{ title: "Suche" }} />
-                  <Stack.Screen
-                    name="+not-found"
-                    options={{ title: "Nicht gefunden" }}
-                  />
-                  <Stack.Screen
-                    name="support"
-                    options={{ title: "Unterstutzen" }}
-                  />
-                  <Stack.Screen
-                    name="licenses"
-                    options={{ title: "Lizenzen" }}
-                  />
-                </Stack>
+                <ErrorBoundary>
+                  <Stack
+                    screenOptions={{
+                      headerShown: false,
+                      gestureEnabled: true,
+                    }}
+                  >
+                    <Stack.Screen name="(tabs)" options={{ title: "Home" }} />
+                    <Stack.Screen
+                      name="[category]/[slug]"
+                      options={{ title: "Artikel" }}
+                    />
+                    <Stack.Screen
+                      name="insta/[post_id]"
+                      options={{ title: "Artikel" }}
+                    />
+                    <Stack.Screen
+                      name="podcast/[id]"
+                      options={{ title: "Podcast" }}
+                    />
+                    <Stack.Screen name="search" options={{ title: "Suche" }} />
+                    <Stack.Screen
+                      name="+not-found"
+                      options={{ title: "Nicht gefunden" }}
+                    />
+                    <Stack.Screen
+                      name="support"
+                      options={{ title: "Unterstutzen" }}
+                    />
+                    <Stack.Screen
+                      name="licenses"
+                      options={{ title: "Lizenzen" }}
+                    />
+                  </Stack>
+                </ErrorBoundary>
                 <AppToast config={toastConfig} />
                 <ChangelogModal
                   isVisible={showChangelog}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import type { PropsWithChildren } from "react";
+import { Component } from "react";
+import { View } from "react-native";
+
+import UiButton from "#/components/ui/UiButton";
+import UiErrorCard from "#/components/ui/UiErrorCard";
+import { spacing } from "#/constants/Spacing";
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Catches render-time errors thrown anywhere below it so the app shows a
+ * recoverable fallback instead of a blank/crashed screen. Only class
+ * components can implement getDerivedStateFromError/componentDidCatch.
+ */
+class ErrorBoundary extends Component<PropsWithChildren, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("Unhandled render error caught by ErrorBoundary:", error);
+  }
+
+  reset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View
+          style={{
+            flex: 1,
+            justifyContent: "center",
+            padding: spacing.xl,
+            gap: spacing.lg,
+          }}
+        >
+          <UiErrorCard text="Etwas ist schiefgelaufen. Bitte versuche es erneut." />
+          <UiButton label="Erneut versuchen" onPress={this.reset} />
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary

- **#14 aus dem Tech-Debt-Audit**: Die App hatte nirgendwo einen React Error Boundary. Ein Render-Fehler in irgendeinem Screen führte zu einem kompletten Absturz (blanker/roter Screen), ohne Recovery-Möglichkeit für den Nutzer.
- Neue `ErrorBoundary`-Komponente (`src/components/ErrorBoundary.tsx`) fängt Render-Fehler ab und zeigt eine einfache Fehlerkarte mit "Erneut versuchen"-Button statt eines Absturzes.
- Eingebunden in `_layout.tsx` um den Haupt-`Stack` (innerhalb aller Provider, sodass Theme/Settings erhalten bleiben).

## Was ein Reviewer wissen sollte

- Bewusst simpel gehalten: kein Fehler-Reporting-Service-Integration, kein automatischer Reload — nur ein Reset des lokalen Boundary-States, damit der Stack neu gerendert wird
- Fängt nur **Render-Fehler** ab (React-Standardverhalten von Error Boundaries), keine Fehler in Event-Handlern oder async Code — die werden weiterhin wie bisher behandelt
- Platzierung um den `Stack` (nicht um die komplette App) heißt: ein Absturz in einem Screen zeigt die Fehlerkarte, aber Provider/Theme/Tab-Bar-Kontext bleiben intakt

## Test plan

- [x] Unit-Test: rendert Children normal, zeigt Fallback bei Fehler, Reset-Button funktioniert (`__tests__/components/ErrorBoundary.test.tsx`)
- [ ] Manuell: einen Render-Fehler in einem Screen provozieren und prüfen, dass die Fehlerkarte statt eines Absturzes erscheint

🤖 Generated with [Claude Code](https://claude.com/claude-code)